### PR TITLE
Convert python booleans in parameters to strings

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -92,6 +92,10 @@ def resolve_parameters(parameters, blueprint, context, provider):
                          "to cloudformation, default value should be used.",
                          k)
             continue
+        if isinstance(value, bool):
+            logger.debug("Converting parameter %s boolean '%s' to string.",
+                         k, value)
+            value = str(value).lower()
         params[k] = value
     return params
 

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -318,3 +318,17 @@ class TestFunctions(unittest.TestCase):
         # so the output is just the output name, not the stack name + the
         # output name
         self.assertEqual(exc.output, "other-stack::a")
+
+    def test_resolve_parameters_booleans(self):
+        self.bp.parameters = {
+            "a": {
+                "type": "String",
+                "description": "A"},
+            "b": {
+                "type": "String",
+                "description": "B"},
+        }
+        params = {"a": True, "b": False}
+        p = resolve_parameters(params, self.bp, self.ctx, self.prov)
+        self.assertEquals("true", p["a"])
+        self.assertEquals("false", p["b"])


### PR DESCRIPTION
Fixes GH-135

Some resources have the concept of boolean Parameters, but these are
booleans in json, which is a lowercase string.  This allows people to
use `true` or `false` in boolean parameters, without having to specify
`!!str` before it in order to force the yaml to not turn them into
python booleans.