### PR TITLE
Prepare for #80

### DIFF
--- a/conf/empire/empire.yaml
+++ b/conf/empire/empire.yaml
@@ -71,12 +71,15 @@ stacks:
   - name: vpc
     class_path: stacker.blueprints.vpc.VPC
     parameters:
-      # Only build in 4 AZs, can be overridden with -p on the command line
-      # Note: If you want more than 4 AZs you should add more subnets below
-      #       Also you need at least 2 AZs in order to use the DB because
-      #       of the fact that the DB blueprint uses MultiAZ
-      # Note: You will create a NAT instance PER Availability zone.
-      AZCount: 4
+      # AZCount is the # of AvailabilityZones to attempt to build in. You
+      # should build in as many as you can afford in order to provide for
+      # better fault tolerance. Note: Since this is all done in a VPC, you
+      # need to find out how many AZs can handle VPC subnets for the
+      # region you are building in. As of this writing, here are the max
+      # allowed AZCount's for each zone:
+      #     us-east-1: 4, us-west-1: 2, us-west-2: 3, eu-west-1: 3
+      # Note: The minimum allowed AZCount is 2.
+      AZCount: ${azcount}
       # Enough subnets for 4 AZs
       PublicSubnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
       PrivateSubnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22

--- a/conf/empire/example.env
+++ b/conf/empire/example.env
@@ -1,3 +1,13 @@
+# azcount is the # of AvailabilityZones to attempt to build in. You
+# should build in as many as you can afford in order to provide for
+# better fault tolerance. Note: Since this is all done in a VPC, you
+# need to find out how many AZs can handle VPC subnets for the
+# region you are building in. As of this writing, here are the max
+# allowed azcount's for each zone:
+#     us-east-1: 4, us-west-1: 2, us-west-2: 3, eu-west-1: 3
+# Note: The minimum allowed azcount is 2.
+azcount: 2
+
 # An external domain where empire.<domain> CNAME will be created
 external_domain:
 ssh_key_name:


### PR DESCRIPTION
This lowers the default azcount to 2, which is the minimum allowed and
also the max allowed in us-west-1.  It also documents why the # is low,
and that it should be increased in most production cases (if it can).