### PR TITLE
Add destroy action

### DIFF
--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -1,0 +1,88 @@
+import logging
+
+from .base import BaseAction
+from ..exceptions import StackDoesNotExist
+from ..plan import (
+    COMPLETE,
+    SKIPPED,
+    SUBMITTED,
+    Plan,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Action(BaseAction):
+    """Responsible for destroying CloudFormation stacks.
+
+    Generates a destruction plan based on stack dependencies. Stack
+    dependencies are reversed from the build action. For example, if a Stack B
+    requires Stack A during build, during destroy Stack A requires Stack B be
+    destroyed first.
+
+    The plan defaults to printing an outline of what will be destroyed. If
+    forced to execute, each stack will get destroyed in order.
+
+    """
+
+    def _get_dependencies(self, stacks_dict):
+        dependencies = {}
+        for stack_name, stack in stacks_dict.iteritems():
+            required_stacks = stack.requires
+            if not required_stacks:
+                if stack_name not in dependencies:
+                    dependencies[stack_name] = required_stacks
+                continue
+
+            for requirement in required_stacks:
+                dependencies.setdefault(requirement, set()).add(stack_name)
+        return dependencies
+
+    def _generate_plan(self):
+        plan = Plan(description='Destroy stacks')
+        stacks_dict = self.context.get_stacks_dict()
+        dependencies = self._get_dependencies(stacks_dict)
+        for stack_name in self.get_stack_execution_order(dependencies):
+            plan.add(
+                stacks_dict[stack_name],
+                run_func=self._destroy_stack,
+                requires=dependencies.get(stack_name),
+            )
+        return plan
+
+    def _destroy_stack(self, stack, **kwargs):
+        try:
+            provider_stack = self.provider.get_stack(stack.fqn)
+        except StackDoesNotExist:
+            logger.debug("Stack %s does not exist.", stack.fqn)
+            # Once the stack has been destroyed, it doesn't exist. If the
+            # status of the step was SUBMITTED, we know we just deleted it,
+            # otherwise it should be skipped
+            if kwargs.get('status', None) is SUBMITTED:
+                return COMPLETE
+            else:
+                return SKIPPED
+
+        logger.debug(
+            "Stack %s provider status: %s",
+            self.provider.get_stack_name(provider_stack),
+            self.provider.get_stack_status(provider_stack),
+        )
+        if self.provider.is_stack_destroyed(provider_stack):
+            return COMPLETE
+        elif self.provider.is_stack_in_progress(provider_stack):
+            return SUBMITTED
+        else:
+            self.provider.destroy_stack(provider_stack)
+        return SUBMITTED
+
+    def run(self, force, *args, **kwargs):
+        plan = self._generate_plan()
+        if force:
+            # need to generate a new plan to log since the outline sets the
+            # steps to COMPLETE in order to log them
+            debug_plan = self._generate_plan()
+            debug_plan.outline(logging.DEBUG)
+            plan.execute()
+        else:
+            plan.outline(message='To execute this plan, run with "-f, --force" flag.')

--- a/stacker/commands/base.py
+++ b/stacker/commands/base.py
@@ -34,6 +34,7 @@ class BaseCommand(object):
                 )
                 subcommand.add_arguments(subparser)
                 subparser.set_defaults(run=subcommand.run)
+                subparser.set_defaults(get_context_kwargs=subcommand.get_context_kwargs)
 
     @property
     def logger(self):
@@ -66,3 +67,17 @@ class BaseCommand(object):
 
     def configure(self, options, **kwargs):
         pass
+
+    def get_context_kwargs(self, options, **kwargs):
+        """Return a dictionary of kwargs that will be passed when setting up the Context.
+
+        This allows commands to pass in any specific arguments they define to the context.
+
+        Args:
+            options (argparse.Namespace): arguments that have been passed via the command line
+
+        Returns:
+            dict: Dictionary that will be passed to Context initializer as kwargs.
+
+        """
+        return {}

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -1,6 +1,7 @@
 import copy
 
 from .build import Build
+from .destroy import Destroy
 from ..base import BaseCommand
 from ...context import Context
 from ...providers import aws
@@ -9,7 +10,7 @@ from ...providers import aws
 class Stacker(BaseCommand):
 
     name = 'stacker'
-    subcommands = (Build,)
+    subcommands = (Build, Destroy)
 
     def configure(self, options, **kwargs):
         super(Stacker, self).configure(options, **kwargs)
@@ -18,7 +19,11 @@ class Stacker(BaseCommand):
             namespace=options.namespace,
             environment=options.environment,
             parameters=copy.deepcopy(options.parameters),
