### PR TITLE
Simplify steps in plan/build action

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -24,7 +24,7 @@ class Action(BaseAction):
 
     """
 
-    def _resolve_parameters(self, outputs, parameters, blueprint):
+    def _resolve_parameters(self, parameters, blueprint):
         """Resolves parameters for a given blueprint.
 
         Given a list of parameters, first discard any parameters that the
@@ -33,7 +33,6 @@ class Action(BaseAction):
         stack.
 
         Args:
-            outputs (dict): any outputs that can be referenced by other stacks
             parameters (dict): A dictionary of parameters provided by the
                 stack definition
             blueprint (`stacker.blueprint.base.Blueprint`): A Blueprint object
@@ -55,16 +54,10 @@ class Action(BaseAction):
                 # Get from the Output of another stack in the stack_map
                 stack_name, output = value.split('::')
                 stack_fqn = self.context.get_fqn(stack_name)
-                # XXX check out this logic to see if this is what we really
-                # want to do
                 try:
-                    stack_outputs = outputs[stack_fqn]
+                    value = self.provider.get_output(stack_fqn, output)
                 except KeyError:
-                    raise exceptions.StackDoesNotExist(stack_fqn)
-                try:
-                    value = stack_outputs[output]
-                except KeyError:
-                    raise exceptions.ParameterDoesNotExist(value)
+                    raise exceptions.OutputDoesNotExist(stack_fqn, value)
             params[k] = value
         return params
 
@@ -81,14 +74,18 @@ class Action(BaseAction):
             tags['required_stacks'] = ':'.join(requires)
         return tags
 
-    def _launch_stack(self, results, stack, **kwargs):
+    def _launch_stack(self, stack, **kwargs):
         """Handles the creating or updating of a stack in CloudFormation.
 
         Also makes sure that we don't try to create or update a stack while
         it is already updating or creating.
 
         """
