### PR TITLE
Use local parameter for AZCount

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -41,6 +41,14 @@ def get_local_parameters(parameter_def, parameters):
                 value = attrs['default']
             except KeyError:
                 raise MissingLocalParameterException(param)
+
+        _type = attrs['type']
+        if _type:
+            try:
+                value = _type(value)
+            except ValueError:
+                raise ValueError("Local parameter %s must be %s.", param,
+                                 _type)
         local[param] = value
 
     return local

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -42,7 +42,7 @@ def get_local_parameters(parameter_def, parameters):
             except KeyError:
                 raise MissingLocalParameterException(param)
 
-        _type = attrs['type']
+        _type = attrs.get('type')
         if _type:
             try:
                 value = _type(value)

--- a/stacker/blueprints/vpc.py
+++ b/stacker/blueprints/vpc.py
@@ -22,13 +22,14 @@ NAT_SG = "NATSG"
 
 
 class VPC(Blueprint):
+    LOCAL_PARAMETERS = {
+        "AZCount":  {
+            "type": int,
+            "default": 2,
+        }
+    }
+
     PARAMETERS = {
-        "AZCount": {
-            "type": "Number",
-            "default": "2",
-            "description": "The number of AZs to build the VPC in. NOTE: "
-                           "this is used by stacker, not by cloudformation "
-                           "directly."},
         "PrivateSubnets": {
             "type": "CommaDelimitedList",
             "description": "Comma separated list of subnets to use for "
@@ -171,7 +172,7 @@ class VPC(Blueprint):
         subnets = {'public': [], 'private': []}
         net_types = subnets.keys()
         zones = []
-        for i in range(int(self.context.parameters["AZCount"])):
+        for i in range(self.local_parameters["AZCount"]):
             az = Select(i, GetAZs(""))
             zones.append(az)
             name_suffix = i


### PR DESCRIPTION
Tested to see if running this against an existing VPC would cause it to rebuild
in a destructive way. Turns out it does not - it actually doesn't even
recognize the stack as needing an update, despite producing an entirely new
template. See #53 for more discussion.