-            stack_names=options.stacks,
-            force_stacks=options.force,
+            # We use
+            # set_default(get_context_kwargs=subcommand.get_context_kwargs) so
+            # the subcommand can provide any specific kwargs to the Context
+            # that it wants. We need to pass down the options so it can
+            # reference any arguments it defined.
+            **options.get_context_kwargs(options)
         )
         options.context.load_config(options.config.read())

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -77,12 +77,6 @@ class StackerCommand(BaseCommand):
         parser.add_argument("-v", "--verbose", action="count", default=0,
                             help="Increase output verbosity. May be specified "
                                  "up to twice.")
-        parser.add_argument("--stacks", action="append",
-                            metavar="STACKNAME", type=str,
-                            help="Only work on the stacks given. Can be "
-                                 "specified more than once. If not specified "
-                                 "then stacker will work on all stacks in the "
-                                 "config file.")
         parser.add_argument("namespace",
                             help="The namespace for the stack collection. "
                                  "This will be used as the prefix to the "

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -31,8 +31,17 @@ class Build(StackerCommand):
                             help="If a stackname is provided to --force, it "
                                  "will be updated, even if it is locked in "
                                  "the config.")
+        parser.add_argument("--stacks", action="append",
+                            metavar="STACKNAME", type=str,
+                            help="Only work on the stacks given. Can be "
+                                 "specified more than once. If not specified "
+                                 "then stacker will work on all stacks in the "
+                                 "config file.")
 
     def run(self, options, **kwargs):
         super(Build, self).run(options, **kwargs)
         action = build.Action(options.context, provider=options.provider)
         action.execute(outline=options.outline)
+
+    def get_context_kwargs(self, options, **kwargs):
+        return {'stack_names': options.stacks, 'force_stacks': options.force}

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -23,7 +23,7 @@ class Destroy(StackerCommand):
     def run(self, options, **kwargs):
         super(Destroy, self).run(options, **kwargs)
         action = destroy.Action(options.context, provider=options.provider)
-        stack_names = map(lambda x: '  - %s' % (x.fqn,), options.context.get_stacks())
+        stack_names = ['  - %s' % (s.fqn,) for s in options.context.get_stacks()]
         message = '\nAre you sure you want to destroy the following stacks:\n%s\n\n(yes/no): ' % (
             '\n'.join(stack_names),
         )

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -1,0 +1,36 @@
+"""Destroys CloudFormation stacks based on the given config.
+
+Stacker will determine the order in which stacks should be destroyed based on
+any manual requirements they specify or output values they rely on from other
+stacks.
+
+"""
+from .base import StackerCommand
+from ...actions import destroy
+
+
+class Destroy(StackerCommand):
+
+    name = "destroy"
+    description = __doc__
+
+    def add_arguments(self, parser):
+        super(Destroy, self).add_arguments(parser)
+        parser.add_argument('-f', '--force', action='store_true',
+                            help="Whehter or not you want to go through "
+                                 " with destroying the stacks")
+
+    def run(self, options, **kwargs):
+        super(Destroy, self).run(options, **kwargs)
+        action = destroy.Action(options.context, provider=options.provider)
+        stack_names = map(lambda x: '  - %s' % (x.fqn,), options.context.get_stacks())
+        message = '\nAre you sure you want to destroy the following stacks:\n%s\n\n(yes/no): ' % (
+            '\n'.join(stack_names),
+        )
+        force = False
+        if options.force:
+            confirm = raw_input(message)
+            force = confirm.lower() == 'yes'
+            if not force:
+                self.logger.info('Confirmation failed, printing ouline...')
+        action.execute(force=force)

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -64,5 +64,13 @@ class Context(object):
         return dict((stack.fqn, stack) for stack in self.get_stacks())
 
     def get_fqn(self, name=None):
-        """Return the fully qualified name of an object within this context."""
+        """Return the fully qualified name of an object within this context.
+
+        If the name passed already appears to be a fully qualified name, it
+        will be returned with no further processing.
+
+        """
+        if name and name.startswith(self._base_fqn + '-'):
+            return name
+
         return '-'.join(filter(None, [self._base_fqn, name]))

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -176,7 +176,7 @@ class Plan(OrderedDict):
 
         self._check_point()
 
-    def outline(self, level=logging.INFO):
+    def outline(self, level=logging.INFO, message=''):
         """Print an outline of the actions the plan is going to take.
 
         The outline will represent the rough ordering of the steps that will be
@@ -185,6 +185,8 @@ class Plan(OrderedDict):
         Args:
             level (Optional[int]): a valid log level that should be used to log
                 the outline
+            message (Optional[str]): a message that will be logged to
+                the user after the outline has been logged.
         """
         steps = 1
         logger.log(level, 'Plan "%s":', self.description)
@@ -201,6 +203,9 @@ class Plan(OrderedDict):
             # completion func
             step.status = COMPLETE
             steps += 1
