### PR TITLE
Destroy action

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -53,12 +53,13 @@ class BaseAction(object):
         return stack_template_url(self.bucket_name, blueprint)
 
     def s3_stack_push(self, blueprint, force=False):
-        """ Pushes the rendered blueprint's template to S3.
+        """Pushes the rendered blueprint's template to S3.
 
         Verifies that the template doesn't already exist in S3 before
         pushing.
 
         Returns the URL to the template in S3.
+
         """
         key_name = stack_template_key_name(blueprint)
         template_url = self.stack_template_url(blueprint)
@@ -86,16 +87,41 @@ class BaseAction(object):
     def post_run(self, *args, **kwargs):
         pass
 
-    def _get_all_stack_names(self, dependency_dict):
+    def _get_all_stack_names(self, dependencies):
+        """Get all stack names specified in dependencies.
+
+        Args:
+            - dependencies (dict): a dictionary where each key should be the
+                fully qualified name of a stack whose value is an array of
+                fully qualified stack names that the stack depends on.
+
+        Returns:
+            set: set of all stack names
+
+        """
         return set(
-            dependency_dict.keys() +
-            [item for dependencies in dependency_dict.values() for item in dependencies]
+            dependencies.keys() +
+            [item for items in dependencies.values() for item in items]
         )
 
-    def get_stack_execution_order(self, dependency_dict):
-        # copy the dependency_dict since we pop items out of it to get the
+    def get_stack_execution_order(self, dependencies):
+        """Return the order in which the stacks should be executed.
+
+        Args:
+            - dependencies (dict): a dictionary where each key should be the
+                fully qualified name of a stack whose value is an array of
+                fully qualified stack names that the stack depends on. This is
+                used to generate the order in which the stacks should be
+                executed.
+
+        Returns:
+            array: An array of stack names in the order which they should be
+                executed.
+
+        """
+        # copy the dependencies since we pop items out of it to get the
         # execution order, we don't want to mutate the one passed in
-        dependencies = copy.deepcopy(dependency_dict)
+        dependencies = copy.deepcopy(dependencies)
         pending_steps = []
         executed_steps = []
         stack_names = self._get_all_stack_names(dependencies)

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -1,0 +1,86 @@
+import logging
+
+from .base import BaseAction
+from ..plan import (
+    COMPLETE,
+    SKIPPED,
+    SUBMITTED,
+    Plan,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Action(BaseAction):
+    """Responsible for destroying CloudFormation stacks.
+
+    Generates a destruction plan based on stack dependencies. Stack
+    dependencies are reversed from the build action. For example, if a Stack B
+    requires Stack A during build, during destroy Stack A requires Stack B be
+    destroyed first.
+
+    The plan defaults to printing an outline of what will be destroyed. If
+    forced to execute, each stack will get destroyed in order.
+
+    """
+
+    def _get_dependencies(self, stacks_dict):
+        dependencies = {}
+        for stack_name, stack in stacks_dict.iteritems():
+            required_stacks = stack.requires
+            if not required_stacks:
+                if stack_name not in dependencies:
+                    dependencies[stack_name] = required_stacks
+                continue
+
+            for requirement in required_stacks:
+                dependencies.setdefault(requirement, set()).add(stack_name)
+        return dependencies
+
+    def _generate_plan(self):
+        plan = Plan(description='Destroy stacks')
+        stacks_dict = self.context.get_stacks_dict()
+        dependencies = self._get_dependencies(stacks_dict)
+        for stack_name in self.get_stack_execution_order(dependencies):
+            plan.add(
+                stacks_dict[stack_name],
+                run_func=self._destroy_stack,
+                requires=dependencies.get(stack_name),
+            )
+        return plan
+
+    def _destroy_stack(self, results, stack, **kwargs):
+        provider_stack = self.provider.get_stack(stack.fqn)
+        if not provider_stack:
+            logger.debug("Stack %s does not exist.", stack.fqn)
+            # Once the stack has been destroyed, it doesn't exist. If the
+            # status of the step was SUBMITTED, we know we just deleted it,
+            # otherwise it should be skipped
+            if kwargs.get('status', None) is SUBMITTED:
+                return COMPLETE
+            else:
+                return SKIPPED
+
+        logger.debug(
+            "Stack %s provider status: %s",
+            self.provider.get_stack_name(provider_stack),
+            self.provider.get_stack_status(provider_stack),
+        )
+        if self.provider.is_stack_destroyed(provider_stack):
+            return COMPLETE
+        elif self.provider.is_stack_in_progress(provider_stack):
+            return SUBMITTED
+        else:
+            self.provider.destroy_stack(provider_stack)
+        return SUBMITTED
+
+    def run(self, force, *args, **kwargs):
+        plan = self._generate_plan()
+        if force:
+            # need to generate a new plan to log since the outline sets the
+            # steps to COMPLETE in order to log them
+            debug_plan = self._generate_plan()
+            debug_plan.outline(logging.DEBUG)
+            plan.execute()
+        else:
+            plan.outline(execute_helper=True)

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -9,15 +9,13 @@ logger = logging.getLogger(__name__)
 class Blueprint(object):
     """Base implementation for dealing with a troposphere template.
 
