### PR TITLE
Add support for diffing existing vs. modified CF templates (redux)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## x.x.x
+- Add support for the 'stacker diff' command
+
 ## 0.6.0 (2016-01-07)
 
 - Support tailing cloudformation event stream when building/destroying stacks [GH-90]

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,14 @@ Stacker Command
 ===============
 
 The stacker command is built to have sub-commands, much like git. Currently the
-only implemented command is ``build``, which handles taking your stack config
-and then launching or updating stacks as necessary.
+comands are:
+
+- ``build`` which handles taking your stack config and then launching or 
+  updating stacks as necessary.
+- ``destroy`` which tears down your stacks
+- ``diff`` which compares your currently deployed stack templates to your 
+  config files 
+- ``info`` which prints information about your currently deployed stacks
 
 Example
 =======

--- a/README.rst
+++ b/README.rst
@@ -26,11 +26,11 @@ Stacker Command
 The stacker command is built to have sub-commands, much like git. Currently the
 comands are:
 
-- ``build`` which handles taking your stack config and then launching or 
+- ``build`` which handles taking your stack config and then launching or
   updating stacks as necessary.
 - ``destroy`` which tears down your stacks
-- ``diff`` which compares your currently deployed stack templates to your 
-  config files 
+- ``diff`` which compares your currently deployed stack templates to your
+  config files
 - ``info`` which prints information about your currently deployed stacks
 
 Example

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -133,6 +133,25 @@ class Action(BaseAction):
         return resolve_parameters(parameters, blueprint, self.context,
                                   self.provider)
 