+
+        if message:
+            logger.log(level, message)
 
     def _check_point(self):
         logger.info('Plan Status:')

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -57,7 +57,7 @@ class Stack(object):
 
     @property
     def requires(self):
-        requires = set(self.definition.get('requires', []))
+        requires = set(map(self.context.get_fqn, self.definition.get('requires', [])))
         # Auto add dependencies when parameters reference the Ouptuts of
         # another stack.
         for value in self.parameters.values():

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -57,7 +57,7 @@ class Stack(object):
 
     @property
     def requires(self):
-        requires = set(map(self.context.get_fqn, self.definition.get('requires', [])))
+        requires = set([self.context.get_fqn(r) for r in self.definition.get('requires', [])])
         # Auto add dependencies when parameters reference the Ouptuts of
         # another stack.
         for value in self.parameters.values():

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -132,11 +132,11 @@ class TestBuildAction(unittest.TestCase):
         dependencies = build_action._get_dependencies()
         self.assertEqual(
             dependencies[context.get_fqn('bastion')],
-            set(map(context.get_fqn, ['vpc'])),
+            set([context.get_fqn('vpc')]),
         )
         self.assertEqual(
             dependencies[context.get_fqn('db')],
-            set(map(context.get_fqn, ['vpc', 'bastion'])),
+            set([context.get_fqn(s) for s in['vpc', 'bastion']]),
         )
         self.assertFalse(dependencies[context.get_fqn('other')])
 
@@ -147,15 +147,17 @@ class TestBuildAction(unittest.TestCase):
         execution_order = build_action.get_stack_execution_order(dependencies)
         self.assertEqual(
             execution_order,
-            map(context.get_fqn, ['other', 'vpc', 'bastion', 'db']),
+            [context.get_fqn(s) for s in ['other', 'vpc', 'bastion', 'db']],
         )
 
     def test_generate_plan(self):
         context = self._get_context()
         build_action = build.Action(context)
         plan = build_action._generate_plan()