-    :type name: string
-    :param name: A name for the blueprint. If not provided, one
-        will be created from the class name automatically.
-
-    :type parameters: Dictionary
-    :param stack: Used for configuring the Blueprint.
-
-    :type mappings: dict
-    :param mappings: Cloudformation Mappings to be used in the template.
+    Args:
+        name (str): A name for the blueprint. If not provided, one will be
+            created from the class name automatically.
+        context (`stacker.context.Context`): the context the blueprint is being
+            executed under.
+        mappings (Optional[dict]): Cloudformation Mappings to be used in the
+            template.
 
     """
     def __init__(self, name, context, mappings=None):
@@ -33,7 +31,7 @@ class Blueprint(object):
 
     @property
     def required_parameters(self):
-        """ Returns all template parameters that do not have a default value. """
+        """Returns all template parameters that do not have a default value."""
         required = []
         for k, v in self.parameters.items():
             if not hasattr(v, 'Default'):

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -1,6 +1,3 @@
-# TODO add a better description about all the actions
-"""Description about what stacker does
-"""
 import copy
 
 from .build import Build
@@ -12,7 +9,6 @@ from ...providers import aws
 class Stacker(BaseCommand):
 
     name = 'stacker'
-    description = __doc__
     subcommands = (Build,)
 
     def configure(self, options, **kwargs):

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -1,6 +1,7 @@
 import copy
 
 from .build import Build
+from .destroy import Destroy
 from ..base import BaseCommand
 from ...context import Context
 from ...providers import aws
@@ -9,7 +10,7 @@ from ...providers import aws
 class Stacker(BaseCommand):
 
     name = 'stacker'
-    subcommands = (Build,)
+    subcommands = (Build, Destroy)
 
     def configure(self, options, **kwargs):
         super(Stacker, self).configure(options, **kwargs)

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -1,10 +1,9 @@
-# TODO make sure this is still relevant
-"""Launches or updates cloudformation stacks based on the given config.
+"""Launches or updates CloudFormation stacks based on the given config.
 
-The script is smart enough to figure out if anything (the template, or
-parameters) has changed for a given stack. If not, it will skip that stack.
+Stacker is smart enough to figure out if anything (the template or parameters)
+have changed for a given stack. If nothing has changed, stacker will correctly
+skip executing anything against the stack.
 
-Can also pull parameters from other stack's outputs.
 """
 
 from .base import StackerCommand

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -1,0 +1,36 @@
+"""Destroys CloudFormation stacks based on the given config.
+
+Stacker will determine the order in which stacks should be destroyed based on
+any manual requirements they specify or output values they rely on from other
+stacks.
+
+"""
+from .base import StackerCommand
+from ...actions import destroy
+
+
+class Destroy(StackerCommand):
+
+    name = "destroy"
+    description = __doc__
+
+    def add_arguments(self, parser):
+        super(Destroy, self).add_arguments(parser)
+        parser.add_argument('-f', '--force', action='store_true',
+                            help="Whehter or not you want to go through "
+                                 " with destroying the stacks")
+
+    def run(self, options, **kwargs):
+        super(Destroy, self).run(options, **kwargs)
+        action = destroy.Action(options.context, provider=options.provider)
+        stack_names = map(lambda x: '  - %s' % (x.fqn,), options.context.get_stacks())
+        message = '\nAre you sure you want to destroy the following stacks:\n%s\n\n(yes/no): ' % (
+            '\n'.join(stack_names),
+        )
+        force = False
+        if options.force:
+            confirm = raw_input(message)
+            force = confirm.lower() == 'yes'
+            if not force:
+                self.logger.info('Confirmation failed, printing ouline...')
+        action.execute(force=force)

--- a/stacker/config.py
+++ b/stacker/config.py
@@ -6,9 +6,20 @@ import yaml
 from . import exceptions
 
 
