### PR TITLE
Support tags as a new top-level keyword

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -71,6 +71,28 @@ the build action::
       args:
         domain: mydomain.com
 
+Tags
+----
+
+Cloudformation supports arbitrary key-value pair tags. All stack-level, including automatically created tags, are
+propagated to resources that AWS CloudFormation supports. See `AWS Cloudformation Resource Tags Type`_ for more details.
+If no tags are specified, the `stacker_namespace` tag is applied to your stack with the value of `namespace` as the
+tag value.
+
+If you prefer to apply a custom set of tags, specify the top-level keyword `tags` as a map. Example::
+
+  tags:
+    "hello": world
+    "my_tag:with_colons_in_key": ${dynamic_tag_value_from_my_env}
+    simple_tag: simple value
+
+If you prefer to have no tags applied to your stacks (versus the default tags that stacker applies), specify an empty
+map for the top-level keyword::
+
+  tags: {}
+
+.. _`AWS Cloudformation Resource Tags Type`: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html
+
 Mappings
 --------
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -168,10 +168,7 @@ class Action(BaseAction):
 
     def _build_stack_tags(self, stack):
         """Builds a common set of tags to attach to a stack"""
-        tags = {
-            "stacker_namespace": self.context.namespace,
-        }
-        return tags
+        return self.context.tags
 
     def _launch_stack(self, stack, **kwargs):
         """Handles the creating or updating of a stack in CloudFormation.

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -1,5 +1,5 @@
-from .exceptions import MissingEnvironment
 from .config import parse_config
+from .exceptions import MissingEnvironment
 from .stack import Stack
 
 
@@ -55,6 +55,9 @@ class Context(object):
         self.force_stacks = force_stacks or []
         self._base_fqn = self.namespace.replace(".", "-").lower()
         self.bucket_name = "stacker-%s" % (self.get_fqn(),)
+        self.tags = {
+            'stacker_namespace': self.namespace
+        }
 
     def load_config(self, conf_string):
         self.config = parse_config(conf_string, environment=self.environment)
@@ -65,6 +68,9 @@ class Context(object):
         bucket_name = self.config.get("stacker_bucket", None)
         if bucket_name:
             self.bucket_name = bucket_name
+        tags = self.config.get("tags", None)
+        if tags is not None:
+            self.tags = dict([(str(tag_key), str(tag_value)) for tag_key, tag_value in tags.items()])
 
     def _get_stack_definitions(self):
         if not self.stack_names:

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -92,6 +92,32 @@ class TestContext(unittest.TestCase):
         fqn = context.get_fqn("stack1")
         self.assertEqual(fqn, "namespacestack1")
 
+    def test_context_tags(self):
+        context = Context({"namespace": "test", "dynamic_context": "baz"})
+        context.load_config("""
+        tags:
+            "a:b": "c"
+            "hello": 1
+            "test_dynamic": ${dynamic_context}
+            simple_tag: simple value
+        """)
+        self.assertEqual(context.tags, {
+            "a:b": "c",
+            "hello": "1",
+            "test_dynamic": "baz",
+            "simple_tag": "simple value"
+        })
+
+    def test_context_tags_with_empty_map(self):
+        context = Context({"namespace": "test"})
+        context.load_config("""tags: {}""")
+        self.assertEqual(context.tags, {})
+
+    def test_context_no_tags_specified(self):
+        context = Context({"namespace": "test"})
+        self.assertEqual(context.tags, {"stacker_namespace": "test"})
+
+
 class TestFunctions(unittest.TestCase):
     """ Test the module level functions """
     def test_get_fqn_redundant_base(self):


### PR DESCRIPTION
Adds a new top-level `tags` keyword. By default, the previously applied `stacker_namespace` tag is still applied to the stack. Alternatively, a user can now specify a different set of tags to apply, including no tags. `config.rst` is updated with the usage examples, including tags based on dynamic environment information.

Might resolve #154 