### PR TITLE
Local parameters for python

### DIFF
--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -11,11 +11,20 @@ class MissingParameterException(Exception):
 
     def __init__(self, parameters, *args, **kwargs):
         self.parameters = parameters
-        message = 'Missing required parameters: %s' % (
+        message = 'Missing required cloudformation parameters: %s' % (
             ', '.join(parameters),
         )
         super(MissingParameterException, self).__init__(message, *args,
                                                         **kwargs)
+
+
+class MissingLocalParameterException(Exception):
+
+    def __init__(self, parameter, *args, **kwargs):
+        self.parameter = parameter
+        message = 'Missing required local parameter: %s' % parameter
+        super(MissingLocalParameterException, self).__init__(message, *args,
+                                                             **kwargs)
 
 
 class ParameterDoesNotExist(Exception):

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -1,0 +1,29 @@
+import unittest
+
+from stacker.blueprints.base import get_local_parameters
+from stacker.exceptions import MissingLocalParameterException
+
+
+class TestLocalParameters(unittest.TestCase):
+    def test_default_parameter(self):
+        parameter_def = {'Param1': {'default': 0}}
+        parameters = {}
+
+        local = get_local_parameters(parameter_def, parameters)
+        self.assertEquals(local['Param1'], 0)
+
+    def test_missing_required(self):
+        parameter_def = {'Param1': {'default': 0}, 'Param2': {}}
+        parameters = {}
+
+        with self.assertRaises(MissingLocalParameterException) as cm:
+            get_local_parameters(parameter_def, parameters)
+
+        self.assertEquals('Param2', cm.exception.parameter)
+
+    def test_supplied_parameter(self):
+        parameter_def = {'Param1': {'default': 0}, 'Param2': {}}
+        parameters = {'Param1': 1, 'Param2': 2}
+
+        local = get_local_parameters(parameter_def, parameters)
+        self.assertEquals(parameters, local)


### PR DESCRIPTION
This allows the definition of local parameters that are meant to be used
by python, not by cloudformation.  The parameters are still passed into
the blueprint the same way (from the command line, or the config) but
they can be used without having to share them with the template.