### PR TITLE
Adds support to Stacker templates for AWS Cloudformation List<> types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4 (???)
+
+- Add support for List<AWS::EC2::*> parameters
+
 ## 0.5.3 (2015-11-03)
 
 - Add --version [GH-91]

--- a/docs/terminology.rst
+++ b/docs/terminology.rst
@@ -48,8 +48,9 @@ parameter
 .. _parameters:
 
 Dynamic variables that are passed into stacks when they are being built. In
-general these are `Cloudformation Parameters`_, which are passed to the
-blueprint upon creation. Can be defined on the command line, or in the config_.
+general these are one or more comma delimited `Cloudformation Parameters`_, 
+which are passed to the blueprint upon creation. Can be defined on the command 
+line, or in the config_.
 
 stack
 =====

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -87,13 +87,18 @@ class Action(BaseAction):
                 continue
             value = v
             if isinstance(value, basestring) and '::' in value:
-                # Get from the Output of another stack in the stack_map
-                stack_name, output = value.split('::')
-                stack_fqn = self.context.get_fqn(stack_name)
-                try:
-                    value = self.provider.get_output(stack_fqn, output)
-                except KeyError:
-                    raise exceptions.OutputDoesNotExist(stack_fqn, value)
+                # Get from the Output(s) of another stack(s) in the stack_map
+                v_list = []
+                values = value.split(',')
+                for v in values:
+                    stack_name, output = v.split('::')
+                    stack_fqn = self.context.get_fqn(stack_name)
+                    try:
+                        v_list.append(
+                            self.provider.get_output(stack_fqn, output))
+                    except KeyError:
+                        raise exceptions.OutputDoesNotExist(stack_fqn, v)
+                value = ','.join(v_list)
             params[k] = value
         return params
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -64,9 +64,9 @@ class Action(BaseAction):
         """Resolves parameters for a given blueprint.
 
         Given a list of parameters, first discard any parameters that the
-        blueprint does not use. Then, if a remaining parameter is in the format
-        <stack_name>::<output_name>, pull that output from the foreign
-        stack.
+        blueprint does not use. Then, if a parameter is a list of outputs
+        in the format of <stack_name>::<output_name>,... pull those output(s)
+        from the foreign stack(s).
 
         Args:
             parameters (dict): A dictionary of parameters provided by the

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -83,13 +83,19 @@ class Stack(object):
         # Auto add dependencies when parameters reference the Ouptuts of
         # another stack.
         for value in self.parameters.values():
+            stack_names = []
             if isinstance(value, basestring) and '::' in value:
-                stack_name, _ = value.split('::')
+                # support for list of Outputs
+                values = value.split(',')
+                for x in values:
+                    stack_name, _ = x.split('::')
+                    stack_names.append(stack_name)
             else:
                 continue
-            stack_fqn = self.context.get_fqn(stack_name)
-            if stack_fqn not in requires:
-                requires.add(stack_fqn)
+            for stack_name in stack_names:
+                stack_fqn = self.context.get_fqn(stack_name)
+                if stack_fqn not in requires:
+                    requires.add(stack_fqn)
         return requires
 
     @property

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -73,10 +73,13 @@ class TestBuildAction(unittest.TestCase):
         parameters = {
             'param_1': 'mock::output_1',
             'param_2': 'other::output_2',
+            'param_3': 'foo::output_3,bar::output_4',
         }
         self.build_action.provider.set_outputs({
             self.context.get_fqn('mock'): {'output_1': 'output1'},
             self.context.get_fqn('other'): {'output_2': 'output2'},
+            self.context.get_fqn('foo'): {'output_3': 'output3'},
+            self.context.get_fqn('bar'): {'output_4': 'output4'},
         })
 
         mock_blueprint = mock.MagicMock()
@@ -87,6 +90,7 @@ class TestBuildAction(unittest.TestCase):
         )
         self.assertEqual(resolved_parameters['param_1'], 'output1')
         self.assertEqual(resolved_parameters['param_2'], 'output2')
+        self.assertEqual(resolved_parameters['param_3'], 'output3,output4')
 
     def test_resolve_parameters_referencing_non_existant_stack(self):
         parameters = {


### PR DESCRIPTION
Adds support to Stacker templates for the AWS Cloudformation List<> types.  Now when you want to launch an instance with multiple SecurityGroups, instead of specifying multiple parameters you can specify a single List<AWS::EC2::SecurityGroup::Id> parameter.