-def parse_config(config_string, environment=None):
-    """ Parse a config, using it as a template with the environment. """
-    t = Template(config_string)
+def parse_config(raw_config, environment=None):
+    """Parse a config, using it as a template with the environment.
+
+    Args:
+        raw_config (str): the raw stacker configuration string.
+        environment (Optional[dict]): any environment values that should be
+            passed to the config
+
+    Returns:
+        dict: the stacker configuration populated with any values passed from
+            the environment
+
+    """
+    t = Template(raw_config)
     buff = StringIO()
     if not environment:
         environment = {}

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -3,6 +3,12 @@ from .stack import Stack
 
 
 class Context(object):
+    """The context under which the current stacks are being executed.
+
+    The stacker Context is responsible for translating the values passed in via
+    the command line and specified in the config to `Stack` objects.
+
+    """
 
     _optional_keys = ('environment', 'stack_names', 'parameters', 'mappings', 'config')
 
@@ -22,10 +28,16 @@ class Context(object):
         return [s for s in self.config['stacks'] if s['name'] in self.stack_names]
 
     def get_stacks(self):
-        # TODO fix docstring
-        """Extract stack definitions from the config.
+        """Get the stacks for the current action.
 
-        If no stack_list given, return stack config as is.
+        Handles configuring the `stacker.stack.Stack` objects that will be used
+        in the current action. Responsible for merging the stack definition in
+        the config, the parameters specified on the command line, and any
+        mappings specified in the config.
+
+        Returns:
+            list: a list of `stacker.stack.Stack` objects
+
         """
         if not hasattr(self, '_stacks'):
             definitions = self._get_stack_definitions()
@@ -44,4 +56,5 @@ class Context(object):
         return dict((stack.fqn, stack) for stack in self.get_stacks())
 
     def get_fqn(self, name=None):
+        """Return the fully qualified name of an object within this context."""
         return '-'.join(filter(None, [self._base_fqn, name]))

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -56,5 +56,13 @@ class Context(object):
         return dict((stack.fqn, stack) for stack in self.get_stacks())
 
     def get_fqn(self, name=None):
-        """Return the fully qualified name of an object within this context."""
+        """Return the fully qualified name of an object within this context.
+
+        If the name passed already appears to be a fully qualified name, it
+        will be returned with no further processing.
+
+        """
+        if name and name.startswith(self._base_fqn + '-'):
+            return name
+
         return '-'.join(filter(None, [self._base_fqn, name]))

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -1,3 +1,5 @@
+
+
 class StackDoesNotExist(Exception):
 
     def __init__(self, stack_name, *args, **kwargs):

--- a/stacker/hooks/ecs.py
+++ b/stacker/hooks/ecs.py
@@ -22,10 +22,11 @@ def connect_to_region(region_name, **kw_params):
 
 
 def create_clusters(region, namespace, mappings, parameters, **kwargs):
-    """ Creates ECS clusters.
+    """Creates ECS clusters.
 
     Expects a 'clusters' argument, which should contain a list of cluster
     names to create.
+
     """
     conn = connect_to_region(region)
     try:

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -10,10 +10,11 @@ from awacs import ecs
 
 def create_ecs_service_role(region, namespace, mappings, parameters,
                             **kwargs):
-    """ Used to create the ecsServieRole, which has to be named exactly that
+    """Used to create the ecsServieRole, which has to be named exactly that
     currently, so cannot be created via CloudFormation. See:
 
     http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAM_policies.html#service_IAM_role
