### PR TITLE
Use existing params

### DIFF
--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -14,13 +14,13 @@ vpc_parameters: &vpc_parameters
 
 stacks:
   - name: vpc
-    class_path: stacker.stacks.vpc.VPC
+    class_path: stacker.blueprints.vpc.VPC
     parameters:
       InstanceType: m3.medium
       SshKeyName: default
       ImageName: NAT
   - name: bastion
-    class_path: stacker.stacks.bastion.Bastion
+    class_path: stacker.blueprints.bastion.Bastion
     parameters:
       # Extends the parameters dict with the contents of the vpc_parameters
       # anchor. Basically we're including all VPC Outputs in the parameters
@@ -36,7 +36,7 @@ stacks:
       SshKeyName: default
       ImageName: bastion
   - name: myDB
-    class_path: stacker.stacks.postgres.PostgresRDS
+    class_path: stacker.blueprints.postgres.PostgresRDS
     parameters:
       << : *vpc_parameters
       InstanceType: db.m3.medium
@@ -45,7 +45,7 @@ stacks:
       MasterUserPassword: ExamplePassword!
       DBName: db1
   - name: myWeb
-    class_path: stacker.stacks.asg.AutoscalingGroup
+    class_path: stacker.blueprints.asg.AutoscalingGroup
     parameters:
       << : *vpc_parameters
       InstanceType: m3.medium

--- a/scripts/stacker
+++ b/scripts/stacker
@@ -4,12 +4,11 @@
 
 import argparse
 import logging
-import code
 from collections import Mapping
 import copy
 
 import yaml
-from stacker.builder import StackBuilder
+from stacker.builder import Builder
 
 logger = logging.getLogger()
 
@@ -20,10 +19,10 @@ INFO_FORMAT = ('[%(asctime)s] %(message)s')
 ISO_8601 = '%Y-%m-%dT%H:%M:%S'
 
 
-def get_stack_config(config, stack_list):
-    """ If given a stack list, extract the stack config for each in config.
+def get_stack_definitions(config, stack_list):
+    """ Extract stack definitions from the config.
 
-    If no stack list given, return stack config as is.
+    If no stack_list given, return stack config as is.
     """
     if not stack_list:
         return config['stacks']
@@ -85,9 +84,6 @@ def parse_args():
                              "specified more than once. If not specified "
                              "then stacker will work on all stacks in the "
                              "config file.")
-    parser.add_argument("--prompt", action="store_true",
-                        help="Drop to python prompt rather than kicking off "
-                             "build of the stack.")
     parser.add_argument('config',
                         help="The config file where stack configuration is "
                              "located. Must be in yaml format.")
@@ -116,12 +112,9 @@ if __name__ == '__main__':
     with open(args.config) as fd:
         config = yaml.load(fd)
 
-    builder = StackBuilder(args.region, mappings=config['mappings'],
-                           config=config, parameters=parameters)
-    if args.prompt:
-        print "Dropping into interactive console..."
-        code.InteractiveConsole(locals()).interact()
-    else:
-        stacks = get_stack_config(config, args.stacks)
-        logger.info("Working on stacks: %s", ', '.join(stacks))
-        builder.build(stacks)
+    builder = Builder(args.region, mappings=config['mappings'],
+                      parameters=parameters)
+
+    stacks = get_stack_definitions(config, args.stacks)
+    logger.info("Working on stacks: %s", ', '.join(stacks))
+    builder.build(stacks)

--- a/stacker/blueprints/asg.py
+++ b/stacker/blueprints/asg.py
@@ -2,12 +2,12 @@ from troposphere import Ref, FindInMap
 from troposphere import ec2, autoscaling
 from troposphere.autoscaling import Tag as ASTag
 
-from stacker.stack import StackTemplateBase
+from .base import Blueprint
 
 CLUSTER_SG_NAME = "%sSG"
 
 
-class AutoscalingGroup(StackTemplateBase):
+class AutoscalingGroup(Blueprint):
     PARAMETERS = {
         'VpcId': {'type': 'AWS::EC2::VPC::Id', 'description': 'Vpc Id'},
         'DefaultSG': {'type': 'AWS::EC2::SecurityGroup::Id',

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -41,6 +41,15 @@ class Blueprint(object):
                 continue
         return params
 
+    @property
+    def required_parameters(self):
+        """ Returns all parameters that do not have a default value. """
+        required = []
+        for k, v in self.parameters:
+            if not hasattr(v, 'Default'):
+                required.append((k, v))
+        return required
+
     def setup_parameters(self):
         t = self.template
         parameters = getattr(self, 'PARAMETERS')

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -6,24 +6,26 @@ logger = logging.getLogger(__name__)
 from troposphere import Template, Parameter
 
 
-class StackTemplateBase(object):
+class Blueprint(object):
     """Base implementation for dealing with a troposphere template.
 
     :type name: string
