### PR TITLE
Remove dns requirement, add hook/plugin support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,18 +33,24 @@ if you'd like to play with something smaller. To launch the stacks, after
 installing stacker and loading your AWS API keys in your environment
 (AWS\_ACCESS\_KEY\_ID & AWS\_SECRET\_ACCESS\_KEY), call the following::
 
-    stacker -v -r us-east-1 -d example.com -p CidrBlock=10.128.0.0/16 conf/example.yaml
+    stacker -v -p BaseDomain=example.com -r us-east-1 -p AZCount=2 -p CidrBlock=10.128.0.0/16 example.com conf/example.yaml
 
 Here's the syntax help from the command::
 
   # stacker -h
-  usage: stacker [-h] [-r REGION] [-m MAX_ZONES] [-v] [-d DOMAIN]
-                 [-p PARAMETER=VALUE] [--stacks STACKNAME]
-                 config
+  usage: stacker [-h] [-r REGION] [-m MAX_ZONES] [-v] [-p PARAMETER=VALUE]
+                 [--stacks STACKNAME]
+                 namespace config
 
-  Launches AWS Cloudformation stacks from config.
+  Launches or updates cloudformation stacks based on the given config. The
+  script is smart enough to figure out if anything (the template, or parameters)
+  has changed for a given stack. If not, it will skip that stack. Can also pull
+  parameters from other stack's outputs.
 
   positional arguments:
+    namespace             The namespace for the stack collection. This will be
+                          used as the prefix to the cloudformation stacks as
+                          well as the s3 bucket where templates are stored.
     config                The config file where stack configuration is located.
                           Must be in yaml format.
 
@@ -59,13 +65,10 @@ Here's the syntax help from the command::
                           availability zones.
     -v, --verbose         Increase output verbosity. May be specified up to
                           twice.
-    -d DOMAIN, --domain DOMAIN
-                          The domain to run in. Gets converted into the
-                          BaseDomain Parameter for use in stack templates.
     -p PARAMETER=VALUE, --parameter PARAMETER=VALUE
-                          Adds parameters from the command line that can be
-                          used inside any of the stacks being built. Can be
-                          specified more than once.
+                          Adds parameters from the command line that can be used
+                          inside any of the stacks being built. Can be specified
+                          more than once.
     --stacks STACKNAME    Only work on the stacks given. Can be specified more
                           than once. If not specified then stacker will work on
                           all stacks in the config file.

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -1,3 +1,14 @@
+# Hooks require a path.
+# If the build should stop when a hook fails, set required to true.
+# pre_build happens before the build
+# post_build happens after the build
+pre_build:
+  - path: stacker.hooks.route53.create_domain
+    required: true
+    # Additional args can be passed as a dict of key/value pairs in kwargs
+    # kwargs:
+# post_build:
+
 mappings:
   AmiMap:
     us-east-1:

--- a/scripts/stacker
+++ b/scripts/stacker
@@ -13,7 +13,9 @@ from collections import Mapping
 import copy
 
 import yaml
+
 from stacker.builder import Builder
+from stacker.util import handle_hooks
 
 logger = logging.getLogger()
 
@@ -73,10 +75,6 @@ def parse_args():
     parser.add_argument('-v', '--verbose', action='count', default=0,
                         help='Increase output verbosity. May be specified up '
                              'to twice.')
-    parser.add_argument('-d', '--domain',
-                        help="The domain to run in. Gets converted into the "
-                             "BaseDomain Parameter for use in stack "
-                             "templates.")
     parser.add_argument("-p", "--parameter", dest="parameters",
                         metavar="PARAMETER=VALUE", type=key_value_arg,
                         action=KeyValueAction, default={},
@@ -89,10 +87,14 @@ def parse_args():
                              "specified more than once. If not specified "
                              "then stacker will work on all stacks in the "
                              "config file.")
