### PR TITLE
Remove required_stacks tag

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -81,17 +81,11 @@ class Action(BaseAction):
             params[k] = value
         return params
 
-    def _build_stack_tags(self, stack, template_url):
+    def _build_stack_tags(self, stack):
         """Builds a common set of tags to attach to a stack"""
-        requires = [req for req in stack.requires]
-        logger.debug("Stack %s required stacks: %s",
-                     stack.name, requires)
         tags = {
-            'template_url': template_url,
             'stacker_namespace': self.context.namespace,
         }
-        if requires:
-            tags['required_stacks'] = ':'.join(requires)
         return tags
 
     def _launch_stack(self, stack, **kwargs):
@@ -120,7 +114,7 @@ class Action(BaseAction):
 
         logger.info("Launching stack %s now.", stack.fqn)
         template_url = self.s3_stack_push(stack.blueprint)
-        tags = self._build_stack_tags(stack, template_url)
+        tags = self._build_stack_tags(stack)
         parameters = self._resolve_parameters(stack.parameters,
                                               stack.blueprint)
         required_params = [k for k, v in stack.blueprint.required_parameters]

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -144,12 +144,6 @@ class Provider(BaseProvider):
             raise
         return True
 
-    def get_required_stacks(self, stack, **kwargs):
-        required_stacks = []
-        if 'required_stacks' in stack.tags:
-            required_stacks = stack.tags['required_stacks']
-        return required_stacks
-
     def get_stack_name(self, stack, **kwargs):
         return stack.stack_name
 


### PR DESCRIPTION
The required_stacks tag could get longer than the AWS limit of 255
chars.  This would cause a stacker build to fail for a largish
deployment.  The required_stacks tag was unused, and all operations
appear to still work.

Testing Done:
- ran unittests
- deployed stack
- destroyed stack