### PR TITLE
Allow users to override name of bucket to store templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,21 @@ stacks between subsequent builds.
 .. _troposphere: https://github.com/cloudtools/troposphere
 .. _string.Template: https://docs.python.org/2/library/string.html#template-strings
 
+Overriding CLoudFormation S3 bucket
+===================================
+
+Stacker uploads your CloudFormation templates to S3 prior to creating your
+stacks. This is to get around limitations imposed by the CloudFormation API. By
+default all templates are uploaded to a ``stacker-${namespace}`` bucket in your
+AWS account, where ``namespace`` is the one that you defined in your
+environment.
+
+You can override where Stacker uploads your template by specifying the
+following in your stack configuration file::
+
+  stacker_bucket: my-bucket
+
+
 Translators
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ stacks between subsequent builds.
 .. _troposphere: https://github.com/cloudtools/troposphere
 .. _string.Template: https://docs.python.org/2/library/string.html#template-strings
 
-Overriding CLoudFormation S3 bucket
+Overriding CloudFormation S3 bucket
 ===================================
 
 Stacker uploads your CloudFormation templates to S3 prior to creating your

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -53,7 +53,7 @@ class BaseAction(object):
     def __init__(self, context, provider=None):
         self.context = context
         self.provider = provider
-        self.bucket_name = 'stacker-%s' % (context.get_fqn(),)
+        self.bucket_name = context.bucket_name
         self._conn = None
         self._cfn_bucket = None
 

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -53,10 +53,14 @@ class Context(object):
         self.config = config or {}
         self.force_stacks = force_stacks or []
         self._base_fqn = self.namespace.replace('.', '-').lower()
+        self.bucket_name = 'stacker-%s' % (self.get_fqn(),)
 
     def load_config(self, conf_string):
         self.config = parse_config(conf_string, environment=self.environment)
         self.mappings = self.config.get('mappings', {})
+        bucket_name = self.config.get('stacker_bucket', None)
+        if bucket_name is not None:
+            self.bucket_name = bucket_name
 
     def _get_stack_definitions(self):
         if not self.stack_names:

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -59,7 +59,7 @@ class Context(object):
         self.config = parse_config(conf_string, environment=self.environment)
         self.mappings = self.config.get('mappings', {})
         bucket_name = self.config.get('stacker_bucket', None)
-        if bucket_name is not None:
+        if bucket_name:
             self.bucket_name = bucket_name
 
     def _get_stack_definitions(self):

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -65,6 +65,21 @@ class TestContext(unittest.TestCase):
         fqn = context.get_fqn('stack1')
         self.assertEqual(fqn, 'namespace-stack1')
 
+    def test_context_default_bucket_name(self):
+        context = Context({'namespace': 'test'})
+        context.load_config("""mappings:""")
+        self.assertEqual(context.bucket_name, 'stacker-test')
+
+    def test_context_bucket_name_is_overriden_but_is_none(self):
+        context = Context({'namespace': 'test'})
+        context.load_config("""stacker_bucket:""")
+        self.assertEqual(context.bucket_name, 'stacker-test')
+
+    def test_context_bucket_name_is_overriden(self):
+        context = Context({'namespace': 'test'})
+        context.load_config("""stacker_bucket: bucket123""")
+        self.assertEqual(context.bucket_name, 'bucket123')
+
 
 class TestFunctions(unittest.TestCase):
     """ Test the module level functions """


### PR DESCRIPTION
Hi,

We'd like to be able to override the default naming convention used to create the S3 bucket where templates are stored.

This pull request adds a `-b` / `--bucket-name` cli option to pass in the name to use. If the option is omitted then the behaviour remains unchanged.

Thanks!