### PR TITLE
Cleanup plan/status split from way back

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -3,13 +3,14 @@ import logging
 from .base import BaseAction
 from .. import exceptions, util
 from ..exceptions import StackDidNotChange
-from ..plan import SUBMITTED, Plan
+from ..plan import Plan
 from ..status import (
     NotSubmittedStatus,
     NotUpdatedStatus,
     DidNotChangeStatus,
     SubmittedStatus,
-    CompleteStatus
+    CompleteStatus,
+    SUBMITTED
 )
 
 

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -5,12 +5,10 @@ from ..exceptions import StackDoesNotExist
 from .. import util
 from ..status import (
     CompleteStatus,
-    SubmittedStatus
-)
-from ..plan import (
+    SubmittedStatus,
     SUBMITTED,
-    Plan,
 )
+from ..plan import Plan
 
 from ..status import StackDoesNotExist as StackDoesNotExistStatus
 

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -9,18 +9,13 @@ from .actions.base import stack_template_key_name
 
 from .status import (
     Status,
-    PendingStatus,
-    SubmittedStatus,
-    CompleteStatus,
-    SkippedStatus
+    PENDING,
+    SUBMITTED,
+    COMPLETE,
+    SKIPPED
 )
 
 logger = logging.getLogger(__name__)
-
-PENDING = PendingStatus()
-SUBMITTED = SubmittedStatus()
-COMPLETE = CompleteStatus()
-SKIPPED = SkippedStatus()
 
 
 class Step(object):

--- a/stacker/status.py
+++ b/stacker/status.py
@@ -44,3 +44,9 @@ class DidNotChangeStatus(SkippedStatus):
 
 class StackDoesNotExist(SkippedStatus):
     reason = "does not exist in cloudformation"
+
+
+PENDING = PendingStatus()
+SUBMITTED = SubmittedStatus()
+COMPLETE = CompleteStatus()
+SKIPPED = SkippedStatus()

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -7,7 +7,12 @@ from stacker.actions import build
 from stacker.actions.build import resolve_parameters
 from stacker.context import Context
 from stacker import exceptions
-from stacker.plan import COMPLETE, PENDING, SKIPPED, SUBMITTED
+from stacker.status import (
+    COMPLETE,
+    PENDING,
+    SKIPPED,
+    SUBMITTED
+)
 from stacker.exceptions import StackDidNotChange
 from stacker.providers.base import BaseProvider
 

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -5,7 +5,7 @@ import mock
 from stacker.actions import destroy
 from stacker.context import Context
 from stacker.exceptions import StackDoesNotExist
-from stacker.plan import (
+from stacker.status import (
     COMPLETE,
     PENDING,
     SKIPPED,

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -3,7 +3,15 @@ import mock
 
 from stacker.context import Context
 from stacker.exceptions import ImproperlyConfigured
-from stacker.plan import COMPLETE, SKIPPED, SUBMITTED, Step, Plan
+from stacker.plan import (
+    Step,
+    Plan,
+)
+from stacker.status import (
+    COMPLETE,
+    SKIPPED,
+    SUBMITTED,
+)
 from stacker.stack import Stack
 
 from .factories import generate_definition


### PR DESCRIPTION
For some reason SUBMITTED, etc were still being created in plan.py,
rather than status.py.