### PR TITLE
Add --environment to CLI to pass in environment args on the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## x.x.x (2016-xx-xx)
+- Add support for passing environment variables on the cli via --env
+
 ## 0.6.1 (2016-02-11)
 - Add support for the 'stacker diff' command [GH-133]
 - Python boolean parameters automatically converted to strings for CloudFormation [GH-136]

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -103,11 +103,13 @@ class BaseCommand(object):
             level=log_level,
         )
 
-    def parse_args(self):
+    def parse_args(self, *vargs):
         parser = argparse.ArgumentParser(description=self.description)
         self.add_subcommands(parser)
         self.add_arguments(parser)
-        return parser.parse_args()
+        args = parser.parse_args(*vargs)
+        args.environment.update(args.cli_envs)
+        return args
 
     def run(self, options, **kwargs):
         self.setup_logging(options.verbose)
@@ -141,6 +143,13 @@ class BaseCommand(object):
                                  "that can be used inside any of the stacks "
                                  "being built. Can be specified more than "
                                  "once.")
+        parser.add_argument("-e", "--env", dest="cli_envs",
+                            metavar="ENV=VALUE", type=key_value_arg,
+                            action=KeyValueAction, default={},
+                            help="Adds environment key/value pairs from "
+                            "the command line. Overrides your environment "
+                            "file settings. Can be specified more than "
+                            "once.")
         parser.add_argument("-r", "--region", default="us-east-1",
                             help="The AWS region to launch in. Default: "
                                  "%(default)s")

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -147,9 +147,9 @@ class BaseCommand(object):
                             metavar="ENV=VALUE", type=key_value_arg,
                             action=KeyValueAction, default={},
                             help="Adds environment key/value pairs from "
-                            "the command line. Overrides your environment "
-                            "file settings. Can be specified more than "
-                            "once.")
+                                 "the command line. Overrides your "
+                                 "environment file settings. Can be specified "
+                                 "more than once.")
         parser.add_argument("-r", "--region", default="us-east-1",
                             help="The AWS region to launch in. Default: "
                                  "%(default)s")

--- a/stacker/tests/test_stacker.py
+++ b/stacker/tests/test_stacker.py
@@ -8,11 +8,10 @@ class TestStacker(unittest.TestCase):
 
     def test_stacker_build_parse_args(self):
         stacker = Stacker()
-        parser = argparse.ArgumentParser(description=stacker.description)
-        stacker.add_subcommands(parser)
-        args = parser.parse_args(
+        args = stacker.parse_args(
             ['build', '-p', 'BaseDomain=mike.com', '-r', 'us-west-2', '-p',
              'AZCount=2', '-p', 'CidrBlock=10.128.0.0/16',
+             '-e', 'namespace=test.override',
              'stacker/tests/fixtures/basic.env',
              'stacker/tests/fixtures/vpc-bastion-db-web.yaml']
         )
@@ -23,12 +22,12 @@ class TestStacker(unittest.TestCase):
         self.assertEqual(parameters['AZCount'], '2')
         self.assertEqual(args.region, 'us-west-2')
         self.assertFalse(args.outline)
+        # verify namespace was modified
+        self.assertEqual(args.environment['namespace'], 'test.override')
 
     def test_stacker_build_context_passed_to_blueprint(self):
         stacker = Stacker()
-        parser = argparse.ArgumentParser(description=stacker.description)
-        stacker.add_subcommands(parser)
-        args = parser.parse_args(
+        args = stacker.parse_args(
             ['build', '-p', 'BaseDomain=mike.com', '-r', 'us-west-2', '-p',
              'AZCount=2', '-p', 'CidrBlock=10.128.0.0/16',
              'stacker/tests/fixtures/basic.env',
@@ -49,9 +48,7 @@ class TestStacker(unittest.TestCase):
 
     def test_stacker_blueprint_property_access_does_not_reset_blueprint(self):
         stacker = Stacker()
-        parser = argparse.ArgumentParser(description=stacker.description)
-        stacker.add_subcommands(parser)
-        args = parser.parse_args(
+        args = stacker.parse_args(
             ['build', '-p', 'BaseDomain=mike.com', '-r', 'us-west-2', '-p',
              'AZCount=2', '-p', 'CidrBlock=10.128.0.0/16',
              'stacker/tests/fixtures/basic.env',
@@ -66,9 +63,7 @@ class TestStacker(unittest.TestCase):
 
     def test_stacker_build_context_stack_names_specified(self):
         stacker = Stacker()
-        parser = argparse.ArgumentParser(description=stacker.description)
-        stacker.add_subcommands(parser)
-        args = parser.parse_args(
+        args = stacker.parse_args(
             ['build', '-p', 'BaseDomain=mike.com', '-r', 'us-west-2', '-p',
              'AZCount=2', '-p', 'CidrBlock=10.128.0.0/16',
              'stacker/tests/fixtures/basic.env',


### PR DESCRIPTION
Hey, we can do this with --parameter, but sometimes you want to
pass in environment variables on the CLI.