+
     """
     conn = ConnectionManager(region).iam
     policy = Policy(

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class Provider(BaseProvider):
+    """AWS CloudFormation Provider"""
 
     DELETED_STATUS = 'DELETE_COMPLETE'
     IN_PROGRESS_STATUSES = (

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -53,7 +53,7 @@ class Stack(object):
 
     @property
     def requires(self):
-        requires = set(self.definition.get('requires', []))
+        requires = set(map(self.context.get_fqn, self.definition.get('requires', [])))
         # Auto add dependencies when parameters reference the Ouptuts of
         # another stack.
         for value in self.parameters.values():

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -4,7 +4,7 @@ from . import util
 
 
 def _gather_parameters(stack_def, builder_parameters):
-    """ Merges builder provided & stack defined parameters.
+    """Merges builder provided & stack defined parameters.
 
     Ensures that more specificly defined parameters (ie: parameters defined
     specifically for the given stack: stack_name::parameter) override less
@@ -14,6 +14,7 @@ def _gather_parameters(stack_def, builder_parameters):
         - builder defined stack specific (stack_name::parameter)
         - builder defined non-specific (parameter)
         - stack_def defined
+
     """
     parameters = copy.deepcopy(stack_def.get('parameters', {}))
     stack_specific_params = {}

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -1,0 +1,150 @@
+from contextlib import nested
+import unittest
+
+import mock
+
+from stacker.actions import destroy
+from stacker.context import Context
+from stacker.plan import (
+    COMPLETE,
+    PENDING,
+    SKIPPED,
+    SUBMITTED,
+)
+
+
+class MockStack(object):
+    """Mock our local Stacker stack and an AWS provider stack"""
+
+    def __init__(self, name, tags=None, **kwargs):
+        self.name = name
+        self.fqn = name
+        self.requires = []
+
+
+class TestDestroyAction(unittest.TestCase):
+
+    def setUp(self):
+        self.context = Context('namespace')
+        self.context.config = {
+            'stacks': [
+                {'name': 'vpc'},
+                {'name': 'bastion', 'requires': ['vpc']},
+                {'name': 'instance', 'requires': ['vpc', 'bastion']},
+                {'name': 'db', 'requires': ['instance', 'vpc', 'bastion']},
+                {'name': 'other', 'requires': ['db']},
+            ],
+        }
+        self.action = destroy.Action(self.context, provider=mock.MagicMock())
+
+    def test_generate_plan(self):
+        plan = self.action._generate_plan()
+        self.assertEqual(
+            map(self.context.get_fqn, ['other', 'db', 'instance', 'bastion', 'vpc']),
+            plan.keys(),
+        )
+
+    def test_only_execute_plan_when_forced(self):
+        with mock.patch.object(self.action, '_generate_plan') as mock_generate_plan:
+            self.action.run(force=False)
+            self.assertEqual(mock_generate_plan().execute.call_count, 0)
+
+    def test_execute_plan_when_forced(self):
+        with mock.patch.object(self.action, '_generate_plan') as mock_generate_plan:
+            self.action.run(force=True)
+            self.assertEqual(mock_generate_plan().execute.call_count, 1)
+
+    def test_destroy_stack_complete_if_state_submitted(self):
+        # Simulate the provider not being able to find the stack (a result of
+        # it being successfully deleted)
+        self.action.provider = mock.MagicMock()
+        self.action.provider.get_stack.return_value = None
+        status = self.action._destroy_stack({}, MockStack('vpc'), status=PENDING)
+        # if we haven't processed the step (ie. has never been SUBMITTED, should be skipped)
+        self.assertEqual(status, SKIPPED)
+        status = self.action._destroy_stack({}, MockStack('vpc'), status=SUBMITTED)
+        # if we have processed the step and then can't find the stack, it means
+        # we successfully deleted it
+        self.assertEqual(status, COMPLETE)
+
+    def test_destroy_stack_in_parallel(self):
+        mock_provider = mock.MagicMock()
+        self.context.config = {
+            'stacks': [
+                {'name': 'vpc'},
+                {'name': 'bastion', 'requires': ['vpc']},
+                {'name': 'instance', 'requires': ['vpc']},
+                {'name': 'db', 'requies': ['vpc']},
+            ],
+        }
+        stacks_dict = self.context.get_stacks_dict()
+
+        results = {'_count': 0}
+
+        def get_stack(stack_name):
+            return stacks_dict.get(stack_name)
+
+        def get_stack_staggered(stack_name):
+            results['_count'] += 1
+            if not results['_count'] % 2:
+                return None
+            return stacks_dict.get(stack_name)
+
+        def wait_func(*args):
+            # we want "get_stack" above to return staggered results for the stack
+            # being "deleted" to simulate waiting on stacks to complete
+            mock_provider.get_stack.side_effect = get_stack_staggered
+
+            non_test_keys = [key for key in results if not key.startswith('_')]
+            if len(non_test_keys) >= 3 and '_dependencies_deleted' not in results:
+                # vpc should not have been deleted until all other stacks have been deleted
+                self.assertNotIn('vpc', results)
+                results['_dependencies_deleted'] = True
+
+        plan = self.action._generate_plan()
+        plan._wait_func = wait_func
+
+        # swap for mock provider
+        plan.provider = mock_provider
+        self.action.provider = mock_provider
+
+        # we want "get_stack" to return the mock stacks above on the first
+        # pass. "wait_func" will simulate the stack being deleted every second
+        # pass
+        mock_provider.get_stack.side_effect = get_stack
+        mock_provider.is_stack_destroyed.return_value = False
+        mock_provider.is_stack_in_progress.return_value = True
+        plan.execute(results)
+
+    def test_destroy_stack_step_statuses(self):
+        mock_provider = mock.MagicMock()
+        stacks_dict = self.context.get_stacks_dict()
+
+        def get_stack(stack_name):
+            return stacks_dict.get(stack_name)
+
+        plan = self.action._generate_plan()
+        _, step = plan.list_pending()[0]
+        # we need the AWS provider to generate the plan, but swap it for
+        # the mock one to make the test easier
+        self.action.provider = mock_provider
+
+        # simulate stack doesn't exist and we haven't submitted anything for deletion
+        mock_provider.get_stack.return_value = None
+        status = step.run({})
+        self.assertEqual(status, SKIPPED)
+
+        # simulate stack getting successfully deleted
+        mock_provider.get_stack.side_effect = get_stack
+        mock_provider.is_stack_destroyed.return_value = False
+        mock_provider.is_stack_in_progress.return_value = False
+        status = step.run({})
+        self.assertEqual(status, SUBMITTED)
+        mock_provider.is_stack_destroyed.return_value = False
+        mock_provider.is_stack_in_progress.return_value = True
+        status = step.run({})
+        self.assertEqual(status, SUBMITTED)
+        mock_provider.is_stack_destroyed.return_value = True
+        mock_provider.is_stack_in_progress.return_value = False
+        status = step.run({})
+        self.assertEqual(status, COMPLETE)

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -21,7 +21,6 @@ class TestStep(unittest.TestCase):
         )
         self.step = Step(
             stack=stack,
-            index=0,
             run_func=lambda x, y: (x, y),
             completion_func=lambda y: True,
         )
