### PR TITLE
Ensure cert exists

### DIFF
--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -78,7 +78,7 @@ def ensure_server_cert_exists(region, namespace, mappings, parameters, **kwargs)
                 continue
 
             path = raw_input('Path to %s (skip): ' % (key,))
-            if path == 'skip':
+            if path == 'skip' or not path.strip():
                 continue
 
             full_path = utils.full_path(path)

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -68,12 +68,15 @@ def ensure_server_cert_exists(region, namespace, mappings, parameters, **kwargs)
             return False
 
         paths = {
-            'certificate': None,
-            'private_key': None,
-            'chain': None,
+            'certificate': kwargs.get('path_to_certificate'),
+            'private_key': kwargs.get('path_to_private_key'),
+            'chain': kwargs.get('path_to_chain'),
         }
 
-        for key in paths.keys():
+        for key, value in paths.iteritems():
+            if value is not None:
+                continue
+
             path = raw_input('Path to %s (skip): ' % (key,))
             if path == 'skip':
                 continue

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -1,11 +1,15 @@
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 
+from boto.exception import BotoServerError
 from boto.iam import connect_to_region
 
 from awacs.aws import Statement, Allow, Policy
 from awacs import ecs
+
+from . import utils
 
 
 def create_ecs_service_role(region, namespace, mappings, parameters,
@@ -29,4 +33,68 @@ def create_ecs_service_role(region, namespace, mappings, parameters,
         ])
     conn.put_role_policy("ecsServiceRole", "AmazonEC2ContainerServiceRole",
                          policy.to_json())
+    return True
+
+
+def _get_cert_arn_from_response(response):
+    return response['upload_server_certificate_response'][
+        'upload_server_certificate_result'
+    ]['server_certificate_metadata']['arn']
+
+
+def ensure_server_cert_exists(region, namespace, mappings, parameters, **kwargs):
+    conn = connect_to_region(region)
+    cert_name = kwargs['cert_name']
+    try:
+        conn.get_server_certificate(cert_name)
+    except BotoServerError:
+        upload = raw_input(
+            'Certificate "%s" wasn\'t found. Upload it now? (yes/no) ' % (
+                cert_name,
+            )
+        )
+        if upload != 'yes':
+            return False
+
+        paths = {
+            'certificate': None,
+            'private_key': None,
+            'chain': None,
+        }
+
+        for key in paths.keys():
+            path = raw_input('Path to %s (skip): ' % (key,))
+            if path == 'skip':
+                continue
+
+            full_path = utils.full_path(path)
+            if not os.path.exists(full_path):
+                logger.error('%s path "%s" does not exist', key, full_path)
+                return False
+            paths[key] = full_path
+
+        parameters = {
+            'cert_name': cert_name,
+        }
+        for key, path in paths.iteritems():
+            if not path:
+                continue
+
+            with open(path) as read_file:
+                contents = read_file.read()
+
+            if key == 'certificate':
+                parameters['cert_body'] = contents
+            elif key == 'private_key':
+                parameters['private_key'] = contents
+            elif key == 'chain':
+                parameters['cert_chain'] = contents
+
+        response = conn.upload_server_cert(**parameters)
+        logger.info(
+            'uploaded certificate: %s (%s)',
+            cert_name,
+            _get_cert_arn_from_response(response),
+        )
+
     return True

--- a/stacker/hooks/utils.py
+++ b/stacker/hooks/utils.py
@@ -1,0 +1,5 @@
+import os
+
+
+def full_path(path):
+    return os.path.abspath(os.path.expanduser(path))


### PR DESCRIPTION
example:

```
pre_build:
  - path: stacker.hooks.iam.ensure_server_cert_exists
    required: true
    args:
      cert_name: ${vault_elb_cert_name}
  - path: stacker.hooks.iam.ensure_server_cert_exists
    required: true
    args:
      cert_name: ${empire_controller_cert_name}
```

makes it easy to use private certs for different environments 