-        provider_stack = self.provider.get_stack(stack.fqn)
+        try:
+            provider_stack = self.provider.get_stack(stack.fqn)
+        except exceptions.StackDoesNotExist:
+            provider_stack = None
+
         if provider_stack and kwargs.get('status') is SUBMITTED:
             logger.debug(
                 "Stack %s provider status: %s",
@@ -104,7 +101,7 @@ class Action(BaseAction):
         logger.info("Launching stack %s now.", stack.fqn)
         template_url = self.s3_stack_push(stack.blueprint)
         tags = self._build_stack_tags(stack, template_url)
-        parameters = self._resolve_parameters(results, stack.parameters,
+        parameters = self._resolve_parameters(stack.parameters,
                                               stack.blueprint)
         required_params = [k for k, v in stack.blueprint.required_parameters]
         parameters = self._handle_missing_parameters(parameters,
@@ -122,21 +119,6 @@ class Action(BaseAction):
             return SKIPPED
 
         return SUBMITTED
-
-    def _get_outputs(self, stack):
-        """Gets all the outputs from a given stack in CloudFormation.
-
-        Updates the local output cache with the values it finds.
-
-        """
-        provider_stack = self.provider.get_stack(stack.fqn)
-        if not provider_stack:
-            raise ValueError("Stack %s does not exist." % (stack.fqn,))
-        stack_outputs = {}
-        for output in provider_stack.outputs:
-            logger.debug("    %s: %s", output.key, output.value)
-            stack_outputs[output.key] = output.value
-        return stack_outputs
 
     def _handle_missing_parameters(self, params, required_params,
                                    existing_stack=None):
@@ -183,8 +165,6 @@ class Action(BaseAction):
             plan.add(
                 stacks[stack_name],
                 run_func=self._launch_stack,
-                completion_func=self._get_outputs,
-                skip_func=self._get_outputs,
                 requires=dependencies.get(stack_name),
             )
         return plan

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -18,11 +18,12 @@ class MissingParameterException(Exception):
                                                         **kwargs)
 
 
-class ParameterDoesNotExist(Exception):
+class OutputDoesNotExist(Exception):
 
-    def __init__(self, parameter, *args, **kwargs):
-        message = 'Parameter: "%s" does not exist in output' % (parameter,)
-        super(ParameterDoesNotExist, self).__init__(message, *args, **kwargs)
+    def __init__(self, stack_name, output, *args, **kwargs):
+        message = 'Output %s does not exist on stack %s' % (output,
+                                                            stack_name)
+        super(OutputDoesNotExist, self).__init__(message, *args, **kwargs)
 
 
 class MissingEnvironment(Exception):

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -9,6 +9,25 @@ from .base import BaseProvider
 logger = logging.getLogger(__name__)
 
 
+def get_output_dict(stack):
+    """Returns a dict of key/values for the outputs for a given CF stack.
+
+    Args:
+        stack (boto.cloudformation.stack.Stack): The stack object to get
+            outputs from.
+
+    Returns:
+        dict: A dictionary with key/values for each output on the stack.
+
+    """
+    outputs = {}
+    for output in stack.outputs:
+        logger.debug("    %s %s: %s", stack.name, output.key,
+                     output.value)
+        outputs[output.key] = output.value
+    return outputs
+
+
 class Provider(BaseProvider):
     """AWS CloudFormation Provider"""
 
@@ -26,6 +45,8 @@ class Provider(BaseProvider):
 
     def __init__(self, region, **kwargs):
         self.region = region
+        self._stacks = {}
+        self._outputs = {}
 
     @property
     def cloudformation(self):
@@ -35,13 +56,15 @@ class Provider(BaseProvider):
         return self._cloudformation
 
     def get_stack(self, stack_name, **kwargs):
-        stack = None
-        try:
-            stack = self.cloudformation.describe_stacks(stack_name)[0]
-        except boto.exception.BotoServerError as e:
-            if 'does not exist' not in e.message:
-                raise
-        return stack
+        if stack_name not in self._stacks:
+            try:
+                self._stacks[stack_name] = \
+                    self.cloudformation.describe_stacks(stack_name)[0]
+            except boto.exception.BotoServerError as e:
+                if 'does not exist' not in e.message:
+                    raise
+                raise exceptions.StackDoesNotExist(stack_name)
+        return self._stacks[stack_name]
 
     def get_stack_status(self, stack, **kwargs):
         return stack.stack_status
@@ -100,3 +123,9 @@ class Provider(BaseProvider):
 
     def get_stack_name(self, stack, **kwargs):
         return stack.stack_name
+
+    def get_outputs(self, stack_name, *args, **kwargs):
+        if stack_name not in self._outputs:
+            stack = self.get_stack(stack_name)
+            self._outputs[stack_name] = get_output_dict(stack)
+        return self._outputs[stack_name]

--- a/stacker/providers/base.py
+++ b/stacker/providers/base.py
@@ -1,30 +1,26 @@
-from .. import exceptions
+def not_implemented(method):
+    raise NotImplementedError("Provider does not support '%s' "
+                              "method." % method)
 
 
 class BaseProvider(object):
-
-    name = None
-
-    def __init__(self, *args, **kwargs):
-        if not self.name:
-            raise exceptions.ImproperlyConfigured('Provider must have a '
-                                                  '"name"')
-
-    def _not_implemented_erorr(self, method):
-        raise NotImplementedError('Provider "%s" does not support "%s"' % (
-                                  self.name, method))
-
     def get_stack(self, stack_name, *args, **kwargs):
-        self._not_implemented_erorr('get_stack')
+        not_implemented("get_stack")
 
     def create_stack(self, *args, **kwargs):
-        self._not_implemented_erorr('create_stack')
+        not_implemented("create_stack")
 
     def update_stack(self, *args, **kwargs):
-        self._not_implemented_erorr('update_stack')
+        not_implemented("update_stack")
 
     def destroy_stack(self, *args, **kwargs):
-        self._not_implemented_erorr('destroy_stack')
+        not_implemented("destroy_stack")
 
     def get_stack_status(self, stack_name, *args, **kwargs):
-        self._not_implemented_erorr('get_stack_status')
+        not_implemented("get_stack_status")
+
+    def get_outputs(self, stack_name, *args, **kwargs):
+        not_implemented("get_outputs")
+
+    def get_output(self, stack_name, output):
+        return self.get_outputs(stack_name)[output]

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -8,6 +8,7 @@ from stacker.context import Context
 from stacker import exceptions
 from stacker.plan import COMPLETE, PENDING, SKIPPED, SUBMITTED
 from stacker.providers.exceptions import StackDidNotChange
+from stacker.providers.base import BaseProvider
 
 
 Parameter = namedtuple('Parameter', ['key', 'value'])
@@ -20,11 +21,28 @@ class MockStack(object):
             self.parameters.append(Parameter(key=k, value=v))
 
 
+class TestProvider(BaseProvider):
+    def __init__(self, outputs=None, *args, **kwargs):
+        self._outputs = outputs or {}
+
+    def set_outputs(self, outputs):
+        self._outputs = outputs
+
+    def get_stack(self, stack_name, **kwargs):
+        if stack_name not in self._outputs:
+            raise exceptions.StackDoesNotExist(stack_name)
+        return {'name': stack_name, 'outputs': self._outputs[stack_name]}
+
+    def get_outputs(self, stack_name, *args, **kwargs):
+        stack = self.get_stack(stack_name)
+        return stack['outputs']
+
+
 class TestBuildAction(unittest.TestCase):
 
     def setUp(self):
         self.context = Context('namespace')
-        self.build_action = build.Action(self.context)
+        self.build_action = build.Action(self.context, provider=TestProvider())
 
     def _get_context(self, **kwargs):
         config = {'stacks': [
@@ -41,14 +59,14 @@ class TestBuildAction(unittest.TestCase):
             'param_1': 'mock::output_1',
             'param_2': 'other::does_not_exist',
         }
-        outputs = {
+        self.build_action.provider.set_outputs({
             self.context.get_fqn('mock'): {'output_1': 'output'},
             self.context.get_fqn('other'): {},
-        }
+        })
         mock_blueprint = mock.MagicMock()
         type(mock_blueprint).parameters = parameters
-        with self.assertRaises(exceptions.ParameterDoesNotExist):
-            self.build_action._resolve_parameters(outputs, parameters,
+        with self.assertRaises(exceptions.OutputDoesNotExist):
+            self.build_action._resolve_parameters(parameters,
                                                   mock_blueprint)
 
     def test_resolve_parameters(self):
@@ -56,29 +74,29 @@ class TestBuildAction(unittest.TestCase):
             'param_1': 'mock::output_1',
             'param_2': 'other::output_2',
         }
-        outputs = {
-            self.context.get_fqn('mock'): {'output_1': 'output_1'},
-            self.context.get_fqn('other'): {'output_2': 'output_2'},
-        }
+        self.build_action.provider.set_outputs({
+            self.context.get_fqn('mock'): {'output_1': 'output1'},
+            self.context.get_fqn('other'): {'output_2': 'output2'},
+        })
+
         mock_blueprint = mock.MagicMock()
         type(mock_blueprint).parameters = parameters
         resolved_parameters = self.build_action._resolve_parameters(
-            outputs,
             parameters,
             mock_blueprint,
         )
-        self.assertEqual(resolved_parameters['param_1'], 'output_1')
-        self.assertEqual(resolved_parameters['param_2'], 'output_2')
+        self.assertEqual(resolved_parameters['param_1'], 'output1')
+        self.assertEqual(resolved_parameters['param_2'], 'output2')
 
     def test_resolve_parameters_referencing_non_existant_stack(self):
         parameters = {
             'param_1': 'mock::output_1',
         }
-        outputs = {}
+        self.build_action.provider.set_outputs({})
         mock_blueprint = mock.MagicMock()
         type(mock_blueprint).parameters = parameters
         with self.assertRaises(exceptions.StackDoesNotExist):
-            self.build_action._resolve_parameters(outputs, parameters,
+            self.build_action._resolve_parameters(parameters,
                                                   mock_blueprint)
 
     def test_gather_missing_from_stack(self):
@@ -170,7 +188,7 @@ class TestBuildAction(unittest.TestCase):
         mock_provider.get_stack.return_value = None
         with mock.patch.object(build_action, 's3_stack_push'):
             # initial run should return SUBMITTED since we've passed off to CF
-            status = step.run({})
+            status = step.run()
             self.assertEqual(status, SUBMITTED)
 
             # provider should now return the CF stack since it exists
@@ -178,7 +196,7 @@ class TestBuildAction(unittest.TestCase):
             # simulate that we're still in progress
             mock_provider.is_stack_in_progress.return_value = True
             mock_provider.is_stack_completed.return_value = False
-            status = step.run({})
+            status = step.run()
             step.set_status(status)
             # status should still be SUBMITTED since we're waiting for it to
             # complete
@@ -186,19 +204,19 @@ class TestBuildAction(unittest.TestCase):
             # simulate completed stack
             mock_provider.is_stack_completed.return_value = True
             mock_provider.is_stack_in_progress.return_value = False
-            status = step.run({})
+            status = step.run()
             self.assertEqual(status, COMPLETE)
             # simulate stack should be skipped
             mock_provider.is_stack_completed.return_value = False
             mock_provider.is_stack_in_progress.return_value = False
             mock_provider.update_stack.side_effect = StackDidNotChange
-            status = step.run({})
+            status = step.run()
             self.assertEqual(status, SKIPPED)
 
             # simulate an update is required
             mock_provider.reset_mock()
             mock_provider.update_stack.side_effect = None
             step.set_status(PENDING)
-            status = step.run({})
+            status = step.run()
             self.assertEqual(status, SUBMITTED)
             self.assertEqual(mock_provider.update_stack.call_count, 1)

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -22,7 +22,6 @@ class TestStep(unittest.TestCase):
         self.step = Step(
             stack=stack,
             run_func=lambda x, y: (x, y),
-            completion_func=lambda y: True,
         )
 
     def test_status(self):
@@ -42,9 +41,7 @@ class TestPlan(unittest.TestCase):
         self.count = 0
         self.context = Context('namespace')
 
-    def _run_func(self, results, stack, **kwargs):
-        self.assertIn('status', kwargs, 'Step "status" should be passed to '
-                                        'all run_funcs')
+    def _run_func(self, stack, **kwargs):
         self.count += 1
         if not self.count % 2:
             return COMPLETE
@@ -52,12 +49,8 @@ class TestPlan(unittest.TestCase):
             return SKIPPED
         return SUBMITTED
 
-    def _completion_func(self, stack):
-        return self.count
-
     def test_execute_plan(self):
         plan = Plan(description='Test', sleep_time=0)
-        _skip_func = mock.MagicMock()
         previous_stack = None
         for i in range(5):
             overrides = {}
@@ -71,17 +64,12 @@ class TestPlan(unittest.TestCase):
             plan.add(
                 stack=stack,
                 run_func=self._run_func,
-                completion_func=self._completion_func,
-                skip_func=_skip_func,
                 requires=stack.requires,
             )
 
-        results = plan.execute()
+        plan.execute()
         self.assertEqual(self.count, 9)
-        self.assertEqual(results[plan.keys()[0]], 2)
-        self.assertEqual(results[plan.keys()[-2]], 8)
         self.assertEqual(len(plan.list_skipped()), 1)
-        self.assertEqual(len(plan.list_skipped()), _skip_func.call_count)
 
     def test_step_must_return_status(self):
         plan = Plan(description='Test', sleep_time=0)
@@ -89,33 +77,28 @@ class TestPlan(unittest.TestCase):
                       context=mock.MagicMock())
         plan.add(
             stack=stack,
-            run_func=lambda x, y,
-            **kwargs: (x, y),
-            completion_func=lambda x: True,
+            run_func=lambda x, **kwargs: (x),
         )
         with self.assertRaises(ValueError):
             plan.execute()
 
     def test_execute_plan_ensure_parallel_builds(self):
+        # key: stack_name, value: current iteration
+        work_states = {}
+        submitted_state = 0
+        # It takes 4 iterations for each task to finish
+        finished_state = 3
 
-        results = {}
-
-        def _test_stack_name(stack):
-            # use a test_stack_name since the plan execution treats the stack
-            # name in the results as a completed stack (either skipped or
-            # complete)
-            return '_test_%s' % (stack.fqn,)
-
-        def _run_func(results, stack, *args, **kwargs):
-            test_stack_name = _test_stack_name(stack)
-            if test_stack_name not in results:
-                results[test_stack_name] = 0
-
-            if results[test_stack_name] and not results[test_stack_name] % 2:
-                return COMPLETE
-            else:
-                results[test_stack_name] += 1
+        def _run_func(stack, *args, **kwargs):
+            if stack.name not in work_states:
+                work_states[stack.name] = submitted_state
                 return SUBMITTED
+
+            if work_states[stack.name] == finished_state:
+                return COMPLETE
+
+            work_states[stack.name] += 1
+            return SUBMITTED
 
         vpc_stack = Stack(definition=generate_definition('vpc', 1),
                           context=self.context)
@@ -128,26 +111,7 @@ class TestPlan(unittest.TestCase):
             context=self.context,
         )
 
-        def _wait_func(sleep_time):
-            vpc_stack_test_name = _test_stack_name(vpc_stack)
-            web_stack_test_name = _test_stack_name(web_stack)
-            db_stack_test_name = _test_stack_name(db_stack)
-            if web_stack_test_name in results:
-                # verify the vpc stack has completed
-                self.assertEqual(results[vpc_stack_test_name], 2)
-                self.assertIn(vpc_stack.fqn, results)
-                if db_stack_test_name not in results:
-                    # verify that this is the first pass at building the
-                    # web_stack, the next loop should trigger running the
-                    # db_stack.
-                    self.assertEqual(results[web_stack_test_name], 1)
-                elif results[db_stack_test_name] == 1:
-                    # verify that both the web_stack and db_stack are in
-                    # progress at the same time
-                    self.assertEqual(results[web_stack_test_name], 1)
-                    self.assertEqual(results[db_stack_test_name], 1)
-
-        plan = Plan(description='Test', sleep_time=0, wait_func=_wait_func)
+        plan = Plan(description='Test', sleep_time=0)
         for stack in [vpc_stack, web_stack, db_stack]:
             plan.add(
                 stack=stack,
@@ -155,7 +119,22 @@ class TestPlan(unittest.TestCase):
                 requires=stack.requires,
             )
 
-        plan.execute(results)
+        parallel_success = False
+        while not plan._single_run():
+            vpc_step = plan[vpc_stack.fqn]
+            web_step = plan[web_stack.fqn]
+            db_step = plan[db_stack.fqn]
+            if not vpc_step.completed:
+                self.assertFalse(web_step.submitted)
+                self.assertFalse(db_step.submitted)
+            else:
+                # If the vpc step is complete, and we see both the web & db
+                # steps submitted during the same run, then parallel running
+                # works
+                if web_step.status == SUBMITTED and \
+                        db_step.status == SUBMITTED:
+                    parallel_success = True
+        self.assertTrue(parallel_success)
 
     def test_plan_wait_func_must_be_function(self):
         with self.assertRaises(ImproperlyConfigured):
@@ -182,7 +161,6 @@ class TestPlan(unittest.TestCase):
             plan.add(
                 stack=stack,
                 run_func=run_func,
-                completion_func=self._completion_func,
                 requires=stack.requires,
             )
 


### PR DESCRIPTION
- Move output gathering to the provider
- add 'caching' of outputs & stacks on provider (hope this will help w/
  #54)
- got rid of _completion_func & _skip_func on steps
- removed passing of 'results' dictionary on Plan.execute
- broke out _single_run from _execute on Plan for testability