### PR TITLE
Remove storage of stacks on context object

### DIFF
--- a/stacker/context.py
+++ b/stacker/context.py
@@ -63,20 +63,19 @@ class Context(object):
             list: a list of :class:`stacker.stack.Stack` objects
 
         """
-        if not hasattr(self, '_stacks'):
-            definitions = self._get_stack_definitions()
-            self._stacks = []
-            for stack_def in definitions:
-                stack = Stack(
-                    definition=stack_def,
-                    context=self,
-                    parameters=self.parameters,
-                    mappings=self.mappings,
-                    force=stack_def['name'] in self.force_stacks,
-                    locked=stack_def.get('locked', False),
-                )
-                self._stacks.append(stack)
-        return self._stacks
+        stacks = []
+        definitions = self._get_stack_definitions()
+        for stack_def in definitions:
+            stack = Stack(
+                definition=stack_def,
+                context=self,
+                parameters=self.parameters,
+                mappings=self.mappings,
+                force=stack_def['name'] in self.force_stacks,
+                locked=stack_def.get('locked', False),
+            )
+            stacks.append(stack)
+        return stacks
 
     def get_stacks_dict(self):
         return dict((stack.fqn, stack) for stack in self.get_stacks())


### PR DESCRIPTION
Fixes GH-111

This will be, in theory, less efficient since every time you call
get_stacks it will have to rebuild the Stack objets, but in the end it
saves the nasty memory issue we have, and it's simple.

If it ever becomes a problem we could store the stack objects in a
STACKS global or something similar, but that seems gross, and the type
of pre-optimization that'll bite you in the ass (like this did).