+    parser.add_argument('namespace',
+                        help='The namespace for the stack collection. This '
+                             'will be used as the prefix to the '
+                             'cloudformation stacks as well as the s3 bucket '
+                             'where templates are stored.')
     parser.add_argument('config',
                         help="The config file where stack configuration is "
                              "located. Must be in yaml format.")
-
     return parser.parse_args()
 
 
@@ -112,15 +114,20 @@ if __name__ == '__main__':
     args = parse_args()
     setup_logging(args.verbose)
     parameters = copy.deepcopy(args.parameters)
-    parameters['BaseDomain'] = args.domain
 
     with open(args.config) as fd:
         config = yaml.load(fd)
 
-    builder = Builder(args.region, mappings=config['mappings'],
+    mappings = config['mappings']
+
+    builder = Builder(args.region, args.namespace, mappings=mappings,
                       parameters=parameters)
 
     stack_definitions = get_stack_definitions(config, args.stacks)
     stack_names = [s['name'] for s in stack_definitions]
+    handle_hooks('pre_build', config.get('pre_build', None), args.region,
+                 args.namespace, mappings, parameters)
     logger.info("Working on stacks: %s", ', '.join(stack_names))
     builder.build(stack_definitions)
+    handle_hooks('post_build', config.get('post_build', None), args.region,
+                 args.namespace, mappings, parameters)

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -14,7 +14,7 @@ class Blueprint(object):
         will be created from the class name automatically.
 
     :type context: BlueprintContext object
-    :param config: Used for configuring the Blueprint.
+    :param context: Used for configuring the Blueprint.
 
     :type mappings: dict
     :param mappings: Cloudformation Mappings to be used in the template.

--- a/stacker/blueprints/vpc.py
+++ b/stacker/blueprints/vpc.py
@@ -21,6 +21,7 @@ class VPC(Blueprint):
     PARAMETERS = {
         "AZCount": {
             "type": "Number",
+            "default": "2",
             "description": "The number of AZs to build the VPC in. NOTE: "
                            "this is used by stacker, not by cloudformation "
                            "directly."},

--- a/stacker/hooks/route53.py
+++ b/stacker/hooks/route53.py
@@ -1,0 +1,19 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+from aws_helper.connection import ConnectionManager
+
+from stacker.util import create_route53_zone
+
+
+def create_domain(region, namespace, mappings, parameters, **kwargs):
+    conn = ConnectionManager(region)
+    try:
+        domain = parameters['BaseDomain']
+    except KeyError:
+        logger.error("BaseDomain parameter not provided.")
+        return False
+    create_route53_zone(conn.route53, domain)
+    return True

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -15,9 +15,11 @@ STATUS_COMPLETE = 2
 
 
 class BlueprintContext(object):
-    def __init__(self, name, class_path, requires=None, parameters=None):
+    def __init__(self, name, class_path, namespace, requires=None,
+                 parameters=None):
         self.name = name
         self.class_path = class_path
+        self.namespace = namespace
         self.parameters = parameters or {}
         requires = requires or []
         self._requires = set(requires)

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -8,6 +8,7 @@ def generate_definition(base_name, _id):
         "name": "%s.%d" % (base_name, _id),
         "class_path": "stacker.blueprints.%s.%s" % (base_name,
                                                     base_name.upper()),
+        "namespace": "example-com",
         "parameters": {
             "ExternalParameter": "fakeStack2::FakeParameter",
             "InstanceType": "m3.medium",

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -2,10 +2,11 @@ import unittest
 
 import string
 import os
+import Queue
 
 from stacker.util import (
     get_bucket_location, cf_safe_name, load_object_from_string,
-    camel_to_snake)
+    camel_to_snake, handle_hooks)
 
 regions = ['us-east-1', 'cn-north-1', 'ap-northeast-1', 'eu-west-1',
            'ap-southeast-1', 'ap-southeast-2', 'us-west-2', 'us-gov-west-1',
@@ -47,3 +48,69 @@ class TestUtil(unittest.TestCase):
         )
         for t in tests:
             self.assertEqual(camel_to_snake(t[0]), t[1])
+
+
+hook_queue = Queue.Queue()
+
+
+def mock_hook(*args):
+    hook_queue.put(args)
+    return True
+
+
+def fail_hook(*args):
+    return None
+
+
+def exception_hook(*args):
+    raise Exception
+
+
+class TestHooks(unittest.TestCase):
+    def test_empty_hook_stage(self):
+        hooks = []
+        handle_hooks('fake', hooks, 'us-east-1', 'stage', {}, {})
+        self.assertTrue(hook_queue.empty())
+
+    def test_missing_required_hook(self):
+        hooks = [{'path': 'not.a.real.path', 'required': True}]
+        with self.assertRaises(ImportError):
+            handle_hooks('missing', hooks, 'us-east-1', 'stage', {}, {})
+
+    def test_missing_required_hook_method(self):
+        hooks = [{'path': 'stacker.hooks.blah', 'required': True}]
+        with self.assertRaises(AttributeError):
+            handle_hooks('missing', hooks, 'us-east-1', 'stage', {}, {})
+
+    def test_missing_non_required_hook_method(self):
+        hooks = [{'path': 'stacker.hooks.blah', 'required': False}]
+        handle_hooks('missing', hooks, 'us-east-1', 'stage', {}, {})
+        self.assertTrue(hook_queue.empty())
+
+    def test_default_required_hook(self):
+        hooks = [{'path': 'stacker.hooks.blah'}]
+        with self.assertRaises(AttributeError):
+            handle_hooks('missing', hooks, 'us-east-1', 'stage', {}, {})
+
+    def test_valid_hook(self):
+        hooks = [{'path': 'stacker.tests.test_util.mock_hook',
+                  'required': True}]
+        handle_hooks('missing', hooks, 'us-east-1', 'stage', {}, {})
+        good = hook_queue.get_nowait()
+        self.assertEqual(good[0], 'us-east-1')
+        with self.assertRaises(Queue.Empty):
+            hook_queue.get_nowait()
+
+    def test_hook_failure(self):
+        hooks = [{'path': 'stacker.tests.test_util.fail_hook',
+                  'required': True}]
+        with self.assertRaises(SystemExit):
+            handle_hooks('fail', hooks, 'us-east-1', 'stage', {}, {})
+        hooks = [{'path': 'stacker.tests.test_util.exception_hook',
+                  'required': True}]
+        with self.assertRaises(Exception):
+            handle_hooks('fail', hooks, 'us-east-1', 'stage', {}, {})
+        hooks = [{'path': 'stacker.tests.test_util.exception_hook',
+                  'required': False}]
+        # Should pass
+        handle_hooks('fail', hooks, 'us-east-1', 'stage', {}, {})

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -113,4 +113,4 @@ class TestHooks(unittest.TestCase):
         hooks = [{'path': 'stacker.tests.test_util.exception_hook',
                   'required': False}]
         # Should pass
-        handle_hooks('fail', hooks, 'us-east-1', 'stage', {}, {})
+        handle_hooks('ignore_exception', hooks, 'us-east-1', 'stage', {}, {})

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -133,7 +133,6 @@ def handle_hooks(stage, hooks, region, namespace, mappings, parameters):
             except KeyError:
                 raise ValueError("%s hook #%d missing path." % (stage, i))
 
-        hook_paths = [h['path'] for h in hooks]
         logger.info("Executing %s hooks: %s", stage, ", ".join(hook_paths))
         for hook in hooks:
             required = hook.get('required', True)


### PR DESCRIPTION
- build hooks
- remove domain as a core concept, replace with namespace
- bucket used for CF templates prepended with 'stacker-'
- asg blueprint optionally sets up DNS if BaseDomain provided
- route53 hook - requires BaseDomain parameter