### PR TITLE
Parameters, if blank, will now not be submitted - falling back to the Parameter defaults

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,14 @@ When updating an existing stack, if you don't supply a parameter in either the
 config or CLI, it will fall back on checking the existing stack for the
 parameter. If it finds it, it will use that automatically.
 
+One additional bit of functionality that should be noted is that if a Parameter
+is defined, but has no value, for example in the stack config like this::
+
+    MyParameter:
+
+That parameter will not be submitted to the stack. This allows you to control
+whether a parameter is submitted to a stack by using environments.
+
 Environments
 ============
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -44,6 +44,57 @@ def should_submit(stack):
     return False
 
 
+def resolve_parameters(parameters, blueprint, context, provider):
+    """Resolves parameters for a given blueprint.
+
+    Given a list of parameters, first discard any parameters that the
+    blueprint does not use. Then, if a parameter is a list of outputs
+    in the format of <stack_name>::<output_name>,... pull those output(s)
+    from the foreign stack(s).
+
+    Args:
+        parameters (dict): A dictionary of parameters provided by the
+            stack definition
+        blueprint (:class:`stacker.blueprint.base.Blueprint`): A Blueprint
+            object that is having the parameters applied to it.
+        context (:class:`stacker.context.Context`): The context object used
+            to get the FQN of stacks.
+        provider (:class:`stacker.providers.base.BaseProvider`): The provider
+            used for looking up stacks & their outputs.
+
+    Returns:
+        dict: The resolved parameters.
+
+    """
+    params = {}
+    blueprint_params = blueprint.parameters
+    for k, v in parameters.items():
+        if k not in blueprint_params:
+            logger.debug("Template %s does not use parameter %s.",
+                         blueprint.name, k)
+            continue
+        value = v
+        if isinstance(value, basestring) and '::' in value:
+            # Get from the Output(s) of another stack(s) in the stack_map
+            v_list = []
+            values = value.split(',')
+            for v in values:
+                stack_name, output = v.split('::')
+                stack_fqn = context.get_fqn(stack_name)
+                try:
+                    v_list.append(
+                        provider.get_output(stack_fqn, output))
+                except KeyError:
+                    raise exceptions.OutputDoesNotExist(stack_fqn, v)
+            value = ','.join(v_list)
+        if value is None:
+            logger.debug("Got None value for parameter %s, converting to a "
+                         "blank string.", k)
+            value = ''
+        params[k] = value
+    return params
+
+
 class Action(BaseAction):
     """Responsible for building & coordinating CloudFormation stacks.
 
@@ -71,36 +122,15 @@ class Action(BaseAction):
         Args:
             parameters (dict): A dictionary of parameters provided by the
                 stack definition
-            blueprint (`stacker.blueprint.base.Blueprint`): A Blueprint object
-                that is having the parameters applied to it.
+            blueprint (:class:`stacker.blueprint.base.Blueprint`): A Blueprint
+                object that is having the parameters applied to it.
 
         Returns:
             dict: The resolved parameters.
 
         """
-        params = {}
-        blueprint_params = blueprint.parameters
-        for k, v in parameters.items():
-            if k not in blueprint_params:
-                logger.debug("Template %s does not use parameter %s.",
-                             blueprint.name, k)
-                continue
-            value = v
-            if isinstance(value, basestring) and '::' in value:
-                # Get from the Output(s) of another stack(s) in the stack_map
-                v_list = []
-                values = value.split(',')
-                for v in values:
-                    stack_name, output = v.split('::')
-                    stack_fqn = self.context.get_fqn(stack_name)
-                    try:
-                        v_list.append(
-                            self.provider.get_output(stack_fqn, output))
-                    except KeyError:
-                        raise exceptions.OutputDoesNotExist(stack_fqn, v)
-                value = ','.join(v_list)
-            params[k] = value
-        return params
+        return resolve_parameters(parameters, blueprint, self.context,
+                                  self.provider)
 
     def _build_stack_tags(self, stack):
         """Builds a common set of tags to attach to a stack"""

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -88,9 +88,10 @@ def resolve_parameters(parameters, blueprint, context, provider):
                     raise exceptions.OutputDoesNotExist(stack_fqn, v)
             value = ','.join(v_list)
         if value is None:
-            logger.debug("Got None value for parameter %s, converting to a "
-                         "blank string.", k)
-            value = ''
+            logger.debug("Got None value for parameter %s, not submitting it "
+                         "to cloudformation, default value should be used.",
+                         k)
+            continue
         params[k] = value
     return params
 

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -28,6 +28,9 @@ class MissingLocalParameterException(Exception):
 class OutputDoesNotExist(Exception):
 
     def __init__(self, stack_name, output, *args, **kwargs):
+        self.stack_name = stack_name
+        self.output = output
+
         message = 'Output %s does not exist on stack %s' % (output,
                                                             stack_name)
         super(OutputDoesNotExist, self).__init__(message, *args, **kwargs)

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -255,7 +255,7 @@ class TestFunctions(unittest.TestCase):
                 }}
         params = {"a": None, "c": "Carrot"}
         p = resolve_parameters(params, self.bp, self.ctx, self.prov)
-        self.assertEqual(p["a"], "")
+        self.assertNotIn("a", p)
 
     def test_resolve_parameters_resolve_outputs(self):
         self.bp.parameters = {

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -4,6 +4,7 @@ import unittest
 import mock
 
 from stacker.actions import build
+from stacker.actions.build import resolve_parameters
 from stacker.context import Context
 from stacker import exceptions
 from stacker.plan import COMPLETE, PENDING, SKIPPED, SUBMITTED
@@ -53,44 +54,6 @@ class TestBuildAction(unittest.TestCase):
             {'name': 'other', 'parameters': {}}
         ]}
         return Context({'namespace': 'namespace'}, config=config, **kwargs)