-        self.assertEqual(plan.keys(), map(context.get_fqn,
-                                          ['other', 'vpc', 'bastion', 'db']))
+        self.assertEqual(
+            plan.keys(),
+            [context.get_fqn(s) for s in ['other', 'vpc', 'bastion', 'db']],
+        )
 
     def test_dont_execute_plan_when_outline_specified(self):
         context = self._get_context()

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -40,7 +40,7 @@ class TestDestroyAction(unittest.TestCase):
     def test_generate_plan(self):
         plan = self.action._generate_plan()
         self.assertEqual(
-            map(self.context.get_fqn, ['other', 'db', 'instance', 'bastion', 'vpc']),
+            [self.context.get_fqn(s) for s in ['other', 'db', 'instance', 'bastion', 'vpc']],
             plan.keys(),
         )
 

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -1,0 +1,153 @@
+import unittest
+
+import mock
+
+from stacker.actions import destroy
+from stacker.context import Context
+from stacker.exceptions import StackDoesNotExist
+from stacker.plan import (
+    COMPLETE,
+    PENDING,
+    SKIPPED,
+    SUBMITTED,
+)
+
+
+class MockStack(object):
+    """Mock our local Stacker stack and an AWS provider stack"""
+
+    def __init__(self, name, tags=None, **kwargs):
+        self.name = name
+        self.fqn = name
+        self.requires = []
+
+
+class TestDestroyAction(unittest.TestCase):
+
+    def setUp(self):
+        self.context = Context('namespace')
+        self.context.config = {
+            'stacks': [
+                {'name': 'vpc'},
+                {'name': 'bastion', 'requires': ['vpc']},
+                {'name': 'instance', 'requires': ['vpc', 'bastion']},
+                {'name': 'db', 'requires': ['instance', 'vpc', 'bastion']},
+                {'name': 'other', 'requires': ['db']},
+            ],
+        }
+        self.action = destroy.Action(self.context, provider=mock.MagicMock())
+
+    def test_generate_plan(self):
+        plan = self.action._generate_plan()
+        self.assertEqual(
+            map(self.context.get_fqn, ['other', 'db', 'instance', 'bastion', 'vpc']),
+            plan.keys(),
+        )
+
+    def test_only_execute_plan_when_forced(self):
+        with mock.patch.object(self.action, '_generate_plan') as mock_generate_plan:
+            self.action.run(force=False)
+            self.assertEqual(mock_generate_plan().execute.call_count, 0)
+
+    def test_execute_plan_when_forced(self):
+        with mock.patch.object(self.action, '_generate_plan') as mock_generate_plan:
+            self.action.run(force=True)
+            self.assertEqual(mock_generate_plan().execute.call_count, 1)
+
+    def test_destroy_stack_complete_if_state_submitted(self):
+        # Simulate the provider not being able to find the stack (a result of
+        # it being successfully deleted)
+        self.action.provider = mock.MagicMock()
+        self.action.provider.get_stack.side_effect = StackDoesNotExist('mock')
+        status = self.action._destroy_stack(MockStack('vpc'), status=PENDING)
+        # if we haven't processed the step (ie. has never been SUBMITTED, should be skipped)
+        self.assertEqual(status, SKIPPED)
+        status = self.action._destroy_stack(MockStack('vpc'), status=SUBMITTED)
+        # if we have processed the step and then can't find the stack, it means
+        # we successfully deleted it
+        self.assertEqual(status, COMPLETE)
+
+    def test_destroy_stack_in_parallel(self):
+        count = {'_count': 0}
+        mock_provider = mock.MagicMock()
+        self.context.config = {
+            'stacks': [
+                {'name': 'vpc'},
+                {'name': 'bastion', 'requires': ['vpc']},
+                {'name': 'instance', 'requires': ['vpc']},
+                {'name': 'db', 'requies': ['vpc']},
+            ],
+        }
+        stacks_dict = self.context.get_stacks_dict()
+
+        def get_stack(stack_name):
+            return stacks_dict.get(stack_name)
+
+        def get_stack_staggered(stack_name):
+            count['_count'] += 1
+            if not count['_count'] % 2:
+                raise StackDoesNotExist(stack_name)
+            return stacks_dict.get(stack_name)
+
+        def wait_func(*args):
+            # we want "get_stack" above to return staggered results for the stack
+            # being "deleted" to simulate waiting on stacks to complete
+            mock_provider.get_stack.side_effect = get_stack_staggered
+
+        plan = self.action._generate_plan()
+        plan._wait_func = wait_func
+
+        # swap for mock provider
+        plan.provider = mock_provider
+        self.action.provider = mock_provider
+
+        # we want "get_stack" to return the mock stacks above on the first
+        # pass. "wait_func" will simulate the stack being deleted every second
+        # pass
+        mock_provider.get_stack.side_effect = get_stack
+        mock_provider.is_stack_destroyed.return_value = False
+        mock_provider.is_stack_in_progress.return_value = True
+
+        independent_stacks = filter(lambda x: x.name != 'vpc', self.context.get_stacks())
+        while not plan._single_run():
+            # vpc should be the last stack that is deleted
+            if plan['namespace-vpc'].completed:
+                self.assertFalse(plan.list_pending())
+
+            # all of the independent stacks should be submitted at the same time
+            if any([plan[stack.fqn].submitted for stack in independent_stacks]):
+                self.assertTrue(all([plan[stack.fqn].submitted for stack in independent_stacks]))
+            wait_func()
+
+    def test_destroy_stack_step_statuses(self):
+        mock_provider = mock.MagicMock()
+        stacks_dict = self.context.get_stacks_dict()
+
+        def get_stack(stack_name):
+            return stacks_dict.get(stack_name)
+
+        plan = self.action._generate_plan()
+        _, step = plan.list_pending()[0]
+        # we need the AWS provider to generate the plan, but swap it for
+        # the mock one to make the test easier
+        self.action.provider = mock_provider
+
+        # simulate stack doesn't exist and we haven't submitted anything for deletion
+        mock_provider.get_stack.side_effect = StackDoesNotExist('mock')
+        status = step.run()
+        self.assertEqual(status, SKIPPED)
+
+        # simulate stack getting successfully deleted
+        mock_provider.get_stack.side_effect = get_stack
+        mock_provider.is_stack_destroyed.return_value = False
+        mock_provider.is_stack_in_progress.return_value = False
+        status = step.run()
+        self.assertEqual(status, SUBMITTED)
+        mock_provider.is_stack_destroyed.return_value = False
+        mock_provider.is_stack_in_progress.return_value = True
+        status = step.run()
+        self.assertEqual(status, SUBMITTED)
+        mock_provider.is_stack_destroyed.return_value = True
+        mock_provider.is_stack_in_progress.return_value = False
+        status = step.run()
+        self.assertEqual(status, COMPLETE)

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -22,7 +22,7 @@ class TestStack(unittest.TestCase):
             parameters={
                 "ExternalParameter": "fakeStack2::FakeParameter",
             },
-            requires=map(self.context.get_fqn, ['fakeStack']),
+            requires=[self.context.get_fqn('fakeStack')],
         )
         stack = Stack(definition=definition, context=self.context)
         self.assertIn(


### PR DESCRIPTION
The destroy action no longer relies on the "required_stacks" tag within
CloudFormation since we can't rely on updating those values. Destroy
will determine the order in which resources should be destroyed based on
any build dependencies determined from the configuration.