-    :param name: A name for the stack template. If not provided, one
+    :param name: A name for the blueprint. If not provided, one
         will be created from the class name automatically.
+
+    :type context: BlueprintContext object
+    :param config: Used for configuring the Blueprint.
 
     :type mappings: dict
     :param mappings: Cloudformation Mappings to be used in the template.
 
-    :type config: dict
-    :param config: A dictionary which is used to pass in configuration info
-        to the stack.
     """
-    def __init__(self, name, config, mappings=None):
+    def __init__(self, name, context, mappings=None):
         self.name = name
         self.mappings = mappings
-        self.config = config
+        # TODO: This is only, currently, used for parameters. should probably
+        #       just pass parameters alone.
+        self.context = context
         self.outputs = {}
         self.reset_template()
 
@@ -32,9 +34,9 @@ class StackTemplateBase(object):
         params = []
         for param in self.template.parameters:
             try:
-                params.append((param, self.config.parameters[param]))
+                params.append((param, self.context.parameters[param]))
             except KeyError:
-                logger.debug("Parameter '%s' not found in config, skipping.",
+                logger.debug("Parameter '%s' not found in context, skipping.",
                              param)
                 continue
         return params

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -31,21 +31,13 @@ class Blueprint(object):
 
     @property
     def parameters(self):
-        params = []
-        for param in self.template.parameters:
-            try:
-                params.append((param, self.context.parameters[param]))
-            except KeyError:
-                logger.debug("Parameter '%s' not found in context, skipping.",
-                             param)
-                continue
-        return params
+        return self.template.parameters
 
     @property
     def required_parameters(self):
         """ Returns all parameters that do not have a default value. """
         required = []
-        for k, v in self.parameters:
+        for k, v in self.parameters.items():
             if not hasattr(v, 'Default'):
                 required.append((k, v))
         return required

--- a/stacker/blueprints/bastion.py
+++ b/stacker/blueprints/bastion.py
@@ -10,12 +10,12 @@
 from troposphere import Ref, ec2, autoscaling, FindInMap
 from troposphere.autoscaling import Tag as ASTag
 
-from ..stack import StackTemplateBase
+from .base import Blueprint
 
 CLUSTER_SG_NAME = "BastionSecurityGroup"
 
 
-class Bastion(StackTemplateBase):
+class Bastion(Blueprint):
     PARAMETERS = {
         "VpcId": {"type": "AWS::EC2::VPC::Id", "description": "Vpc Id"},
         "DefaultSG": {"type": "AWS::EC2::SecurityGroup::Id",

--- a/stacker/blueprints/postgres.py
+++ b/stacker/blueprints/postgres.py
@@ -1,14 +1,14 @@
 from troposphere import Ref, ec2, Output, GetAtt, Join
 from troposphere.rds import DBInstance, DBSubnetGroup
 
-from ..stack import StackTemplateBase
+from .base import Blueprint
 
 RDS_INSTANCE_NAME = "PostgresRDS%s"
 RDS_SUBNET_GROUP = "%sSubnetGroup"
 RDS_SG_NAME = "RdsSG%s"
 
 
-class PostgresRDS(StackTemplateBase):
+class PostgresRDS(Blueprint):
     PARAMETERS = {
         'VpcId': {'type': 'AWS::EC2::VPC::Id', 'description': 'Vpc Id'},
         'PrivateSubnets': {'type': 'List<AWS::EC2::Subnet::Id>',

--- a/stacker/blueprints/vpc.py
+++ b/stacker/blueprints/vpc.py
@@ -188,8 +188,8 @@ class VPC(Blueprint):
 
     def create_template(self):
         self.cidr_block = netaddr.IPNetwork(
-            self.config.parameters['CidrBlock'])
-        self.zones = self.config.parameters['Zones']
+            self.context.parameters['CidrBlock'])
+        self.zones = self.context.parameters['Zones']
         self.template.add_output(
             Output("AvailabilityZones",
                    Value=Join(",", self.zones)))

--- a/stacker/blueprints/vpc.py
+++ b/stacker/blueprints/vpc.py
@@ -10,12 +10,12 @@ from troposphere import ec2
 from troposphere.route53 import RecordSetType
 import netaddr
 
-from ..stack import StackTemplateBase
+from .base import Blueprint
 
 NAT_INSTANCE_NAME = "NatInstance%s"
 
 
-class VPC(StackTemplateBase):
+class VPC(Blueprint):
     PARAMETERS = {
         "InstanceType": {
             "type": "String",

--- a/stacker/builder.py
+++ b/stacker/builder.py
@@ -243,8 +243,8 @@ class Builder(object):
             raise AttributeError("Stack class %s does not have a "
                                  "'rendered' "
                                  "attribute." % (stack_context.class_path))
-        blueprint = cls(name=stack_name, mappings=self.mappings,
-                        context=stack_context)
+        blueprint = cls(name=stack_name, context=stack_context,
+                        mappings=self.mappings)
         self.plan[stack_name].blueprint = blueprint
         return blueprint
 

--- a/stacker/builder.py
+++ b/stacker/builder.py
@@ -1,6 +1,4 @@
 import logging
-import copy
-from collections import OrderedDict, Iterable
 import time
 
 logger = logging.getLogger(__name__)
@@ -11,110 +9,8 @@ from boto.exception import S3ResponseError, BotoServerError
 
 from .util import (create_route53_zone, load_object_from_string,
                    find_subnetable_zones)
-
-
-INPROGRESS_STATUSES = ('CREATE_IN_PROGRESS',
-                       'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS',
-                       'UPDATE_IN_PROGRESS')
-COMPLETE_STATUSES = ('CREATE_COMPLETE', 'UPDATE_COMPLETE')
-
-STATUS_SUBMITTED = 1
-STATUS_COMPLETE = 2
-
-
-class BlueprintContext(object):
-    def __init__(self, name, class_path, requires=None, parameters=None):
-        self.name = name
-        self.class_path = class_path
-        self.parameters = parameters or {}
-        requires = requires or []
-        self._requires = set(requires)
-
-        self.blueprint = None
-        self.status = None
-
-    def __repr__(self):
-        return self.name
-
-    @property
-    def completed(self):
-        return self.status == STATUS_COMPLETE
-
-    @property
-    def submitted(self):
-        return self.status >= STATUS_SUBMITTED
-
-    @property
-    def requires(self):
-        requires = copy.deepcopy(self._requires)
-        # Auto add dependencies when parameters reference the Ouptuts of
-        # another stack.
-        parameters = self.parameters
-        for value in parameters.values():
-            if isinstance(value, basestring) and '::' in value:
-                stack_name, _ = value.split('::')
-            else:
-                continue
-            if stack_name not in requires:
-                requires.add(stack_name)
-        return requires
-
-    def complete(self):
-        logger.debug("Setting %s state to complete.", self.name)
-        self.status = STATUS_COMPLETE
-
-    def submit(self):
-        logger.debug("Setting %s state to submitted.", self.name)
-        self.status = STATUS_SUBMITTED
-
-
-class Plan(OrderedDict):
-    """ Used to organize the order in which stacks will be created/updated.
-    """
-    def add(self, definition):
-        self[definition['name']] = BlueprintContext(**definition)
-
-    def _parse_items(self, items):
-        if isinstance(items, Iterable) and not isinstance(items, basestring):
-            return items
-        return [items, ]
-
-    def complete(self, items):
-        items = self._parse_items(items)
-        for i in items:
-            self[i].complete()
-
-    def submit(self, items):
-        items = self._parse_items(items)
-        for i in items:
-            self[i].submit()
-
-    def list_completed(self):
-        result = OrderedDict()
-        for k, record in self.items():
-            if record.status == STATUS_COMPLETE:
-                result[k] = record
-        return result
-
-    def list_pending(self):
-        result = OrderedDict()
-        for k, record in self.items():
-            if record.status != STATUS_COMPLETE:
-                result[k] = record
-        return result
-
-    def list_submitted(self):
-        result = OrderedDict()
-        for k, record in self.items():
-            if record.status == STATUS_SUBMITTED:
-                result[k] = record
-        return result
-
-    @property
-    def completed(self):
-        if self.list_pending():
-            return False
-        return True
+from .plan import (Plan, INPROGRESS_STATUSES, STATUS_SUBMITTED,
+                   COMPLETE_STATUSES)
 
 
 class Builder(object):

--- a/stacker/builder.py
+++ b/stacker/builder.py
@@ -22,7 +22,7 @@ STATUS_SUBMITTED = 1
 STATUS_COMPLETE = 2
 
 
-class StackConfig(object):
+class BlueprintContext(object):
     def __init__(self, name, class_path, requires=None, parameters=None):
         self.name = name
         self.class_path = class_path
@@ -30,7 +30,7 @@ class StackConfig(object):
         requires = requires or []
         self._requires = set(requires)
 
-        self.template = None
+        self.blueprint = None
         self.status = None
 
     def __repr__(self):
@@ -68,9 +68,11 @@ class StackConfig(object):
         self.status = STATUS_SUBMITTED
 
 
-class TaskTracker(OrderedDict):
+class Plan(OrderedDict):
+    """ Used to organize the order in which stacks will be created/updated.
+    """
     def add(self, definition):
-        self[definition['name']] = StackConfig(**definition)
+        self[definition['name']] = BlueprintContext(**definition)
 
     def _parse_items(self, items):
         if isinstance(items, Iterable) and not isinstance(items, basestring):
@@ -115,18 +117,35 @@ class TaskTracker(OrderedDict):
         return True
 
 
-class StackBuilder(object):
-    def __init__(self, region, mappings=None, config=None,
-                 parameters=None, max_zone_count=None):
+class Builder(object):
+    """ Responsible for building & coordinating CloudFormation stacks.
+
+    Handles the conversion from:
+        config -> Blueprints -> Cloudformation Templates
+
+    Then pushes the templates into S3 if they have changed. Then kicks off
+    the stacks in order, depending on their dependencies/requirements (to
+    other stacks, and usually it is done automatically though manual
+    dependencies can be specified in the config).
+
+    If a stack already exists, but it's template or parameters have changed
+    it updates the stack, handling dependencies.
+
+    Also manages the translation of Output's to Parameters between stacks,
+    allowing you to pull information from one stack and use it in another.
+    """
+
+    def __init__(self, region, mappings=None, parameters=None,
+                 max_zone_count=None):
         self.region = region
         self.domain = parameters["BaseDomain"]
         self.mappings = mappings or {}
-        self.config = config or {}
         self.parameters = parameters or {}
-        self._conn = None
         self.max_zone_count = max_zone_count
-        self._cfn_bucket = None
         self.cfn_domain = self.domain.replace('.', '-')
+
+        self._conn = None
+        self._cfn_bucket = None
 
         self.reset()
 
@@ -156,7 +175,7 @@ class StackBuilder(object):
         return find_subnetable_zones(self.conn.vpc)
 
     def reset(self):
-        self.stacks = TaskTracker()
+        self.plan = Plan()
         self.outputs = {}
 
     def get_stack_full_name(self, stack_name):
@@ -170,21 +189,29 @@ class StackBuilder(object):
         return "https://s3.amazonaws.com/%s/%s" % (self.cfn_domain,
                                                    key_name)
 
-    def s3_stack_push(self, stack_template, force=False):
-        key_name = self.stack_template_key_name(stack_template)
-        template_url = self.stack_template_url(stack_template)
+    def s3_stack_push(self, blueprint, force=False):
+        """ Pushes the rendered blueprint's template to S3.
+
+        Verifies that the template doesn't already exist in S3 before
+        pushing.
+
+        Returns the URL to the template in S3.
+        """
+        key_name = self.stack_template_key_name(blueprint)
+        template_url = self.stack_template_url(blueprint)
         if self.cfn_bucket.get_key(key_name) and not force:
             logger.debug("Cloudformation template %s already exists.",
                          template_url)
             return template_url
         key = self.cfn_bucket.new_key(key_name)
-        key.set_contents_from_string(stack_template.rendered)
+        key.set_contents_from_string(blueprint.rendered)
         return template_url
 
     def setup_prereqs(self):
         create_route53_zone(self.conn.route53, self.domain)
 
-    def get_cf_stack_status(self, stack_name):
+    def get_stack_status(self, stack_name):
+        """ Get the status of a CloudFormation stack. """
         stack_info = self.conn.cloudformation.describe_stacks(stack_name)
         return stack_info[0].stack_status
 
@@ -192,38 +219,48 @@ class StackBuilder(object):
         """ For stack in stack_set, return a set of stacks that are still
         not complete (either not submitted or just not complete).
         """
-        pending = self.stacks.list_pending()
+        pending = self.plan.list_pending()
         result = {}
         for stack in stack_set:
             if stack in pending:
-                result[stack] = self.stacks[stack].status
+                result[stack] = self.plan[stack].status
         return result
 
-    def build_template(self, stack_config):
-        stack_name = stack_config.name
+    def build_blueprint(self, stack_context):
+        """ Build a Blueprint object for the given stack context.
+
+        Applys the blueprint to the stack_context in the plan.
+        """
+        stack_name = stack_context.name
         try:
-            template = self.stacks[stack_name].template
-            if template:
-                return template
+            blueprint = self.plan[stack_name].blueprint
+            if blueprint:
+                return blueprint
         except (KeyError, AttributeError):
             pass
-        class_path = stack_config.class_path
-        cls = load_object_from_string(class_path)
+        cls = load_object_from_string(stack_context.class_path)
         if not hasattr(cls, 'rendered'):
             raise AttributeError("Stack class %s does not have a "
                                  "'rendered' "
-                                 "attribute." % (class_path))
-        template = cls(name=stack_name, mappings=self.mappings,
-                       config=stack_config)
-        self.stacks[stack_name].template = template
-        return template
+                                 "attribute." % (stack_context.class_path))
+        blueprint = cls(name=stack_name, mappings=self.mappings,
+                        context=stack_context)
+        self.plan[stack_name].blueprint = blueprint
+        return blueprint
 
-    def resolve_parameters(self, parameters, stack):
+    def resolve_parameters(self, parameters, blueprint):
+        """ Resolves parameters for a given blueprint.
+
+        Given a list of parameters, first discard any parameters that the
+        blueprint does not use. Then, if a remaining parameter is in the format
+        <stack_name>::<output_name>, pull that output from the foreign
+        stack.
+        """
         params = []
         for k, v in parameters.items():
-            if k not in stack.template.parameters:
+            if k not in blueprint.template.parameters:
                 logger.debug("Template %s does not use parameter %s.",
-                             stack.name, k)
+                             blueprint.name, k)
                 continue
             value = v
             if isinstance(value, basestring) and '::' in value:
@@ -234,86 +271,132 @@ class StackBuilder(object):
             params.append((k, value))
         return params
 
-    def launch_stack(self, stack_name, template):
-        cf = self.conn.cloudformation
-        full_name = self.get_stack_full_name(stack_name)
-        stack_config = self.stacks[stack_name]
-        stack = None
+    def get_stack(self, stack_full_name):
+        """ Give a stacks full name, query for the boto Stack object.
+
+        If no stack exists with that name, return None.
+        """
         try:
-            stack = cf.describe_stacks(full_name)[0]
+            return self.conn.cloudformation.describe_stacks(stack_full_name)[0]
         except BotoServerError as e:
             if 'does not exist' not in e.message:
                 raise
+        return None
+
+    def build_stack_tags(self, stack_context, template_url):
+        """ Builds a common set of tags to attach to a stack.
+        """
+        requires = [
+            self.get_stack_full_name(s) for s in stack_context.requires]
+        logger.debug("Stack %s required stacks: %s",
+                     stack_context.name, requires)
+        tags = {'template_url': template_url}
+        if requires:
+            tags['required_stacks'] = ':'.join(requires)
+
+    def create_stack(self, full_name, template_url, parameters, tags):
+        """ Creates a stack in CloudFormation """
+        logger.info("Stack %s not found, creating.", full_name)
+        logger.debug("Using parameters: %s", parameters)
+        logger.debug("Using tags: %s", tags)
+        self.conn.cloudformation.create_stack(full_name,
+                                              template_url=template_url,
+                                              parameters=parameters, tags=tags,
+                                              capabilities=['CAPABILITY_IAM'])
+        return True
+
+    def update_stack(self, full_name, template_url, parameters, tags):
+        """ Updates an existing stack in CloudFormation. """
+        try:
+            logger.info("Attempting to update stack %s.", full_name)
+            self.conn.cloudformation.update_stack(
+                full_name, template_url=template_url, parameters=parameters,
+                tags=tags, capabilities=['CAPABILITY_IAM'])
+            return True
+        except BotoServerError as e:
+            if 'No updates are to be performed.' in e.message:
+                logger.info("Stack %s did not change, not updating.",
+                            full_name)
+                return True
+            raise
+
+    def launch_stack(self, stack_name, blueprint):
+        """ Handles the creating or updating of a stack in CloudFormation.
+
+        Also makes sure that we don't try to create or update a stack while
+        it is already updating or creating.
+        """
+        full_name = self.get_stack_full_name(stack_name)
+        stack_context = self.plan[stack_name]
+        stack = self.get_stack(full_name)
         if stack and stack.stack_status in INPROGRESS_STATUSES:
             logger.debug("Stack %s in progress with %s status.",
                          full_name, stack.stack_status)
             return
-        template_url = self.s3_stack_push(template)
-        params = stack_config.parameters
-        parameters = self.resolve_parameters(params, template)
-        requires = [self.get_stack_full_name(s) for s in stack_config.requires]
-        logger.debug("Stack %s required stacks: %s", stack_name, requires)
-        tags = {'template_url': template_url}
-        if requires:
-            tags['required_stacks'] = ':'.join(requires)
+        template_url = self.s3_stack_push(blueprint)
+        tags = self.build_stack_tags(stack_context, template_url)
+        parameters = self.resolve_parameters(stack_context.parameters,
+                                             blueprint)
+        submitted = False
         if not stack:
-            logger.info("Stack %s not found, creating.", full_name)
-            logger.debug("Using parameters: %s", parameters)
-            logger.debug("Using tags: %s", tags)
-            cf.create_stack(full_name, template_url=template_url,
-                            parameters=parameters,
-                            tags=tags,
-                            capabilities=['CAPABILITY_IAM'])
-            stack_config.submit()
+            submitted = self.create_stack(full_name, template_url, parameters,
+                                          tags)
         else:
-            try:
-                logger.info("Attempting to update stack %s.", full_name)
-                cf.update_stack(full_name, template_url=template_url,
-                                parameters=parameters,
-                                tags=tags,
-                                capabilities=['CAPABILITY_IAM'])
-                stack_config.submit()
-            except BotoServerError as e:
-                if 'No updates are to be performed.' in e.message:
-                    logger.info("Stack %s did not change, not updating.",
-                                stack_name)
-                    stack_config.submit()
-                    return
-                raise
+            submitted = self.update_stack(full_name, template_url, parameters,
+                                          tags)
+
+        if submitted:
+            stack_context.submit()
 
     def get_outputs(self, stack_name, force=False):
+        """ Gets all the outputs from a given stack in CloudFormation.
+
+        Updates the local output cache with the values it finds.
+        """
         logger.debug("Getting outputs from stack %s.", stack_name)
         if stack_name in self.outputs and not force:
             return
 
         full_name = self.get_stack_full_name(stack_name)
-        cf = self.conn.cloudformation
-        stack = cf.describe_stacks(full_name)[0]
+        stack = self.conn.cloudformation.describe_stacks(full_name)[0]
         stack_outputs = {}
         self.outputs[stack_name] = stack_outputs
         for output in stack.outputs:
             logger.debug("    %s: %s", output.key, output.value)
             stack_outputs[output.key] = output.value
+        return self.outputs
 
-    def update_stack_status(self):
-        for stack_name in self.stacks.list_pending():
-            stack_record = self.stacks[stack_name]
+    def sync_plan_status(self):
+        """ Updates the status of each stack in the local plan.
+
+        For each stack listed as 'pending' but 'submitted' in the local plan,
+        query CloudFormation for the stack's status.
+
+        If the status is one of the COMPLETE_STATUSES, then mark it as
+        complete in the local plan.
+        """
+        for stack_name in self.plan.list_pending():
+            stack_context = self.plan[stack_name]
             full_name = self.get_stack_full_name(stack_name)
-            local_status = stack_record.status
+            local_status = stack_context.status
             # We only update local status on stacks that have been marked
             # locally as submitted
             if not local_status == STATUS_SUBMITTED:
                 logger.debug("Stack %s not submitted yet.", stack_name)
                 continue
             logger.debug("Getting '%s' stack state from AWS.", stack_name)
-            cf_status = self.get_cf_stack_status(full_name)
-            logger.debug("Stack %s cloudformation status: %s", stack_name,
+            cf_status = self.get_stack_status(full_name)
+            logger.debug("Stack %s cloudformation status: %s", full_name,
                          cf_status)
             if cf_status in COMPLETE_STATUSES:
                 logger.info("Stack %s complete: %s", stack_name, cf_status)
-                stack_record.complete()
+                stack_context.complete()
 
     def build(self, stack_definitions):
+        """ Kicks off the build/update of the stacks in the stack_definitions.
+
+        This is the main entry point for the Builder.
+        """
         self.reset()
         self.parameters['Zones'] = \
             self.verify_zone_availability()[:self.max_zone_count]
@@ -321,21 +404,21 @@ class StackBuilder(object):
         for stack_def in stack_definitions:
             # Combine the Builder parameters with the stack parameters
             stack_def['parameters'].update(self.parameters)
-            self.stacks.add(stack_def)
-        logger.info("Launching stacks: %s", ', '.join(self.stacks.keys()))
+            self.plan.add(stack_def)
+        logger.info("Launching stacks: %s", ', '.join(self.plan.keys()))
 
         attempts = 0
-        while not self.stacks.completed:
+        while not self.plan.completed:
             attempts += 1
-            self.update_stack_status()
-            pending_stacks = self.stacks.list_pending()
-            submitted_stacks = self.stacks.list_submitted()
+            self.sync_plan_status()
+            pending_stacks = self.plan.list_pending()
+            submitted_stacks = self.plan.list_submitted()
             if not attempts % 10:
                 logger.info("Waiting on stacks: %s",
                             ', '.join(submitted_stacks))
             for stack_name in pending_stacks:
-                stack_config = self.stacks[stack_name]
-                requires = stack_config.requires
+                stack_context = self.plan[stack_name]
+                requires = stack_context.requires
                 pending_required = self.get_pending_stacks(requires)
                 if pending_required:
                     logger.debug("Stack %s still waiting on required stacks: "
@@ -343,6 +426,6 @@ class StackBuilder(object):
                     continue
                 logger.debug("All required stacks are finished, building %s "
                              "now.", stack_name)
-                template = self.build_template(stack_config)
-                self.launch_stack(stack_name, template)
+                blueprint = self.build_blueprint(stack_context)
+                self.launch_stack(stack_name, blueprint)
             time.sleep(5)

--- a/stacker/builder.py
+++ b/stacker/builder.py
@@ -13,6 +13,17 @@ from .plan import (Plan, INPROGRESS_STATUSES, STATUS_SUBMITTED,
                    COMPLETE_STATUSES)
 
 
+class MissingParameterException(Exception):
+    def __init__(self, blueprint, parameters):
+        self.blueprint = blueprint
+        self.parameter = parameters
+        self.message = "Blueprint %s missing required parameters: %s" % (
+            blueprint, ', '.join(parameters))
+
+    def __str__(self):
+        return self.message
+
+
 class Builder(object):
     """ Responsible for building & coordinating CloudFormation stacks.
 