-
-    def test_resolve_parameters_referencing_non_existant_output(self):
-        parameters = {
-            'param_1': 'mock::output_1',
-            'param_2': 'other::does_not_exist',
-        }
-        self.build_action.provider.set_outputs({
-            self.context.get_fqn('mock'): {'output_1': 'output'},
-            self.context.get_fqn('other'): {},
-        })
-        mock_blueprint = mock.MagicMock()
-        type(mock_blueprint).parameters = parameters
-        with self.assertRaises(exceptions.OutputDoesNotExist):
-            self.build_action._resolve_parameters(parameters,
-                                                  mock_blueprint)
-
-    def test_resolve_parameters(self):
-        parameters = {
-            'param_1': 'mock::output_1',
-            'param_2': 'other::output_2',
-            'param_3': 'foo::output_3,bar::output_4',
-        }
-        self.build_action.provider.set_outputs({
-            self.context.get_fqn('mock'): {'output_1': 'output1'},
-            self.context.get_fqn('other'): {'output_2': 'output2'},
-            self.context.get_fqn('foo'): {'output_3': 'output3'},
-            self.context.get_fqn('bar'): {'output_4': 'output4'},
-        })
-
-        mock_blueprint = mock.MagicMock()
-        type(mock_blueprint).parameters = parameters
-        resolved_parameters = self.build_action._resolve_parameters(
-            parameters,
-            mock_blueprint,
-        )
-        self.assertEqual(resolved_parameters['param_1'], 'output1')
-        self.assertEqual(resolved_parameters['param_2'], 'output2')
-        self.assertEqual(resolved_parameters['param_3'], 'output3,output4')
 
     def test_resolve_parameters_referencing_non_existant_stack(self):
         parameters = {
@@ -257,3 +220,101 @@ class TestBuildAction(unittest.TestCase):
         for t in test_scenarios:
             mock_stack.enabled = t.enabled
             self.assertEqual(build.should_submit(mock_stack), t.result)
+
+
+class TestFunctions(unittest.TestCase):
+    """ test module level functions """
+
+    def setUp(self):
+        self.ctx = Context({'namespace': 'test'})
+        self.prov = mock.MagicMock()
+        self.bp = mock.MagicMock()
+
+    def test_resolve_parameters_unused_parameter(self):
+        self.bp.parameters = {
+            "a": {
+                "type": "String",
+                "description": "A"},
+            "b": {
+                "type": "String",
+                "description": "B"
+                }}
+        params = {"a": "Apple", "c": "Carrot"}
+        p = resolve_parameters(params, self.bp, self.ctx, self.prov)
+        self.assertNotIn("c", p)
+        self.assertIn("a", p)
+
+    def test_resolve_parameters_none_conversion(self):
+        self.bp.parameters = {
+            "a": {
+                "type": "String",
+                "description": "A"},
+            "b": {
+                "type": "String",
+                "description": "B"
+                }}
+        params = {"a": None, "c": "Carrot"}
+        p = resolve_parameters(params, self.bp, self.ctx, self.prov)
+        self.assertEqual(p["a"], "")
+
+    def test_resolve_parameters_resolve_outputs(self):
+        self.bp.parameters = {
+            "a": {
+                "type": "String",
+                "description": "A"},
+            "b": {
+                "type": "String",
+                "description": "B"
+                }}
+        params = {"a": "other-stack::a", "b": "Banana"}
+        self.prov.get_output.return_value = "Apple"
+        p = resolve_parameters(params, self.bp, self.ctx, self.prov)
+        kall = self.prov.get_output.call_args
+        args, kwargs = kall
+        self.assertTrue(args[0], "test-other-stack")
+        self.assertTrue(args[1], "a")
+        self.assertEqual(p["a"], "Apple")
+        self.assertEqual(p["b"], "Banana")
+
+    def test_resolve_parameters_multiple_outputs(self):
+        def get_output(stack, param):
+            d = {'a': 'Apple', 'c': 'Carrot'}
+            return d[param]
+
+        self.bp.parameters = {
+            "a": {
+                "type": "String",
+                "description": "A"},
+            "b": {
+                "type": "String",
+                "description": "B"
+                }}
+        params = {"a": "other-stack::a,other-stack::c", "b": "Banana"}
+        self.prov.get_output.side_effect = get_output
+        p = resolve_parameters(params, self.bp, self.ctx, self.prov)
+        self.assertEqual(self.prov.get_output.call_count, 2)
+        self.assertEqual(p["a"], "Apple,Carrot")
+        self.assertEqual(p["b"], "Banana")
+
+    def test_resolve_parameters_output_does_not_exist(self):
+        def get_output(stack, param):
+            d = {'c': 'Carrot'}
+            return d[param]
+
+        self.bp.parameters = {
+            "a": {
+                "type": "String",
+                "description": "A"
+            },
+        }
+        params = {"a": "other-stack::a"}
+        self.prov.get_output.side_effect = get_output
+        with self.assertRaises(exceptions.OutputDoesNotExist) as cm:
+            resolve_parameters(params, self.bp, self.ctx, self.prov)
+
+        exc = cm.exception
+        self.assertEqual(exc.stack_name, "test-other-stack")
+        # Not sure this is actually what we want - should probably change it
+        # so the output is just the output name, not the stack name + the
+        # output name
+        self.assertEqual(exc.output, "other-stack::a")

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -1,8 +1,8 @@
-import json
 import unittest
 
 from mock import patch
 from stacker.config import parse_config
+from stacker.environment import parse_environment
 from stacker import exceptions
 
 config = """a: $a
@@ -36,3 +36,12 @@ class TestConfig(unittest.TestCase):
         patched.check_output.return_value = 'secret\n'
         c = parse_config('a: $a', {'a': '!vault secret/hello@value'})
         self.assertEqual(c['a'], 'secret')
+
+    def test_blank_env_values(self):
+        conf = """a: ${key1}"""
+        e = parse_environment("""key1:""")
+        c = parse_config(conf, e)
+        self.assertEqual(c['a'], None)
+        e = parse_environment("""key1: !!str""")
+        c = parse_config(conf, e)
+        self.assertEqual(c['a'], "")

--- a/stacker/tests/test_environment.py
+++ b/stacker/tests/test_environment.py
@@ -39,3 +39,8 @@ class TestEnvironment(unittest.TestCase):
     def test_simple_key_value_parsing_exception(self):
         with self.assertRaises(ValueError):
             parse_environment(test_error_env)
+
+    def test_blank_value(self):
+        e = """key1:"""
+        parsed = parse_environment(e)
+        self.assertEqual(parsed["key1"], "")


### PR DESCRIPTION
There's (almost?) never a good reason to pass 'None' as a Parameter to a
cfn template, so in the case that None is passed in (usually due to a
blank parameter in the config/env), change it to a blank string. I think
this is almost always what is expected.

This also makes a function called resolve_parameters, pulling it out of
the build.Action class, so it is easier to test.