### PR TITLE
Typo fix.

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -63,7 +63,7 @@ PARAMETER_PROPERTIES = {
     'min_length': 'MinLength',
     'max_value': 'MaxValue',
     'min_value': 'MinValue',
-    'constaint_description': 'ConstraintDescription'
+    'constraint_description': 'ConstraintDescription'
 }
 
 


### PR DESCRIPTION
Prevented constraint descriptions from getting passed on.