@@ -153,7 +164,7 @@ class Builder(object):
         stack.
         """
         params = {}
-        bp_params = blueprint.template.parameters
+        blueprint_params = blueprint.parameters
         for k, v in parameters.items():
             if k not in blueprint_params:
                 logger.debug("Template %s does not use parameter %s.",
@@ -166,11 +177,21 @@ class Builder(object):
                 self.get_outputs(stack_name)
                 value = self.outputs[stack_name][output]
             params[k] = value
-        required_params = [k for kv in blueprint.required_parameters]
+        # Deal w/ missing parameters
+        required_params = [k for k, v in blueprint.required_parameters]
         missing_params = list(set(required_params) - set(params.keys()))
         if existing_stack:
+            stack_params = {p.key: p.value for p in existing_stack.parameters}
             for p in missing_params:
-                # TODO: CONTINUE HERE                
+                if p in stack_params:
+                    value = stack_params[p]
+                    logger.debug("Using parameter %s from existing stack: %s",
+                                 p, value)
+                    params[p] = value
+        final_missing = list(set(required_params) - set(params.keys()))
+        if final_missing:
+            raise MissingParameterException(blueprint.name, final_missing)
+
         return params.items()
 
     def get_stack(self, stack_full_name):
@@ -238,7 +259,7 @@ class Builder(object):
         template_url = self.s3_stack_push(blueprint)
         tags = self.build_stack_tags(stack_context, template_url)
         parameters = self.resolve_parameters(stack_context.parameters,
-                                             blueprint)
+                                             blueprint, stack)
         submitted = False
         if not stack:
             submitted = self.create_stack(full_name, template_url, parameters,
@@ -255,9 +276,9 @@ class Builder(object):
 
         Updates the local output cache with the values it finds.
         """
