### PR TITLE
Support dumping out rendered cloudformation templates for each stack

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -297,17 +297,15 @@ class Action(BaseAction):
 
         """
         plan = self._generate_plan(tail=tail)
-        if outline:
-            plan.outline()
-        elif dump:
-            plan.dump(dump)
-        else:
-            # need to generate a new plan to log since the outline sets the
-            # steps to COMPLETE in order to log them
-            debug_plan = self._generate_plan()
-            debug_plan.outline(logging.DEBUG)
+        if not outline and not dump:
+            plan.outline(logging.DEBUG)
             logger.info("Launching stacks: %s", ', '.join(plan.keys()))
             plan.execute()
+        else:
+            if outline:
+                plan.outline()
+            if dump:
+                plan.dump(dump)
 
     def post_run(self, outline=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -290,22 +290,24 @@ class Action(BaseAction):
             util.handle_hooks('pre_build', pre_build, self.provider.region,
                               self.context)
 
-    def run(self, outline=False, tail=False, *args, **kwargs):
+    def run(self, outline=False, tail=False, dump=False, *args, **kwargs):
         """Kicks off the build/update of the stacks in the stack_definitions.
 
         This is the main entry point for the Builder.
 
         """
         plan = self._generate_plan(tail=tail)
-        if not outline:
+        if outline:
+            plan.outline()
+        elif dump:
+            plan.dump(dump)
+        else:
             # need to generate a new plan to log since the outline sets the
             # steps to COMPLETE in order to log them
             debug_plan = self._generate_plan()
             debug_plan.outline(logging.DEBUG)
             logger.info("Launching stacks: %s", ', '.join(plan.keys()))
             plan.execute()
-        else:
-            plan.outline()
 
     def post_run(self, outline=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -40,11 +40,13 @@ class Build(BaseCommand):
         parser.add_argument('-t', '--tail', action='store_true',
                             help='Tail the CloudFormation logs while working'
                                  'with stacks')
+        parser.add_argument('-d', '--dump', action='store', type=str,
+                            help='Dump the rendered Cloudformation templates to a directory')
 
     def run(self, options, **kwargs):
         super(Build, self).run(options, **kwargs)
         action = build.Action(options.context, provider=options.provider)
-        action.execute(outline=options.outline, tail=options.tail)
+        action.execute(outline=options.outline, tail=options.tail, dump=options.dump)
 
     def get_context_kwargs(self, options, **kwargs):
         return {'stack_names': options.stacks, 'force_stacks': options.force}

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import json
 import logging
 import multiprocessing
 import os
@@ -285,23 +284,32 @@ class Plan(OrderedDict):
         if message:
             logger.log(level, message)
 
-    def dump(self, output):
+        self.reset()
+
+    def reset(self):
+        for _, step in self.iteritems():
+            step.status = PENDING
+
+    def dump(self, directory):
         steps = 1
         logger.info('Dumping "%s"...', self.description)
-        if not os.path.exists(output):
-            os.makedirs(output)
+        directory = os.path.expanduser(directory)
+        if not os.path.exists(directory):
+            os.makedirs(directory)
 
         while not self.completed:
             step_name, step = self.list_pending()[0]
             blueprint = step.stack.blueprint
             filename = stack_template_key_name(blueprint)
-            path = os.path.join(output, filename)
+            path = os.path.join(directory, filename)
             logger.info('Writing stack "%s" -> %s', step_name, path)
             with open(path, 'w') as f:
                 f.write(blueprint.rendered)
 
             step.status = COMPLETE
             steps += 1
+
+        self.reset()
 
     def _check_point(self):
         """Outputs the current status of all steps in the plan."""


### PR DESCRIPTION
Output looks like:

```
$ stacker build -r us-west-2 conf/lunohq/development.env conf/lunohq/config.yaml --dump dump
[2016-05-17T14:05:33] Dumping "Create/Update stacks"...
[2016-05-17T14:05:33] Writing stack "dev-lunohq-vpc" -> dump/vpc-3ea2d331.json
[2016-05-17T14:05:33] Writing stack "dev-lunohq-empireDB" -> dump/empireDB-2bc493a4.json
[2016-05-17T14:05:33] Writing stack "dev-lunohq-empireMinion" -> dump/empireMinion-6b3bcb53.json
[2016-05-17T14:05:33] Writing stack "dev-lunohq-empireController" -> dump/empireController-92678c3c.json
...
````