### PR TITLE
Re-add boto2 dep to fix broken hooks imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ src_dir = os.path.dirname(__file__)
 
 install_requires = [
     "troposphere>=1.2.2",
+    "boto>=2.42",
     "boto3>=1.3.1",
     "botocore>=1.4.38",
     "PyYAML>=3.11",


### PR DESCRIPTION
This should patch up #187 to unblock #183. boto2 and boto3 will happily co-exist until each of the hooks is migrated to the boto3 equivalent. Not sure how I missed this before...