-        logger.debug("Getting outputs from stack %s.", stack_name)
         if stack_name in self.outputs and not force:
             return
+        logger.debug("Getting outputs from stack %s.", stack_name)
 
         full_name = self.get_stack_full_name(stack_name)
         stack = self.conn.cloudformation.describe_stacks(full_name)[0]

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -1,0 +1,109 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+import copy
+from collections import OrderedDict, Iterable
+
+INPROGRESS_STATUSES = ('CREATE_IN_PROGRESS',
+                       'UPDATE_COMPLETE_CLEANUP_IN_PROGRESS',
+                       'UPDATE_IN_PROGRESS')
+COMPLETE_STATUSES = ('CREATE_COMPLETE', 'UPDATE_COMPLETE')
+
+STATUS_SUBMITTED = 1
+STATUS_COMPLETE = 2
+
+
+class BlueprintContext(object):
+    def __init__(self, name, class_path, requires=None, parameters=None):
+        self.name = name
+        self.class_path = class_path
+        self.parameters = parameters or {}
+        requires = requires or []
+        self._requires = set(requires)
+
+        self.blueprint = None
+        self.status = None
+
+    def __repr__(self):
+        return self.name
+
+    @property
+    def completed(self):
+        return self.status == STATUS_COMPLETE
+
+    @property
+    def submitted(self):
+        return self.status >= STATUS_SUBMITTED
+
+    @property
+    def requires(self):
+        requires = copy.deepcopy(self._requires)
+        # Auto add dependencies when parameters reference the Ouptuts of
+        # another stack.
+        parameters = self.parameters
+        for value in parameters.values():
+            if isinstance(value, basestring) and '::' in value:
+                stack_name, _ = value.split('::')
+            else:
+                continue
+            if stack_name not in requires:
+                requires.add(stack_name)
+        return requires
+
+    def complete(self):
+        logger.debug("Setting %s state to complete.", self.name)
+        self.status = STATUS_COMPLETE
+
+    def submit(self):
+        logger.debug("Setting %s state to submitted.", self.name)
+        self.status = STATUS_SUBMITTED
+
+
+class Plan(OrderedDict):
+    """ Used to organize the order in which stacks will be created/updated.
+    """
+    def add(self, definition):
+        self[definition['name']] = BlueprintContext(**definition)
+
+    def _parse_items(self, items):
+        if isinstance(items, Iterable) and not isinstance(items, basestring):
+            return items
+        return [items, ]
+
+    def complete(self, items):
+        items = self._parse_items(items)
+        for i in items:
+            self[i].complete()
+
+    def submit(self, items):
+        items = self._parse_items(items)
+        for i in items:
+            self[i].submit()
+
+    def list_completed(self):
+        result = OrderedDict()
+        for k, record in self.items():
+            if record.status == STATUS_COMPLETE:
+                result[k] = record
+        return result
+
+    def list_pending(self):
+        result = OrderedDict()
+        for k, record in self.items():
+            if record.status != STATUS_COMPLETE:
+                result[k] = record
+        return result
+
+    def list_submitted(self):
+        result = OrderedDict()
+        for k, record in self.items():
+            if record.status == STATUS_SUBMITTED:
+                result[k] = record
+        return result
+
+    @property
+    def completed(self):
+        if self.list_pending():
+            return False
+        return True

--- a/stacker/tests/test_parse_user_data.py
+++ b/stacker/tests/test_parse_user_data.py
@@ -2,7 +2,7 @@ import unittest
 
 import yaml
 
-from ..parse_user_data import cf_tokenize
+from ..tokenize_userdata import cf_tokenize
 
 
 class TestCfTokenize(unittest.TestCase):


### PR DESCRIPTION
When updating a stack, if a parameter is not given but is set on the existing stack, use the existing stack's parameter.  Also, this pull allows us to catch missing parameters earlier.

Fixes GH-11
Fixes GH-15