+    def build_parameters(self, stack, provider_stack=None):
+        """Builds the parameters for our stack
+
+        Args:
+            stack (:class:`cloudformation.stack`): A Cloudformation stack
+            provider_stack (:class:`stacker.providers.base.Provider`): An
+                optional Stacker provider object
+
+        Returns:
+            dict: The parameters for the given stack
+        """
+        parameters = self._resolve_parameters(stack.parameters,
+                                              stack.blueprint)
+        required_params = [k for k, v in stack.blueprint.required_parameters]
+        parameters = self._handle_missing_parameters(parameters,
+                                                     required_params,
+                                                     provider_stack)
+        return parameters
+
     def _build_stack_tags(self, stack):
         """Builds a common set of tags to attach to a stack"""
         tags = {
@@ -170,12 +189,7 @@ class Action(BaseAction):
         logger.info("Launching stack %s now.", stack.fqn)
         template_url = self.s3_stack_push(stack.blueprint)
         tags = self._build_stack_tags(stack)
-        parameters = self._resolve_parameters(stack.parameters,
-                                              stack.blueprint)
-        required_params = [k for k, v in stack.blueprint.required_parameters]
-        parameters = self._handle_missing_parameters(parameters,
-                                                     required_params,
-                                                     provider_stack)
+        parameters = self.build_parameters(stack, provider_stack)
 
         try:
             if not provider_stack:

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -23,7 +23,7 @@ def diff_dictionaries(old_dict, new_dict):
         int: number of changed records
         list: [str(<change type>), <key>, <value>]
 
-        Where <change type>: +, - or empty string
+        Where <change type>: +, - or <space>
     """
 
     old_set = set(old_dict)
@@ -49,7 +49,7 @@ def diff_dictionaries(old_dict, new_dict):
             output.append(['-', key, old_dict[key]])
             output.append(['+', key, new_dict[key]])
         else:
-            output.append(['', key, new_dict[key]])
+            output.append([' ', key, new_dict[key]])
 
     return [changes, output]
 
@@ -79,12 +79,12 @@ class Action(build.Action):
         if changes == 0:
             return
 
-        print """*** New Parameters
---- Old Parameters
+        print """--- Old Parameters
++++ New Parameters
 ******************"""
 
         for line in diff:
-            print "%s\t%s = %s" % (line[0], line[1], line[2])
+            print "%s%s = %s" % (line[0], line[1], line[2])
 
     def _normalize_json(self, template):
         """Normalizes our template for diffing
@@ -121,7 +121,6 @@ class Action(build.Action):
             old_stack, new_stack,
             fromfile=from_file, tofile=to_file)
 
-        # lines is a generator, not a list hence this is a bit fugly
         template_changes = list(lines)
         if not template_changes:
             print "*** No changes to template ***"

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -1,0 +1,83 @@
+import logging
+
+from .. import exceptions
+from ..plan import COMPLETE, SKIPPED, Plan
+from . import build
+import difflib
+import json
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+class Action(build.Action):
+    """ Responsible for diff'ing CF stacks in AWS and on disk
+
+    Generates the build plan based on stack dependencies (these dependencies
+    are determined automatically based on references to output values from
+    other stacks).
+
+    The plan is then used to pull the current CloudFormation template from
+    AWS and compare it to the generated templated based on the current
+    config.
+    """
+
+    def _normalize_json(self, json_str):
+        """Takes a string representing a JSON object and normalizes it"""
+        obj = json.loads(json_str)
+        json_str = json.dumps(obj, sort_keys=True, indent=4)
+        lines = json_str.split("\n")
+        result = []
+        for line in lines:
+            result.append(line + "\n")
+        return result
+
+    def _diff_stack(self, stack, **kwargs):
+        """Handles the diffing a stack in CloudFormation vs our config"""
+        if not build.should_submit(stack) or not build.should_update(stack):
+            return SKIPPED
+
+        try:
+            old_stack = self.provider.get_template(stack.fqn)
+        except exceptions.StackDoesNotExist:
+            old_stack = None
+
+        new_stack = self._normalize_json(stack.blueprint.rendered)
+        logger.info("============== Stack: %s ==============", stack)
+        if not old_stack:
+            logger.info("New template contents:")
+            sys.stdout.write(''.join(new_stack))
+        else:
+            old_stack = self._normalize_json(old_stack)
+            count = 0
+            lines = difflib.context_diff(
+                old_stack, new_stack,
+                fromfile="old_stack", tofile="new_stack")
+
+            for line in lines:
+                sys.stdout.write(line)
+                count += 1
+            if not count:
+                print "*** No changes ***"
+                return SKIPPED
+        return COMPLETE
+
+    def _generate_plan(self):
+        plan_kwargs = {}
+        plan = Plan(description='Create/Update stacks', **plan_kwargs)
+        stacks = self.context.get_stacks_dict()
+        dependencies = self._get_dependencies()
+        for stack_name in self.get_stack_execution_order(dependencies):
+            plan.add(
+                stacks[stack_name],
+                run_func=self._diff_stack,
+                requires=dependencies.get(stack_name),
+            )
+        return plan
+
+    def run(self, *args, **kwargs):
+        plan = self._generate_plan()
+        debug_plan = self._generate_plan()
+        debug_plan.outline(logging.DEBUG)
+        logger.info("Diffing stacks: %s", ', '.join(plan.keys()))
+        plan.execute()

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -3,6 +3,7 @@ import copy
 from .build import Build
 from .destroy import Destroy
 from .info import Info
+from .diff import Diff
 from .base import BaseCommand
 from ...context import Context
 from ...providers import aws
@@ -12,7 +13,7 @@ from ... import __version__
 class Stacker(BaseCommand):
 
     name = 'stacker'
-    subcommands = (Build, Destroy, Info)
+    subcommands = (Build, Destroy, Info, Diff)
 
     def configure(self, options, **kwargs):
         super(Stacker, self).configure(options, **kwargs)

--- a/stacker/commands/stacker/diff.py
+++ b/stacker/commands/stacker/diff.py
@@ -17,7 +17,7 @@ class Diff(BaseCommand):
         parser.add_argument("--force", action="append", default=[],
                             metavar="STACKNAME", type=str,
                             help="If a stackname is provided to --force, it "
-                                 "will be updated, even if it is locked in "
+                                 "will be diffed, even if it is locked in "
                                  "the config.")
         parser.add_argument("--stacks", action="append",
                             metavar="STACKNAME", type=str,

--- a/stacker/commands/stacker/diff.py
+++ b/stacker/commands/stacker/diff.py
@@ -1,0 +1,35 @@
+""" Diffs the config against the currently running CloudFormation stacks
+
+Sometimes small changes can have big impacts.  Run 'stacker diff' before
+'stacker build' to detect bad things(tm) from happening in advance!
+"""
+
+from .base import BaseCommand
+from ...actions import diff
+
+
+class Diff(BaseCommand):
+    name = 'diff'
+    description = __doc__
+
+    def add_arguments(self, parser):
+        super(Diff, self).add_arguments(parser)
+        parser.add_argument("--force", action="append", default=[],
+                            metavar="STACKNAME", type=str,
+                            help="If a stackname is provided to --force, it "
+                                 "will be updated, even if it is locked in "
+                                 "the config.")
+        parser.add_argument("--stacks", action="append",
+                            metavar="STACKNAME", type=str,
+                            help="Only work on the stacks given. Can be "
+                                 "specified more than once. If not specified "
+                                 "then stacker will work on all stacks in the "
+                                 "config file.")
+
+    def run(self, options, **kwargs):
+        super(Diff, self).run(options, **kwargs)
+        action = diff.Action(options.context, provider=options.provider)
+        action.execute()
+
+    def get_context_kwargs(self, options, **kwargs):
+        return {'stack_names': options.stacks, 'force_stacks': options.force}

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -203,10 +203,7 @@ class Provider(BaseProvider):
         for p in stack.parameters:
             parameters[p.key] = p.value
         ret = stack.get_template()
-        try:
-            template = ret['GetTemplateResponse']['GetTemplateResult']
-            template = template['TemplateBody']
-        except KeyError:
-            raise exceptions.StackDoesNotExist(stack_name)
+        template = ret['GetTemplateResponse']['GetTemplateResult']
+        template = template['TemplateBody']
 
         return [template, parameters]

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -193,17 +193,20 @@ class Provider(BaseProvider):
             stacks = retry_on_throttling(
                 self.cloudformation.describe_stacks,
                 kwargs=dict(stack_name_or_id=stack_name))
-            stack = stacks[0]
-            parameters = dict()
-            for p in stack.parameters:
-                parameters[p.key] = p.value
-            ret = stack.get_template()
-            template = ret['GetTemplateResponse']['GetTemplateResult']
-            template = template['TemplateBody']
-            return [template, parameters]
         except boto.exception.BotoServerError as e:
             if 'does not exist' not in e.message:
                 raise
             raise exceptions.StackDoesNotExist(stack_name)
+
+        stack = stacks[0]
+        parameters = dict()
+        for p in stack.parameters:
+            parameters[p.key] = p.value
+        ret = stack.get_template()
+        try:
+            template = ret['GetTemplateResponse']['GetTemplateResult']
+            template = template['TemplateBody']
         except KeyError:
             raise exceptions.StackDoesNotExist(stack_name)
+
+        return [template, parameters]

--- a/stacker/providers/aws.py
+++ b/stacker/providers/aws.py
@@ -184,12 +184,23 @@ class Provider(BaseProvider):
             self._outputs[stack_name] = get_output_dict(stack)
         return self._outputs[stack_name]
 
-    def get_template(self, stack_name):
+    def get_stack_info(self, stack_name):
+        """ Get the template and parameters of the stack currently in AWS
+
+        Returns [ template, parameters ]
+        """
         try:
-            ret = retry_on_throttling(self.cloudformation.get_template,
-                                       args=[stack_name])
-            result = ret['GetTemplateResponse']['GetTemplateResult']
-            return result['TemplateBody']
+            stacks = retry_on_throttling(
+                self.cloudformation.describe_stacks,
+                kwargs=dict(stack_name_or_id=stack_name))
+            stack = stacks[0]
+            parameters = dict()
+            for p in stack.parameters:
+                parameters[p.key] = p.value
+            ret = stack.get_template()
+            template = ret['GetTemplateResponse']['GetTemplateResult']
+            template = template['TemplateBody']
+            return [template, parameters]
         except boto.exception.BotoServerError as e:
             if 'does not exist' not in e.message:
                 raise

--- a/stacker/tests/actions/test_diff.py
+++ b/stacker/tests/actions/test_diff.py
@@ -1,0 +1,38 @@
+import unittest
+
+from stacker.actions.diff import diff_dictionaries
+
+
+class TestDiffDictionary(unittest.TestCase):
+    def setUp(self):
+        self.old_dict = {
+            'a': 'Apple',
+            'b': 'Banana',
+            'c': 'Corn',
+        }
+        self.new_dict = {
+            'a': 'Apple',
+            'b': 'Bob',
+            'd': 'Doug',
+        }
+
+    def test_diff_dictionaries(self):
+        [count, changes] = diff_dictionaries(self.old_dict, self.new_dict)
+        self.assertEqual(count, 3)
+        expected_output = [
+            ["", "a", "Apple"],
+            ["-", "b", "Banana"],
+            ["+", "b", "Bob"],
+            ["-", "c", "Corn"],
+            ["+", "d", "Doug"],
+        ]
+        changes.sort()
+        expected_output.sort()
+
+        # compare all the outputs to the expected change
+        for expected_change in expected_output:
+            change = changes.pop(0)
+            self.assertListEqual(change, expected_change)
+
+        # No extra output
+        self.assertEqual(len(changes), 0)

--- a/stacker/tests/actions/test_diff.py
+++ b/stacker/tests/actions/test_diff.py
@@ -20,7 +20,7 @@ class TestDiffDictionary(unittest.TestCase):
         [count, changes] = diff_dictionaries(self.old_dict, self.new_dict)
         self.assertEqual(count, 3)
         expected_output = [
-            ["", "a", "Apple"],
+            [" ", "a", "Apple"],
             ["-", "b", "Banana"],
             ["+", "b", "Bob"],
             ["-", "c", "Corn"],


### PR DESCRIPTION
Sometimes it's hard to figure out what is different between your
existing CloudFormation deployment and the template changes you've made.

Now you can specify the 'stacker diff' command to see
what has changed in one or more stacks and get a feel for what
changes AWS will make when you deploy the changes for real.