### PR TITLE
Make database locked output only debug

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -27,8 +27,8 @@ def should_update(stack):
     """
     if stack.locked:
         if not stack.force:
-            logger.info("Stack %s locked and not in --force list. "
-                        "Refusing to update.", stack.name)
+            logger.debug("Stack %s locked and not in --force list. "
+                         "Refusing to update.", stack.name)
             return False
         else:
             logger.debug("Stack %s locked, but is in --force "


### PR DESCRIPTION
This quiets regular output down to only showing the things that are
going to be updated.  After the first run we dump the plan, so you can
see that things have been skipped because they are locked.