### PR TITLE
support mixed parameters referencing / not referencing other stacks

### DIFF
--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -88,6 +88,9 @@ class Stack(object):
                 # support for list of Outputs
                 values = value.split(",")
                 for x in values:
+                    # Skip parameters not referencing another stack
+                    if '::' not in x:
+                        continue
                     stack_name, _ = x.split("::")
                     stack_names.append(stack_name)
             else:

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -277,6 +277,15 @@ class TestFunctions(unittest.TestCase):
         p = resolve_parameters(params, self.bp, self.ctx, self.prov)
         self.assertNotIn("a", p)
 
+    def test_resolve_parameters_list_processing(self):
+        self.bp.parameters = {
+            "a": {
+                "type": "List",
+                "description": "A"}}
+        params = {"a": "Apple,Anchor"}
+        p = resolve_parameters(params, self.bp, self.ctx, self.prov)
+        self.assertEqual(p["a"], "Apple,Anchor")
+
     def test_resolve_parameters_resolve_outputs(self):
         self.bp.parameters = {
             "a": {


### PR DESCRIPTION
Currently parameters can reference multiple outputs in other stacks:
```
SomeParameter: stack1::Output1,stack2::Output2
```

This commit allows parameter lists to also include variables not
referencing another stack, e.g.:
```
SomeParameter: ${ThingInEnvFile},stack1::Output1
```

I considered updating the documentation in [Using Outputs as Parameters](https://github.com/remind101/stacker/blob/master/docs/config.rst#using-outputs-as-parameters), but I'm not sure how to change the last part ("You can also pull multiple...") to note the functionality. Maybe a new section? Maybe the new functionality doesn't need to be called out?