### PR TITLE
build now optionally runs (only) the hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## x.x.x (2016-xx-xx)
 - Add support for passing environment variables on the cli via --env
+- Add support for build --skip-hook and --run-hook for pre/post_build hooks
 
 ## 0.6.1 (2016-02-11)
 - Add support for the 'stacker diff' command [GH-133]

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -291,6 +291,10 @@ class Action(BaseAction):
             # need to generate a new plan to log since the outline sets the
             # steps to COMPLETE in order to log them
             debug_plan = self._generate_plan()
+
+            # don't actually deploy anything if we're just running the hooks
+            if self.context.run_hook:
+                return
             debug_plan.outline(logging.DEBUG)
             logger.info("Launching stacks: %s", ', '.join(plan.keys()))
             plan.execute()

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -37,9 +37,14 @@ class Build(BaseCommand):
                                  "specified more than once. If not specified "
                                  "then stacker will work on all stacks in the "
                                  "config file.")
-        parser.add_argument('-t', '--tail', action='store_true',
-                            help='Tail the CloudFormation logs while working'
-                                 'with stacks')
+        parser.add_argument("-t", "--tail", action="store_true",
+                            help="Tail the CloudFormation logs while working"
+                                 "with stacks")
+        parser.add_argument("--skip-hook", action="append", default=[],
+                            choices=["pre", "post"],
+                            help="Which hooks to skip during build")
+        parser.add_argument("--run-hook", choices=["pre", "post"],
+                            help="Run a hook without the rest of the build")
 
     def run(self, options, **kwargs):
         super(Build, self).run(options, **kwargs)
@@ -47,4 +52,9 @@ class Build(BaseCommand):
         action.execute(outline=options.outline, tail=options.tail)
 
     def get_context_kwargs(self, options, **kwargs):
-        return {'stack_names': options.stacks, 'force_stacks': options.force}
+        return {
+            'stack_names': options.stacks,
+            'force_stacks': options.force,
+            'skip_hooks': options.skip_hook,
+            'run_hook': options.run_hook,
+        }

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -40,7 +40,7 @@ class Context(object):
 
     def __init__(self, environment, stack_names=None,
                  parameters=None, mappings=None, config=None,
-                 force_stacks=None):
+                 force_stacks=None, skip_hooks=None, run_hook=None):
         try:
             self.namespace = environment['namespace']
         except KeyError:
@@ -52,6 +52,8 @@ class Context(object):
         self.mappings = mappings or {}
         self.config = config or {}
         self.force_stacks = force_stacks or []
+        self.skip_hooks = skip_hooks or []
+        self.run_hook = run_hook or None
         self._base_fqn = self.namespace.replace('.', '-').lower()
         self.bucket_name = 'stacker-%s' % (self.get_fqn(),)
 

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -100,6 +100,24 @@ class TestHooks(unittest.TestCase):
         with self.assertRaises(Queue.Empty):
             hook_queue.get_nowait()
 
+    def test_skip_hook(self):
+        context = Context({'namespace': 'namespace'}, skip_hooks=['pre'])
+        hooks = [{'path': 'stacker.hooks.blah', 'required': True}]
+        handle_hooks('pre_build', hooks, 'us-east-1', context)
+        self.assertTrue(hook_queue.empty())
+
+    def test_run_hook_match(self):
+        context = Context({'namespace': 'namespace'}, run_hook='pre')
+        hooks = [{'path': 'stacker.hooks.blah', 'required': True}]
+        with self.assertRaises(AttributeError):
+            handle_hooks('pre_build', hooks, 'us-east-1', context)
+
+    def test_run_hook_no_match(self):
+        context = Context({'namespace': 'namespace'}, run_hook='pre')
+        hooks = [{'path': 'stacker.hooks.blah', 'required': True}]
+        handle_hooks('post_build', hooks, 'us-east-1', context)
+        self.assertTrue(hook_queue.empty())
+
     def test_hook_failure(self):
         hooks = [{'path': 'stacker.tests.test_util.fail_hook',
                   'required': True}]

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -164,6 +164,17 @@ def cf_safe_name(name):
     return ''.join([uppercase_first_letter(part) for part in parts])
 
 
+def skip_hook(stage, context):
+    """Determines if the hooks for a given stage should be skipped"""
+    if stage == 'pre_build' and ('pre' in context.skip_hooks or (
+        context.run_hook and context.run_hook != 'pre')):
+        return True
+    elif stage == 'post_build' and ('post' in context.skip_hooks or (
+        context.run_hook and context.run_hook != 'post')):
+        return True
+    return False
+
+
 # TODO: perhaps make this a part of the builder?
 def handle_hooks(stage, hooks, region, context):
     """ Used to handle pre/post_build hooks.
@@ -181,6 +192,10 @@ def handle_hooks(stage, hooks, region, context):
     """
     if not hooks:
         logger.debug("No %s hooks defined.", stage)
+        return
+
+    if skip_hook(stage, context):
+        logger.debug("Skipping %s hooks.", stage)
         return
 
     hook_paths = []


### PR DESCRIPTION
pre/post hooks are powerful, but occasionly you need a little more
control over when they run.  This change extends the build command
to support two new flags: --skip-hook and --run-hook which skip
running the pre/post hooks or only run the corresponding hooks.

Testing:
- Manual testing
- Unit tests