### PR TITLE
Make sure we don't run post_run & pre_run during diff

### DIFF
--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -182,3 +182,10 @@ class Action(build.Action):
         debug_plan.outline(logging.DEBUG)
         logger.info("Diffing stacks: %s", ', '.join(plan.keys()))
         plan.execute()
+
+    """Don't ever do anything for pre_run or post_run"""
+    def pre_run(self, *args, **kwargs):
+        pass
+
+    def post_run(self, *args, **kwargs):
+        pass


### PR DESCRIPTION
pretty straight forward... diff is a subclass of build which means by default it was running the hooks.