### PR TITLE
Environment file should be a simple key: value pair file.

### DIFF
--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -151,7 +151,7 @@ class BaseCommand(object):
                                  "up to twice.")
         parser.add_argument('environment', type=environment_file,
                             default={},
-                            help="Path to a simple key/value pair environment "
+                            help="Path to a simple `key: value` pair environment "
                                  "file. The values in the environment file can "
                                  "be used in the stack config as if it were a "
                                  "string.Template type: "

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -2,7 +2,7 @@ import argparse
 from collections import Mapping
 import logging
 
-import yaml
+from ...environment import parse_environment
 
 DEBUG_FORMAT = ('[%(asctime)s] %(levelname)s %(name)s:%(lineno)d'
                 '(%(funcName)s): %(message)s')
@@ -37,10 +37,10 @@ def key_value_arg(string):
     return {k: v}
 
 
-def yaml_file_type(yaml_file):
-    """ Reads a yaml file and returns the resulting data. """
-    with open(yaml_file) as fd:
-        return yaml.load(fd)
+def environment_file(input_file):
+    """Reads a stacker environment file and returns the resulting data."""
+    with open(input_file) as fd:
+        return parse_environment(fd.read())
 
 
 class BaseCommand(object):
@@ -149,11 +149,12 @@ class BaseCommand(object):
         parser.add_argument("-v", "--verbose", action="count", default=0,
                             help="Increase output verbosity. May be specified "
                                  "up to twice.")
-        parser.add_argument('environment', type=yaml_file_type,
+        parser.add_argument('environment', type=environment_file,
                             default={},
-                            help="Path to a yaml environment file. The values in "
-                                 "the environment file can be used in the stack "
-                                 "config as if it were a string.Template type: "
+                            help="Path to a simple key/value pair environment "
+                                 "file. The values in the environment file can "
+                                 "be used in the stack config as if it were a "
+                                 "string.Template type: "
                                  "https://docs.python.org/2/library/string.html"
                                  "#template-strings. Must define at least a "
                                  "'namespace'.")

--- a/stacker/environment.py
+++ b/stacker/environment.py
@@ -1,0 +1,11 @@
+
+
+def parse_environment(raw_environment):
+    environment = {}
+    for line in raw_environment.split('\n'):
+        if ':' not in line:
+            continue
+
+        key, value = line.split(':', 1)
+        environment[key] = value.strip()
+    return environment

--- a/stacker/environment.py
+++ b/stacker/environment.py
@@ -4,13 +4,16 @@ def parse_environment(raw_environment):
     environment = {}
     for line in raw_environment.split('\n'):
         line = line.strip()
-
-        if ':' not in line:
+        if not line:
             continue
 
         if line.startswith('#'):
             continue
 
-        key, value = line.split(':', 1)
+        try:
+            key, value = line.split(':', 1)
+        except ValueError:
+            raise ValueError('Environment must be in key: value format')
+
         environment[key] = value.strip()
     return environment

--- a/stacker/environment.py
+++ b/stacker/environment.py
@@ -3,7 +3,12 @@
 def parse_environment(raw_environment):
     environment = {}
     for line in raw_environment.split('\n'):
+        line = line.strip()
+
         if ':' not in line:
+            continue
+
+        if line.startswith('#'):
             continue
 
         key, value = line.split(':', 1)

--- a/stacker/tests/test_environment.py
+++ b/stacker/tests/test_environment.py
@@ -1,0 +1,22 @@
+import unittest
+
+from stacker.environment import parse_environment
+
+test_env = """key1: value1
+key2: value2
+key3: some:complex::value
+key4: :otherValue:
+key5: <another>@value
+"""
+
+
+class TestEnvironment(unittest.TestCase):
+
+    def test_simple_key_value_parsing(self):
+        parsed_env = parse_environment(test_env)
+        self.assertTrue(isinstance(parsed_env, dict))
+        self.assertEqual(parsed_env['key1'], 'value1')
+        self.assertEqual(parsed_env['key2'], 'value2')
+        self.assertEqual(parsed_env['key3'], 'some:complex::value')
+        self.assertEqual(parsed_env['key4'], ':otherValue:')
+        self.assertEqual(parsed_env['key5'], '<another>@value')

--- a/stacker/tests/test_environment.py
+++ b/stacker/tests/test_environment.py
@@ -3,8 +3,13 @@ import unittest
 from stacker.environment import parse_environment
 
 test_env = """key1: value1
+# some: comment
+ # here: about
+# key2
 key2: value2
+# another comment here
 key3: some:complex::value
+# one more here as well
 key4: :otherValue:
 key5: <another>@value
 """
@@ -20,3 +25,4 @@ class TestEnvironment(unittest.TestCase):
         self.assertEqual(parsed_env['key3'], 'some:complex::value')
         self.assertEqual(parsed_env['key4'], ':otherValue:')
         self.assertEqual(parsed_env['key5'], '<another>@value')
+        self.assertEqual(len(parsed_env.keys()), 5)

--- a/stacker/tests/test_environment.py
+++ b/stacker/tests/test_environment.py
@@ -4,14 +4,23 @@ from stacker.environment import parse_environment
 
 test_env = """key1: value1
 # some: comment
+
  # here: about
+
 # key2
 key2: value2
+
 # another comment here
 key3: some:complex::value
+
+
 # one more here as well
 key4: :otherValue:
 key5: <another>@value
+"""
+
+test_error_env = """key1: valu1
+error
 """
 
 
@@ -26,3 +35,7 @@ class TestEnvironment(unittest.TestCase):
         self.assertEqual(parsed_env['key4'], ':otherValue:')
         self.assertEqual(parsed_env['key5'], '<another>@value')
         self.assertEqual(len(parsed_env.keys()), 5)
+
+    def test_simple_key_value_parsing_exception(self):
+        with self.assertRaises(ValueError):
+            parse_environment(test_error_env)


### PR DESCRIPTION
We no longer want to double yaml parse the environment file. This treats
the environment as a group of dumb key: value pairs, where the raw
string value will be passed to the yaml config.