@@ -56,7 +55,7 @@ class TestPlan(unittest.TestCase):
         return self.count
 
     def test_execute_plan(self):
-        plan = Plan(details='Test', provider=mock.MagicMock(), sleep_time=0)
+        plan = Plan(description='Test', sleep_time=0)
         _skip_func = mock.MagicMock()
         previous_stack = None
         for i in range(5):
@@ -84,7 +83,7 @@ class TestPlan(unittest.TestCase):
         self.assertEqual(len(plan.list_skipped()), _skip_func.call_count)
 
     def test_step_must_return_status(self):
-        plan = Plan(details='Test', provider=mock.MagicMock(), sleep_time=0)
+        plan = Plan(description='Test', sleep_time=0)
         stack = Stack(definition=generate_definition('vpc', 1), context=mock.MagicMock())
         plan.add(
             stack=stack,
@@ -144,7 +143,7 @@ class TestPlan(unittest.TestCase):
                     self.assertEqual(results[web_stack_test_name], 1)
                     self.assertEqual(results[db_stack_test_name], 1)
 
-        plan = Plan(details='Test', provider=mock.MagicMock(), sleep_time=0, wait_func=_wait_func)
+        plan = Plan(description='Test', sleep_time=0, wait_func=_wait_func)
         for stack in [vpc_stack, web_stack, db_stack]:
             plan.add(
                 stack=stack,
@@ -156,10 +155,10 @@ class TestPlan(unittest.TestCase):
 
     def test_plan_wait_func_must_be_function(self):
         with self.assertRaises(ImproperlyConfigured):
-            Plan(details='Test', provider=mock.MagicMock(), wait_func='invalid')
+            Plan(description='Test', wait_func='invalid')
 
     def test_plan_steps_listed_with_fqn(self):
-        plan = Plan(details='Test', provider=mock.MagicMock(), sleep_time=0)
+        plan = Plan(description='Test', sleep_time=0)
         stack = Stack(definition=generate_definition('vpc', 1), context=Context('namespace'))
         plan.add(stack=stack, run_func=lambda x, y: (x, y))
         steps = plan.list_pending()
@@ -167,7 +166,7 @@ class TestPlan(unittest.TestCase):
 
     def test_execute_plan_wait_func_not_called_if_complete(self):
         wait_func = mock.MagicMock()
-        plan = Plan(details='Test', provider=mock.MagicMock(), wait_func=wait_func)
+        plan = Plan(description='Test', wait_func=wait_func)
 
         def run_func(*args, **kwargs):
             return COMPLETE


### PR DESCRIPTION
depends on the subcommands PR.

destruction no longer uses the "required_stacks" tag associated with cloudformation stacks since we can't update those values. we're now simply reversing the dependencies we determine when building stacks.