### PR TITLE
Deal w/ CF throttling errors

### DIFF
--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -5,8 +5,21 @@ from boto import cloudformation
 
 from . import exceptions
 from .base import BaseProvider
+from ..util import retry_with_backoff
 
 logger = logging.getLogger(__name__)
+
+
+def retry_cf_throttling(fn, attempts=3, args=None, kwargs=None):
+    def _throttling_checker(exc):
+        if exc.status == 400 and "Throttling" in exc.message:
+            logger.debug("AWS throttling calls.")
+            return True
+        return False
+
+    return retry_with_backoff(fn, args=args, kwargs=kwargs, attempts=attempts,
+                              exc_list=[boto.exception.BotoServerError],
+                              retry_checker=_throttling_checker)
 
 
 class Provider(BaseProvider):
@@ -37,7 +50,8 @@ class Provider(BaseProvider):
     def get_stack(self, stack_name, **kwargs):
         stack = None
         try:
-            stack = self.cloudformation.describe_stacks(stack_name)[0]
+            stack = retry_cf_throttling(self.cloudformation.describe_stacks,
+                                        args=[stack_name])[0]
         except boto.exception.BotoServerError as e:
             if 'does not exist' not in e.message:
                 raise
@@ -57,30 +71,33 @@ class Provider(BaseProvider):
 
     def destroy_stack(self, stack, **kwargs):
         logger.info("Destroying stack: %s" % (stack.stack_name,))
-        self.cloudformation.delete_stack(stack.stack_id)
+        retry_cf_throttling(self.cloudformation.delete_stack,
+                            args=[stack.stack_id])
         return True
 
     def create_stack(self, fqn, template_url, parameters, tags, **kwargs):
         logger.info("Stack %s not found, creating.", fqn)
         logger.debug("Using parameters: %s", parameters)
         logger.debug("Using tags: %s", tags)
-        self.cloudformation.create_stack(
-            fqn,
-            template_url=template_url,
-            parameters=parameters, tags=tags,
-            capabilities=['CAPABILITY_IAM'],
+        retry_cf_throttling(
+            self.cloudformation.create_stack,
+            args=[fqn],
+            kwargs=dict(template_url=template_url,
+                        parameters=parameters, tags=tags,
+                        capabilities=['CAPABILITY_IAM']),
         )
         return True
 
     def update_stack(self, fqn, template_url, parameters, tags, **kwargs):
         try:
             logger.info("Attempting to update stack %s.", fqn)
-            self.cloudformation.update_stack(
-                fqn,
-                template_url=template_url,
-                parameters=parameters,
-                tags=tags,
-                capabilities=['CAPABILITY_IAM'],
+            retry_cf_throttling(
+                self.cloudformation.update_stack,
+                args=[fqn],
+                kwargs=dict(template_url=template_url,
+                            parameters=parameters,
+                            tags=tags,
+                            capabilities=['CAPABILITY_IAM']),
             )
         except boto.exception.BotoServerError as e:
             if 'No updates are to be performed.' in e.message:

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -10,7 +10,23 @@ from ..util import retry_with_backoff
 logger = logging.getLogger(__name__)
 
 
-def retry_cf_throttling(fn, attempts=3, args=None, kwargs=None):
+def retry_on_throttling(fn, attempts=3, args=None, kwargs=None):
+    """Wrap retry_with_backoff to handle AWS Cloudformation Throttling.
+
+    Args:
+        fn (function): The function to call.
+        attempts (int): Maximum # of attempts to retry the function.
+        args (list): List of positional arguments to pass to the function.
+        kwargs (dict): Dict of keyword arguments to pass to the function.
+
+    Returns:
+        passthrough: This returns the result of the function call itself.
+
+    Raises:
+        passthrough: This raises any exceptions the function call raises,
+            except for boto.exception.BotoServerError, provided it doesn't
+            retry more than attempts.
+    """
     def _throttling_checker(exc):
         if exc.status == 400 and "Throttling" in exc.message:
             logger.debug("AWS throttling calls.")
@@ -50,7 +66,7 @@ class Provider(BaseProvider):
     def get_stack(self, stack_name, **kwargs):
         stack = None
         try:
-            stack = retry_cf_throttling(self.cloudformation.describe_stacks,
+            stack = retry_on_throttling(self.cloudformation.describe_stacks,
                                         args=[stack_name])[0]
         except boto.exception.BotoServerError as e:
             if 'does not exist' not in e.message:
@@ -71,7 +87,7 @@ class Provider(BaseProvider):
 
     def destroy_stack(self, stack, **kwargs):
         logger.info("Destroying stack: %s" % (stack.stack_name,))
-        retry_cf_throttling(self.cloudformation.delete_stack,
+        retry_on_throttling(self.cloudformation.delete_stack,
                             args=[stack.stack_id])
         return True
 
@@ -79,7 +95,7 @@ class Provider(BaseProvider):
         logger.info("Stack %s not found, creating.", fqn)
         logger.debug("Using parameters: %s", parameters)
         logger.debug("Using tags: %s", tags)
-        retry_cf_throttling(
+        retry_on_throttling(
             self.cloudformation.create_stack,
             args=[fqn],
             kwargs=dict(template_url=template_url,
@@ -91,7 +107,7 @@ class Provider(BaseProvider):
     def update_stack(self, fqn, template_url, parameters, tags, **kwargs):
         try:
             logger.info("Attempting to update stack %s.", fqn)
-            retry_cf_throttling(
+            retry_on_throttling(
                 self.cloudformation.update_stack,
                 args=[fqn],
                 kwargs=dict(template_url=template_url,

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -10,7 +10,8 @@ logger = logging.getLogger(__name__)
 
 
 def retry_with_backoff(function, args=None, kwargs=None, attempts=5,
-                       min_delay=1, max_delay=3, exc_list=None):
+                       min_delay=1, max_delay=3, exc_list=None,
+                       retry_checker=None):
     """ Retries function, catching expected Exceptions. """
     args = args or []
     kwargs = kwargs or {}
@@ -23,11 +24,18 @@ def retry_with_backoff(function, args=None, kwargs=None, attempts=5,
         try:
             return function(*args, **kwargs)
         except exc_list as e:
-            if attempt == attempts:
-                logger.error("Function %s failed after %s retries. Giving up.",
-                             function.func_name, attempts)
+            # If there is no retry checker function, or if there is and it
+            # returns True, then go ahead and retry
+            if not retry_checker or retry_checker(e):
+                if attempt == attempts:
+                    logger.error("Function %s failed after %s retries. Giving "
+                                 "up.", function.func_name, attempts)
+                    raise
+                logger.debug("Caught expected exception: %r", e)
+            # If there is a retry checker function, and it returned False,
+            # do not retry
+            else:
                 raise
-            logger.debug("Caught expected exception: %r", e)
         time.sleep(sleep_time)
 
 


### PR DESCRIPTION
We now retry with a backoff if we get throttling errors from
cloudformation's API.

Fixes #54