### PR TITLE
Add configuration option for appending to sys.path

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -40,6 +40,15 @@ updating your stacks. By default it uses a bucket named
 If you want to change this, provide the **stacker_bucket** top level key word
 in the config.
 
+Module Paths
+----------------
+When setting the ``classpath`` for blueprints/hooks, it is sometimes desirable to
+load modules from outside the default ``sys.path`` (e.g., to include modules
+inside the same repo as config files).
+
+Adding a path (e.g. ``./``) to the **sys_path** top level key word will allow
+modules from that path location to be used.
+
 Pre & Post Hooks
 ----------------
 

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import sys
 
 import boto3
 import botocore.exceptions
@@ -118,6 +119,8 @@ class BaseAction(object):
         return template_url
 
     def execute(self, *args, **kwargs):
+        if "sys_path" in self.context.config:
+            sys.path.append(self.context.config["sys_path"])
         self.pre_run(*args, **kwargs)
         self.run(*args, **kwargs)
         self.post_run(*args, **kwargs)


### PR DESCRIPTION
I'd like to be able to store my configs and blueprints in the same repository, e.g.:
```
README.md
requirements.txt
conf/config.yaml
conf/dev.env
blueprints/__init__.py
blueprints/bastion.py
```

Currently this isn't possible because [util/load_object_from_string](https://github.com/remind101/stacker/blob/master/stacker/util.py#L133-L148) only loads from the default `sys.path` which doesn't include the top level repo directory (only the system paths and the stacker directory under its pip installed location of `src/stacker/`.

With this commit the yaml configuration file can optionally include a top-level `sys_path` key which will append its value to `sys.path`, e.g. `sys_path: ./`.