### PR TITLE
Remove automatic subnet building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## pending
 
+- remove auto-subnet splitting in vpc stack
+
 ## 0.2.2 (2015-03-31)
 
 - Allow AWS to generate the DBInstanceIdentifier

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -19,6 +19,14 @@ stacks:
       InstanceType: m3.medium
       SshKeyName: default
       ImageName: NAT
+      # Only build 2 AZs, can be overridden with -p on the command line
+      # Note: If you want more than 4 AZs you should add more subnets below
+      #       Also you need at least 2 AZs in order to use the DB because
+      #       of the fact that the DB blueprint uses MultiAZ
+      AZCount: 2
+      # Enough subnets for 4 AZs
+      PublicSubnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
+      PrivateSubnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22
   - name: bastion
     class_path: stacker.blueprints.bastion.Bastion
     parameters:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ src_dir = os.path.dirname(__file__)
 install_requires = [
     'aws_helper>=0.2.0',
     'troposphere>=0.7.1',
-    'netaddr>=0.7.10',
     'boto>=2.25.0',
     'PyYAML>=3.11',
 ]

--- a/stacker/blueprints/vpc.py
+++ b/stacker/blueprints/vpc.py
@@ -3,21 +3,37 @@
 This includes the VPC, it's subnets, availability zones, etc.
 """
 
-from collections import OrderedDict
-
-from troposphere import Ref, Output, Join, FindInMap
+from troposphere import Ref, Output, Join, FindInMap, Select, GetAZs
 from troposphere import ec2
-import netaddr
 
 from .base import Blueprint
 
 NAT_INSTANCE_NAME = 'NatInstance%s'
 GATEWAY = 'InternetGateway'
 GW_ATTACH = 'GatewayAttach'
+VPC_NAME = "VPC"
+VPC_ID = Ref(VPC_NAME)
+DEFAULT_SG = "DefaultSG"
+NAT_SG = "NATSG"
 
 
 class VPC(Blueprint):
     PARAMETERS = {
+        "AZCount": {
+            "type": "Number",
+            "description": "The number of AZs to build the VPC in. NOTE: "
+                           "this is used by stacker, not by cloudformation "
+                           "directly."},
+        "PrivateSubnets": {
+            "type": "CommaDelimitedList",
+            "description": "Comma separated list of subnets to use for "
+                           "non-public hosts. NOTE: Must have as many subnets "
+                           "as AZCount"},
+        "PublicSubnets": {
+            "type": "CommaDelimitedList",
+            "description": "Comma separated list of subnets to use for "
+                           "public hosts. NOTE: Must have as many subnets "
+                           "as AZCount"},
         "InstanceType": {
             "type": "String",
             "description": "NAT EC2 instance type.",
@@ -40,24 +56,23 @@ class VPC(Blueprint):
 
     def create_vpc(self):
         t = self.template
-        vpc = t.add_resource(ec2.VPC(
-            'VPC',
+        t.add_resource(ec2.VPC(
+            VPC_NAME,
             CidrBlock=Ref("CidrBlock"), EnableDnsSupport=True,
             EnableDnsHostnames=True))
 
         # Just about everything needs this, so storing it on the object
-        self.vpc_ref = Ref(vpc)
-        t.add_output(Output("VpcId", Value=self.vpc_ref))
+        t.add_output(Output("VpcId", Value=VPC_ID))
 
     def create_default_security_group(self):
         t = self.template
-        self.default_sg = t.add_resource(ec2.SecurityGroup(
-            'DefaultSG',
-            VpcId=self.vpc_ref,
+        t.add_resource(ec2.SecurityGroup(
+            DEFAULT_SG,
+            VpcId=VPC_ID,
             GroupDescription='Default Security Group'))
         t.add_output(
             Output('DefaultSG',
-                   Value=Ref(self.default_sg)))
+                   Value=Ref(DEFAULT_SG)))
 
     def create_dhcp_options(self):
         t = self.template
@@ -67,7 +82,7 @@ class VPC(Blueprint):
             DomainNameServers=['AmazonProvidedDNS', ]))
         t.add_resource(ec2.VPCDHCPOptionsAssociation(
             'DHCPAssociation',
-            VpcId=self.vpc_ref,
+            VpcId=VPC_ID,
             DhcpOptionsId=Ref(dhcp_options)))
 
     def create_gateway(self):
@@ -75,107 +90,100 @@ class VPC(Blueprint):
         t.add_resource(ec2.InternetGateway(GATEWAY))
         t.add_resource(ec2.VPCGatewayAttachment(
             GW_ATTACH,
-            VpcId=self.vpc_ref,
+            VpcId=VPC_ID,
             InternetGatewayId=Ref(GATEWAY)))
 
     def create_network(self):
         t = self.template
         self.create_gateway()
+        vpc_id = Ref("VPC")
         t.add_resource(ec2.NetworkAcl('DefaultACL',
-                                      VpcId=self.vpc_ref))
+                                      VpcId=vpc_id))
 
-        # Now create the subnets
-        self.subnets = OrderedDict()
-        self.subnets['public'] = []
-        self.subnets['private'] = []
-        networks = {'private': self.cidr_block.subnet(22)}
-        # Give /24's to the public networks from the first /22
-        networks['public'] = next(networks['private']).subnet(24)
-        network_prefixes = []
-
-        self.nat_sg = self.create_nat_security_groups()
-
-        for _, subnet_type in enumerate(self.subnets):
-            name_prefix = subnet_type.capitalize()
-            for _, zone in enumerate(self.zones):
-                name_suffix = zone[-1].upper()
-                cidr_block = str(next(networks[subnet_type]))
-                # Used by other templates to pick static IPs
-                network_prefixes.append('.'.join(cidr_block.split('.')[:-1]))
-                subnet = t.add_resource(ec2.Subnet(
-                    '%sSubnet%s' % (name_prefix, name_suffix),
-                    AvailabilityZone=zone,
-                    VpcId=self.vpc_ref,
+        self.create_nat_security_groups()
+        subnets = {'public': [], 'private': []}
+        net_types = subnets.keys()
+        zones = []
+        for i in range(int(self.context.parameters["AZCount"])):
+            az = Select(i, GetAZs(""))
+            zones.append(az)
+            name_suffix = i
+            for net_type in net_types:
+                name_prefix = net_type.capitalize()
+                subnet_name = "%sSubnet%s" % (name_prefix, name_suffix)
+                subnets[net_type].append(subnet_name)
+                t.add_resource(ec2.Subnet(
+                    subnet_name,
+                    AvailabilityZone=az,
+                    VpcId=vpc_id,
                     DependsOn=GW_ATTACH,
-                    CidrBlock=cidr_block))
-                self.subnets[subnet_type].append(subnet)
-                route_table = t.add_resource(ec2.RouteTable(
-                    "%sRouteTable%s" % (name_prefix, name_suffix),
-                    VpcId=self.vpc_ref,
-                    Tags=[ec2.Tag('type', subnet_type)]))
-
+                    CidrBlock=Select(i, Ref("%sSubnets" % name_prefix))))
+                route_table_name = "%sRouteTable%s" % (name_prefix,
+                                                       name_suffix)
+                t.add_resource(ec2.RouteTable(
+                    route_table_name,
+                    VpcId=vpc_id,
+                    Tags=[ec2.Tag('type', net_type)]))
                 t.add_resource(ec2.SubnetRouteTableAssociation(
                     "%sRouteTableAssociation%s" % (name_prefix, name_suffix),
-                    SubnetId=Ref(subnet),
-                    RouteTableId=Ref(route_table)))
-
-                if subnet_type == 'public':
+                    SubnetId=Ref(subnet_name),
+                    RouteTableId=Ref(route_table_name)))
+                if net_type == 'public':
                     # the public subnets are where the NAT instances live,
                     # so their default route needs to go to the AWS
                     # Internet Gateway
-                    t.add_resource(
-                        ec2.Route("%sRoute%s" % (name_prefix, name_suffix),
-                                  RouteTableId=Ref(route_table),
-                                  DestinationCidrBlock='0.0.0.0/0',
-                                  GatewayId=Ref(GATEWAY)))
-
-                    self.create_nat_instance(zone, subnet)
+                    t.add_resource(ec2.Route(
+                        "%sRoute%s" % (name_prefix, name_suffix),
+                        RouteTableId=Ref(route_table_name),
+                        DestinationCidrBlock="0.0.0.0/0",
+                        GatewayId=Ref(GATEWAY)))
+                    self.create_nat_instance(i, subnet_name)
                 else:
                     # Private subnets are where actual instances will live
                     # so their gateway needs to be through the nat instances
                     t.add_resource(ec2.Route(
                         '%sRoute%s' % (name_prefix, name_suffix),
-                        RouteTableId=Ref(route_table),
+                        RouteTableId=Ref(route_table_name),
                         DestinationCidrBlock='0.0.0.0/0',
                         InstanceId=Ref(NAT_INSTANCE_NAME % name_suffix)))
-            t.add_output(
-                Output(
-                    "%sSubnets" % name_prefix,
-                    Value=Join(",",
-                               [Ref(sn) for sn in self.subnets[subnet_type]])))
-            t.add_output(
-                Output("%sNetworkPrefixes" % name_prefix,
-                       Value=Join(",", network_prefixes)))
+        for net_type in net_types:
+            t.add_output(Output(
+                "%sSubnets" % net_type.capitalize(),
+                Value=Join(",",
+                           [Ref(sn) for sn in subnets[net_type]])))
+        self.template.add_output(Output(
+            "AvailabilityZones",
+            Value=Join(",", zones)))
 
     def create_nat_security_groups(self):
         t = self.template
         # First setup the NAT Security Group Rules
         nat_private_in_all_rule = ec2.SecurityGroupRule(
             IpProtocol='-1', FromPort='-1', ToPort='-1',
-            SourceSecurityGroupId=Ref(self.default_sg))
+            SourceSecurityGroupId=Ref(DEFAULT_SG))
 
         nat_public_out_all_rule = ec2.SecurityGroupRule(
             IpProtocol='-1', FromPort='-1', ToPort='-1', CidrIp='0.0.0.0/0')
 
         return t.add_resource(ec2.SecurityGroup(
-            'NATSG',
-            VpcId=self.vpc_ref,
+            NAT_SG,
+            VpcId=VPC_ID,
             GroupDescription='NAT Instance Security Group',
             SecurityGroupIngress=[nat_private_in_all_rule],
             SecurityGroupEgress=[nat_public_out_all_rule, ]))
 
-    def create_nat_instance(self, zone, subnet):
+    def create_nat_instance(self, zone_id, subnet_name):
         t = self.template
-        suffix = zone[-1].upper()
+        suffix = zone_id
         nat_instance = t.add_resource(ec2.Instance(
             NAT_INSTANCE_NAME % suffix,
             ImageId=FindInMap('AmiMap', Ref("AWS::Region"), Ref("ImageName")),
-            SecurityGroupIds=[Ref(self.default_sg), Ref(self.nat_sg)],
-            SubnetId=Ref(subnet),
+            SecurityGroupIds=[Ref(DEFAULT_SG), Ref(NAT_SG)],
+            SubnetId=Ref(subnet_name),
             InstanceType=Ref('InstanceType'),
             SourceDestCheck=False,
             KeyName=Ref('SshKeyName'),
-            Tags=[ec2.Tag('Name', 'nat-gw%s' % suffix.lower())],
+            Tags=[ec2.Tag('Name', 'nat-gw%s' % suffix)],
             DependsOn=GW_ATTACH))
 
         t.add_resource(ec2.EIP(
@@ -186,12 +194,6 @@ class VPC(Blueprint):
         return nat_instance
 
     def create_template(self):
-        self.cidr_block = netaddr.IPNetwork(
-            self.context.parameters['CidrBlock'])
-        self.zones = self.context.parameters['Zones']
-        self.template.add_output(
-            Output("AvailabilityZones",
-                   Value=Join(",", self.zones)))
         self.create_vpc()
         self.create_default_security_group()
         self.create_dhcp_options()


### PR DESCRIPTION
Before this stacker would automatically determine availability zones and
both public & private subnets, based on subnet math. It put too much of
the burden on python. Now, instead, the AZs are determined
automatically, but in CloudFormation (Fn::GetAZs) and you only provide a
count of AZs.  As well, you need to provide a set of Public & Private
subnets to use.