### PR TITLE
Remove required_stacks tag

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -87,11 +87,8 @@ class Action(BaseAction):
         logger.debug("Stack %s required stacks: %s",
                      stack.name, requires)
         tags = {
-            'template_url': template_url,
             'stacker_namespace': self.context.namespace,
         }
-        if requires:
-            tags['required_stacks'] = ':'.join(requires)
         return tags
 
     def _launch_stack(self, stack, **kwargs):

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -144,12 +144,6 @@ class Provider(BaseProvider):
             raise
         return True
 
-    def get_required_stacks(self, stack, **kwargs):
-        required_stacks = []
-        if 'required_stacks' in stack.tags:
-            required_stacks = stack.tags['required_stacks']
-        return required_stacks
-
     def get_stack_name(self, stack, **kwargs):
         return stack.stack_name
 


### PR DESCRIPTION
The required_stacks tag could get longer than the AWS limit of 255
chars.  This would cause a stacker build to fail for a largish
deployment.  The required_stacks tag was unused, and all operations
appear to still work.

Testing Done:
- ran unittests
- deployed stack
- destroyed stack