### PR TITLE
Environment feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,5 +101,29 @@ When updating an existing stack, if you don't supply a parameter in either the
 config or CLI, it will fall back on checking the existing stack for the
 parameter. If it finds it, it will use that automatically.
 
+Environments
+============
+
+As well as definining the stack config, you can further customize the stack
+config via an environment (ie the ``-e or --environment`` argument).
+
+The environment should point at a yaml formatted file that contains a flat
+dictionary (ie: only key: value pairs).  Those keys can be used in the
+stack config as python `string.Template`_ mappings.
+
+For example, if you wanted to name a stack based on the environment you were
+building it in, first you would create an environment file with the
+environment name in it (staging in this case)::
+
+  environment: stage
+
+Then, in the stack definition for the stack you are modifying (say the vpc
+stack), you would have the following::
+
+  - name: ${environment}VPC
+
+Stacker would then name the VPC stack ``stageVPC``.
+
 .. _Remind: http://www.remind.com/
 .. _troposphere: https://github.com/cloudtools/troposphere
+.. _string.Template: https://docs.python.org/2/library/string.html#template-strings

--- a/conf/stage.env
+++ b/conf/stage.env
@@ -1,0 +1,4 @@
+# This is just an example of the format for environment files
+# You can use a flag dictionary in yaml format. Values can be strings or
+# numbers, but cannot be more complex data types (dictionaries, lists, etc)
+environment: stage

--- a/scripts/stacker
+++ b/scripts/stacker
@@ -16,6 +16,7 @@ import yaml
 
 from stacker.builder import Builder
 from stacker.util import handle_hooks
+from stacker.config import parse_config
 
 logger = logging.getLogger()
 
@@ -62,11 +63,24 @@ def key_value_arg(string):
     return {k: v}
 
 
+def yaml_file_type(yaml_file):
+    """ Reads a yaml file and returns the resulting data. """
+    with open(yaml_file) as fd:
+        return yaml.load(fd)
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-r', '--region', default='us-east-1',
                         help="The AWS region to launch in. Default: "
                              "%(default)s")
+    parser.add_argument('-e', '--environment', type=yaml_file_type,
+                        default={},
+                        help="Path to a yaml environment file. The values in "
+                             "the environment file can be used in the stack "
+                             "config as if it were a string.Template type: "
+                             "https://docs.python.org/2/library/string.html"
+                             "#template-strings")
     parser.add_argument('-m', '--max-zones', type=int,
                         help="Gives you the ability to limit the # of zones "
                              "that resources will be launched in. If not "
@@ -92,7 +106,7 @@ def parse_args():
                              'will be used as the prefix to the '
                              'cloudformation stacks as well as the s3 bucket '
                              'where templates are stored.')
-    parser.add_argument('config',
+    parser.add_argument('config', type=argparse.FileType(),
                         help="The config file where stack configuration is "
                              "located. Must be in yaml format.")
     return parser.parse_args()
@@ -114,9 +128,9 @@ if __name__ == '__main__':
     args = parse_args()
     setup_logging(args.verbose)
     parameters = copy.deepcopy(args.parameters)
+    config_string = args.config.read()
 
-    with open(args.config) as fd:
-        config = yaml.load(fd)
+    config = parse_config(config_string, args.environment)
 
     mappings = config['mappings']
 

--- a/stacker/config.py
+++ b/stacker/config.py
@@ -1,0 +1,29 @@
+from string import Template
+from StringIO import StringIO
+
+import yaml
+
+
+class MissingEnvironment(Exception):
+    def __init__(self, key):
+        self.key = key
+        self.message = "Environment missing key %s." % key
+
+    def __str__(self):
+        return self.message
+
+
+def parse_config(config_string, environment=None):
+    """ Parse a config, using it as a template with the environment. """
+    t = Template(config_string)
+    buff = StringIO()
+    if not environment:
+        environment = {}
+    try:
+        buff.write(t.substitute(environment))
+    except KeyError, e:
+        raise MissingEnvironment(e.args[0])
+
+    buff.seek(0)
+    config = yaml.load(buff)
+    return config

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -1,0 +1,24 @@
+import unittest
+
+from stacker.config import parse_config, MissingEnvironment
+
+config = """a: $a
+b: $b
+c: $c"""
+
+
+class TestConfig(unittest.TestCase):
+    def test_missing_env(self):
+        env = {'a': 'A'}
+        try:
+            parse_config(config, env)
+        except MissingEnvironment as e:
+            self.assertEqual(e.key, 'b')
+
+    def test_no_variable_config(self):
+        c = parse_config("a: A", {})
+        self.assertEqual(c["a"], "A")
+
+    def valid_env_substitution(self):
+        c = parse_config("a: $a", {"a": "A"})
+        self.assertEqual(c["a"], "A")


### PR DESCRIPTION
These are simple key/value yaml files that can be used as a map against the config as if the config were a python string.Template template.

This allows for substituting values based on the environment, which seems like it might be a pretty common use case.