### PR TITLE
Initial pass at interactive aws provider

### DIFF
--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -6,7 +6,9 @@ from .info import Info
 from .diff import Diff
 from .base import BaseCommand
 from ...context import Context
-from ...providers import aws
+from ...providers.aws import (
+    interactive,
+)
 from ... import __version__
 
 
@@ -17,7 +19,7 @@ class Stacker(BaseCommand):
 
     def configure(self, options, **kwargs):
         super(Stacker, self).configure(options, **kwargs)
-        options.provider = aws.Provider(region=options.region)
+        options.provider = interactive.Provider(region=options.region)
         options.context = Context(
             environment=options.environment,
             parameters=copy.deepcopy(options.parameters),

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 
 from .build import Build
 from .destroy import Destroy
@@ -12,6 +13,8 @@ from ...providers.aws import (
 )
 from ... import __version__
 
+logger = logging.getLogger(__name__)
+
 
 class Stacker(BaseCommand):
 
@@ -22,8 +25,10 @@ class Stacker(BaseCommand):
         super(Stacker, self).configure(options, **kwargs)
         imode = getattr(options, 'interactive', False)
         if imode:
+            logger.info('Using Interactive AWS Provider')
             options.provider = interactive.Provider(region=options.region)
         else:
+            logger.info('Using Default AWS Provider')
             options.provider = default.Provider(region=options.region)
         options.context = Context(
             environment=options.environment,

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -7,6 +7,7 @@ from .diff import Diff
 from .base import BaseCommand
 from ...context import Context
 from ...providers.aws import (
+    default,
     interactive,
 )
 from ... import __version__
@@ -19,7 +20,11 @@ class Stacker(BaseCommand):
 
     def configure(self, options, **kwargs):
         super(Stacker, self).configure(options, **kwargs)
-        options.provider = interactive.Provider(region=options.region)
+        imode = getattr(options, 'interactive', False)
+        if imode:
+            options.provider = interactive.Provider(region=options.region)
+        else:
+            options.provider = default.Provider(region=options.region)
         options.context = Context(
             environment=options.environment,
             parameters=copy.deepcopy(options.parameters),

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -112,10 +112,10 @@ class BaseCommand(object):
         return args
 
     def run(self, options, **kwargs):
-        self.setup_logging(options.verbose)
+        pass
 
     def configure(self, options, **kwargs):
-        pass
+        self.setup_logging(options.verbose)
 
     def get_context_kwargs(self, options, **kwargs):
         """Return a dictionary of kwargs that will be used with the Context.

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -168,3 +168,10 @@ class BaseCommand(object):
         parser.add_argument("config", type=argparse.FileType(),
                             help="The config file where stack configuration "
                                  "is located. Must be in yaml format.")
+        parser.add_argument("-i", "--interactive", action='store_true',
+                            help="Enable interactive mode. If specified, this "
+                            "will use the AWS interactive provider, which "
+                            "leverages Cloudformation Change Sets to display "
+                            "changes before running cloudformation templates. "
+                            "You'll be asked if you want to execute each change "
+                            "set.")

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -58,3 +58,7 @@ class StackDidNotChange(Exception):
     """Exception raised when there are no changes to be made by the
     provider.
     """
+
+
+class CancelExecution(Exception):
+    """Exception raised when we want to cancel executing the plan."""

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -4,7 +4,11 @@ import multiprocessing
 import os
 import time
 
-from .exceptions import ImproperlyConfigured
+from .exceptions import (
+    CancelExecution,
+    ImproperlyConfigured,
+)
+
 from .actions.base import stack_template_key_name
 
 from .status import (
@@ -242,6 +246,9 @@ class Plan(OrderedDict):
                     if attempts == 1:
                         self._check_point()
                     self._wait_func(self.sleep_time)
+        except CancelExecution:
+            logger.info("Cancelling execution")
+            return
         finally:
             for watcher in self._watchers.values():
                 self._terminate_watcher(watcher)

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -5,9 +5,9 @@ import time
 import boto3
 import botocore.exceptions
 
-from .base import BaseProvider
-from .. import exceptions
-from ..util import retry_with_backoff
+from ..base import BaseProvider
+from ... import exceptions
+from ...util import retry_with_backoff
 
 logger = logging.getLogger(__name__)
 

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -5,7 +5,7 @@ import yaml
 
 from ... import exceptions
 from .default import (
-    Provider as BaseProvider,
+    Provider as AWSProvider,
     retry_on_throttling,
 )
 
@@ -24,7 +24,7 @@ def get_change_set_name():
     return 'change-set-{}'.format(int(time.time()))
 
 
-class Provider(BaseProvider):
+class Provider(AWSProvider):
     """AWS Cloudformation Change Set Provider"""
 
     def _wait_till_change_set_complete(self, change_set_id):

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -68,11 +68,14 @@ class Provider(BaseProvider):
         if response["ExecutionStatus"] != "AVAILABLE":
             raise Exception("Unable to execute change set: {}".format(response))
 
-        print "\nCloudformation wants to make the following changes to stack: {}\n".format(fqn)
-        print yaml.safe_dump(response["Changes"])
+        message = (
+            "Cloudformation wants to make the following changes to stack: "
+            "%s\n%s"
+        )
+        logger.info(message, fqn, yaml.safe_dump(response["Changes"]))
         approve = raw_input("Execute the above changes? [y/n] ")
         if approve != "y":
-            raise Exception("Don't execute change set")
+            raise exceptions.CancelExecution
 
         retry_on_throttling(
             self.cloudformation.execute_change_set,

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -1,0 +1,83 @@
+import logging
+import time
+
+import yaml
+
+from ... import exceptions
+from .default import (
+    Provider as BaseProvider,
+    retry_on_throttling,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def get_change_set_name():
+    """Return a valid Change Set Name.
+
+    The name has to satisfy the following regex:
+        [a-zA-Z][-a-zA-Z0-9]*
+
+    And must be unique across all change sets.
+
+    """
+    return 'change-set-{}'.format(int(time.time()))
+
+
+class Provider(BaseProvider):
+    """AWS Cloudformation Change Set Provider"""
+
+    def _wait_till_change_set_complete(self, change_set_id):
+        response = retry_on_throttling(
+            self.cloudformation.describe_change_set,
+            kwargs={
+                'ChangeSetName': change_set_id,
+            },
+        )
+        if response["Status"] not in ("FAILED", "CREATE_COMPLETE"):
+            time.sleep(2)
+            return self._wait_till_change_set_complete(change_set_id)
+        return response
+
+    def update_stack(self, fqn, template_url, parameters, tags, **kwargs):
+        logger.debug("Attempting to create change set for stack: %s.", fqn)
+        response = retry_on_throttling(
+            self.cloudformation.create_change_set,
+            kwargs={
+                'StackName': fqn,
+                'TemplateURL': template_url,
+                'Parameters': parameters,
+                'Tags': tags,
+                'Capabilities': ["CAPABILITY_IAM"],
+                'ChangeSetName': get_change_set_name(),
+            },
+        )
+        change_set_id = response["Id"]
+        response = self._wait_till_change_set_complete(change_set_id)
+        if response["Status"] == "FAILED":
+            if "didn't contain changes" in response["StatusReason"]:
+                logger.debug(
+                    "Stack %s did not change, not updating.",
+                    fqn,
+                )
+                raise exceptions.StackDidNotChange
+            raise Exception(
+                "Failed to describe change set: {}".format(response)
+            )
+
+        if response["ExecutionStatus"] != "AVAILABLE":
+            raise Exception("Unable to execute change set: {}".format(response))
+
+        print "\nCloudformation wants to make the following changes to stack: {}\n".format(fqn)
+        print yaml.safe_dump(response["Changes"])
+        approve = raw_input("Execute the above changes? [y/n] ")
+        if approve != "y":
+            raise Exception("Don't execute change set")
+
+        retry_on_throttling(
+            self.cloudformation.execute_change_set,
+            kwargs={
+                'ChangeSetName': change_set_id,
+            },
+        )
+        return True


### PR DESCRIPTION
Not ready to merge, but wanted to get it out there to start some discussion around the output:

Right now it looks like:

```
$ ./bin/test-empire build
stacker build conf/empire/example.env conf/empire/empire.yaml --env namespace=mh.empire.dev --env external_domain=empire.com --env ssh_key_name=remind-us-east-1 --env trusted_network_cidr=0.0.0.0/0 --env docker_registry_user=mhahn --env docker_registry_email=mwhahn@gmail.com --env docker_registry_password=aT4Okzn{wbe3SoO8Z --env empiredb_user=empire --env empiredb_password=SomePasswordHere22 --env empire_controller_token_secret=oi234lk2j432lk4j22oiA --env empire_environment=dev
[2016-07-28T13:26:13] Executing pre_build hooks: stacker.hooks.route53.create_domain
[2016-07-28T13:26:14] Launching stacks: mh-empire-dev-vpc, mh-empire-dev-bastion, mh-empire-dev-empireMinion, mh-empire-dev-empireDB, mh-empire-dev-empireController, mh-empire-dev-empireDaemon, mh-empire-dev-acmeApp

Cloudformation wants to make the following changes to stack: mh-empire-dev-empireDaemon

- ResourceChange:
    Action: Modify
    Details:
    - CausingEntity: TaskDefinition
      ChangeSource: ResourceReference
      Evaluation: Static
      Target: {Attribute: Properties, Name: TaskDefinition, RequiresRecreation: Never}
    LogicalResourceId: Service
    PhysicalResourceId: arn:aws:ecs:us-east-1:935008130000:service/mh-empire-dev-empireDaemon-Service-1KBHNP1GPSF5H
    Replacement: 'False'
    ResourceType: AWS::ECS::Service
    Scope: [Properties]
  Type: Resource
- ResourceChange:
    Action: Modify
    Details:
    - CausingEntity: TaskMemory
      ChangeSource: ParameterReference
      Evaluation: Static
      Target: {Attribute: Properties, Name: ContainerDefinitions, RequiresRecreation: Always}
    - ChangeSource: DirectModification
      Evaluation: Dynamic
      Target: {Attribute: Properties, Name: ContainerDefinitions, RequiresRecreation: Always}
    LogicalResourceId: TaskDefinition
    PhysicalResourceId: arn:aws:ecs:us-east-1:935008130000:task-definition/mh-empire-dev-empireDaemon-TaskDefinition-1WGARY55GXE62:1
    Replacement: 'True'
    ResourceType: AWS::ECS::TaskDefinition
    Scope: [Properties]
  Type: Resource

Execute the above changes? [y/n] y
[2016-07-28T13:32:58] Updating existing stack: mh-empire-dev-empireDaemon
[2016-07-28T13:32:58] Plan Status:
[2016-07-28T13:32:58]   - step "mh-empire-dev-vpc": skipped (nochange)
[2016-07-28T13:32:58]   - step "mh-empire-dev-bastion": skipped (nochange)
[2016-07-28T13:32:58]   - step "mh-empire-dev-empireMinion": skipped (nochange)
[2016-07-28T13:32:58]   - step "mh-empire-dev-empireDB": skipped (locked)
[2016-07-28T13:32:58]   - step "mh-empire-dev-empireController": skipped (nochange)
[2016-07-28T13:32:58]   - step "mh-empire-dev-empireDaemon": submitted (updating existing stack)
[2016-07-28T13:32:58]   - step "mh-empire-dev-acmeApp": pending
[2016-07-28T13:33:44] Plan Status:
[2016-07-28T13:33:44]   - step "mh-empire-dev-vpc": skipped (nochange)
[2016-07-28T13:33:44]   - step "mh-empire-dev-bastion": skipped (nochange)
[2016-07-28T13:33:44]   - step "mh-empire-dev-empireMinion": skipped (nochange)
[2016-07-28T13:33:44]   - step "mh-empire-dev-empireDB": skipped (locked)
[2016-07-28T13:33:44]   - step "mh-empire-dev-empireController": skipped (nochange)
[2016-07-28T13:33:44]   - step "mh-empire-dev-empireDaemon": submitted (updating existing stack)
[2016-07-28T13:33:44]   - step "mh-empire-dev-acmeApp": pending
[2016-07-28T13:34:35] Plan Status:
[2016-07-28T13:34:35]   - step "mh-empire-dev-vpc": skipped (nochange)
[2016-07-28T13:34:35]   - step "mh-empire-dev-bastion": skipped (nochange)
[2016-07-28T13:34:35]   - step "mh-empire-dev-empireMinion": skipped (nochange)
[2016-07-28T13:34:35]   - step "mh-empire-dev-empireDB": skipped (locked)
[2016-07-28T13:34:35]   - step "mh-empire-dev-empireController": skipped (nochange)
[2016-07-28T13:34:35]   - step "mh-empire-dev-empireDaemon": submitted (updating existing stack)
[2016-07-28T13:34:35]   - step "mh-empire-dev-acmeApp": pending
[2016-07-28T13:34:43] Plan Status:
[2016-07-28T13:34:43]   - step "mh-empire-dev-vpc": skipped (nochange)
[2016-07-28T13:34:43]   - step "mh-empire-dev-bastion": skipped (nochange)
[2016-07-28T13:34:43]   - step "mh-empire-dev-empireMinion": skipped (nochange)
[2016-07-28T13:34:43]   - step "mh-empire-dev-empireDB": skipped (locked)
[2016-07-28T13:34:43]   - step "mh-empire-dev-empireController": skipped (nochange)
[2016-07-28T13:34:43]   - step "mh-empire-dev-empireDaemon": complete (updating existing stack)
[2016-07-28T13:34:43]   - step "mh-empire-dev-acmeApp": skipped (nochange)
```

I'm going to play with some cli libraries to see if I can come up with something cleaner.