### PR TITLE
Ensure keypair exists

### DIFF
--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -17,12 +17,12 @@ def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
         return True
 
     logger.info('keypair: "%s" not found', keypair_name)
-    upload = raw_input(
-        'would you like to import "%s" keypair now? (yes/no) ' % (
+    create_or_upload = raw_input(
+        'import or create keypair "%s"? (import/create/cancel) ' % (
             keypair_name,
         ),
     )
-    if upload == 'yes':
+    if create_or_upload == 'import':
         path = raw_input('path to keypair file: ')
         full_path = os.path.abspath(os.path.expanduser(path))
         if not os.path.exists(full_path):
@@ -36,6 +36,16 @@ def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
                                              b64encode(contents))
         logger.info(message, keypair.name, keypair.fingerprint, 'imported')
         return True
+    elif create_or_upload == 'create':
+        path = raw_input('directory to save keyfile: ')
+        full_path - os.path.abspath(os.path.expanduser(path))
+        if not os.path.exists(full_path) and not os.path.isdir(full_path):
+            logger.error('"%s" is not a valid directory', full_path)
+            return False
+
+        keypair = connection.create_key_pair(keypair_name)
+        logger.info(message, keypair.name, keypair.fingerprint, 'created')
+        return keypair.save(full_path)
     else:
-        logger.warning('keypair must manually be imported')
+        logger.warning('no action to find keypair, failing')
         return False

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -1,4 +1,3 @@
-from base64 import b64encode
 import logging
 import os
 
@@ -32,8 +31,7 @@ def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
         with open(full_path) as read_file:
             contents = read_file.read()
 
-        keypair = connection.import_key_pair(keypair_name,
-                                             b64encode(contents))
+        keypair = connection.import_key_pair(keypair_name, contents)
         logger.info(message, keypair.name, keypair.fingerprint, 'imported')
         return True
     elif create_or_upload == 'create':

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -38,7 +38,7 @@ def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
         return True
     elif create_or_upload == 'create':
         path = raw_input('directory to save keyfile: ')
-        full_path - os.path.abspath(os.path.expanduser(path))
+        full_path = os.path.abspath(os.path.expanduser(path))
         if not os.path.exists(full_path) and not os.path.isdir(full_path):
             logger.error('"%s" is not a valid directory', full_path)
             return False

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -3,6 +3,8 @@ import os
 
 from boto.ec2 import connect_to_region
 
+from . import utils
+
 logger = logging.getLogger(__name__)
 
 
@@ -36,7 +38,7 @@ def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
         return True
     elif create_or_upload == 'create':
         path = raw_input('directory to save keyfile: ')
-        full_path = os.path.abspath(os.path.expanduser(path))
+        full_path = utils.full_path(path)
         if not os.path.exists(full_path) and not os.path.isdir(full_path):
             logger.error('"%s" is not a valid directory', full_path)
             return False

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -1,0 +1,41 @@
+from base64 import b64encode
+import logging
+import os
+
+from boto.ec2 import connect_to_region
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
+    connection = connect_to_region(region)
+    keypair_name = kwargs.get('keypair', parameters.get('SshKeyName'))
+    keypair = connection.get_key_pair(keypair_name)
+    message = 'keypair: %s (%s) %s'
+    if keypair:
+        logger.info(message, keypair.name, keypair.fingerprint, 'exists')
+        return True
+
+    logger.info('keypair: "%s" not found', keypair_name)
+    upload = raw_input(
+        'would you like to import "%s" keypair now? (yes/no) ' % (
+            keypair_name,
+        ),
+    )
+    if upload == 'yes':
+        path = raw_input('path to keypair file: ')
+        full_path = os.path.abspath(os.path.expanduser(path))
+        if not os.path.exists(full_path):
+            logger.error('Failed to find keypair at path: %s', full_path)
+            return False
+
+        with open(full_path) as read_file:
+            contents = read_file.read()
+
+        keypair = connection.import_key_pair(keypair_name,
+                                             b64encode(contents))
+        logger.info(message, keypair.name, keypair.fingerprint, 'imported')
+        return True
+    else:
+        logger.warning('keypair must manually be imported')
+        return False

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -17,7 +17,7 @@ def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
 
     logger.info('keypair: "%s" not found', keypair_name)
     create_or_upload = raw_input(
-        'import or create keypair "%s"? (import/create/cancel) ' % (
+        'import or create keypair "%s"? (import/create/Cancel) ' % (
             keypair_name,
         ),
     )

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -25,7 +25,7 @@ def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
     )
     if create_or_upload == 'import':
         path = raw_input('path to keypair file: ')
-        full_path = os.path.abspath(os.path.expanduser(path))
+        full_path = utils.full_path(path)
         if not os.path.exists(full_path):
             logger.error('Failed to find keypair at path: %s', full_path)
             return False

--- a/stacker/hooks/utils.py
+++ b/stacker/hooks/utils.py
@@ -1,0 +1,5 @@
+import os
+
+
+def full_path(path):
+    return os.path.abspath(os.path.expanduser(path))


### PR DESCRIPTION
example:

```
pre_build:
  - path: stacker.hooks.keypair.ensure_keypair_exists
    required: true
    args:
      keypair: ${ssh_key_name}
```