### PR TITLE
Add Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER Mike Barrett
 
 COPY scripts/docker-stacker /bin/docker-stacker
 RUN mkdir -p /stacks
+WORKDIR /stacks
 COPY . /tmp/stacker
 RUN cd /tmp/stacker && python setup.py install && rm -rf /tmp/stacker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7.10
+MAINTAINER Mike Barrett
+
+COPY scripts/docker-stacker /bin/docker-stacker
+RUN mkdir -p /stacks
+COPY . /tmp/stacker
+RUN cd /tmp/stacker && python setup.py install && rm -rf /tmp/stacker
+
+ENTRYPOINT ["docker-stacker"]
+CMD ["-h"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: build
+
+build:
+	docker build -t remind101/stacker .

--- a/README.rst
+++ b/README.rst
@@ -105,3 +105,11 @@ Stacker would then name the VPC stack ``stageVPC``.
 .. _Remind: http://www.remind.com/
 .. _troposphere: https://github.com/cloudtools/troposphere
 .. _string.Template: https://docs.python.org/2/library/string.html#template-strings
+
+Docker
+======
+
+Stack can also be executed from Docker. Use this method to run stacker if you
+want to avoid setting up a python environment::
+
+  docker run -v `pwd`:/stacks remind101/stacker build ...

--- a/scripts/docker-stacker
+++ b/scripts/docker-stacker
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is meant to be used from within the Docker image for stacker. It
+# simply installs the stacks at /stacks and then runs stacker.
+
+set -e
+
+cd /stacks
+python setup.py install
+
+exec stacker $@


### PR DESCRIPTION
This adds a method for running stacker to provision stacks using Docker, which can be an easier alternative for the pythonically challenged, and produces a more common environment between developers.

See https://github.com/remind101/private_stacks/pull/42 for an example on how this might be used.