### PR TITLE
Fixing incorrect behaviour of --force flag when using destroy command

### DIFF
--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -31,7 +31,7 @@ class Destroy(BaseCommand):
             '\n'.join(stack_names),
         )
         force = False
-        if options.force:
+        if not options.force:
             confirm = raw_input(message)
             force = confirm.lower() == 'yes'
             if not force:


### PR DESCRIPTION
The user is asked to confirm stack deletions when the force flag is set. This should be the other way around.