### PR TITLE
Reduce the verbosity of stacker output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     "botocore>=1.4.38",
     "PyYAML>=3.11",
     "awacs>=0.5.3",
+    "colorama==0.3.7",
 ]
 
 tests_require = [

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -49,7 +49,7 @@ def should_submit(stack):
     if stack.enabled:
         return True
 
-    logger.info("Stack %s is not enabled.  Skipping.", stack.name)
+    logger.debug("Stack %s is not enabled.  Skipping.", stack.name)
     return False
 
 
@@ -208,7 +208,7 @@ class Action(BaseAction):
 
         if not provider_stack:
             new_status = SubmittedStatus("creating new stack")
-            logger.info("Creating new stack: %s", stack.fqn)
+            logger.debug("Creating new stack: %s", stack.fqn)
             self.provider.create_stack(stack.fqn, template_url, parameters,
                                        tags)
         else:
@@ -218,7 +218,7 @@ class Action(BaseAction):
                 new_status = SubmittedStatus("updating existing stack")
                 self.provider.update_stack(stack.fqn, template_url, parameters,
                                            tags)
-                logger.info("Updating existing stack: %s", stack.fqn)
+                logger.debug("Updating existing stack: %s", stack.fqn)
             except StackDidNotChange:
                 return DidNotChangeStatus()
 
@@ -297,7 +297,7 @@ class Action(BaseAction):
         plan = self._generate_plan(tail=tail)
         if not outline and not dump:
             plan.outline(logging.DEBUG)
-            logger.info("Launching stacks: %s", ", ".join(plan.keys()))
+            logger.debug("Launching stacks: %s", ", ".join(plan.keys()))
             plan.execute()
         else:
             if outline:

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -82,7 +82,7 @@ class Action(BaseAction):
         elif self.provider.is_stack_in_progress(provider_stack):
             return DestroyingStatus
         else:
-            logger.info("Destroying stack: %s", stack.fqn)
+            logger.debug("Destroying stack: %s", stack.fqn)
             self.provider.destroy_stack(provider_stack)
         return DestroyingStatus
 

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -2,6 +2,8 @@ import argparse
 from collections import Mapping
 import logging
 
+from ...logger.handler import LogLoopStreamHandler
+
 from ...environment import parse_environment
 
 DEBUG_FORMAT = ("[%(asctime)s] %(levelname)s %(name)s:%(lineno)d"
@@ -97,11 +99,11 @@ class BaseCommand(object):
         if verbosity < 2:
             logging.getLogger("botocore").setLevel(logging.CRITICAL)
 
-        return logging.basicConfig(
-            format=log_format,
-            datefmt=ISO_8601,
-            level=log_level,
-        )
+        fmt = logging.Formatter(log_format, ISO_8601)
+        hdlr = LogLoopStreamHandler()
+        hdlr.setFormatter(fmt)
+        logging.root.addHandler(hdlr)
+        logging.root.setLevel(log_level)
 
     def parse_args(self, *vargs):
         parser = argparse.ArgumentParser(description=self.description)

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -2,15 +2,8 @@ import argparse
 from collections import Mapping
 import logging
 
-from ...logger.handler import LogLoopStreamHandler
-
 from ...environment import parse_environment
-
-DEBUG_FORMAT = ("[%(asctime)s] %(levelname)s %(name)s:%(lineno)d"
-                "(%(funcName)s): %(message)s")
-INFO_FORMAT = ("[%(asctime)s] %(message)s")
-
-ISO_8601 = "%Y-%m-%dT%H:%M:%S"
+from ...logger import setup_logging
 
 
 class KeyValueAction(argparse.Action):
@@ -90,21 +83,6 @@ class BaseCommand(object):
             self._logger = logging.getLogger(self.name)
         return self._logger
 
-    def setup_logging(self, verbosity):
-        log_level = logging.INFO
-        log_format = INFO_FORMAT
-        if verbosity > 0:
-            log_level = logging.DEBUG
-            log_format = DEBUG_FORMAT
-        if verbosity < 2:
-            logging.getLogger("botocore").setLevel(logging.CRITICAL)
-
-        fmt = logging.Formatter(log_format, ISO_8601)
-        hdlr = LogLoopStreamHandler()
-        hdlr.setFormatter(fmt)
-        logging.root.addHandler(hdlr)
-        logging.root.setLevel(log_level)
-
     def parse_args(self, *vargs):
         parser = argparse.ArgumentParser(description=self.description)
         self.add_subcommands(parser)
@@ -117,7 +95,7 @@ class BaseCommand(object):
         pass
 
     def configure(self, options, **kwargs):
-        self.setup_logging(options.verbose)
+        setup_logging(options.verbose, options.interactive)
 
     def get_context_kwargs(self, options, **kwargs):
         """Return a dictionary of kwargs that will be used with the Context.

--- a/stacker/logger/__init__.py
+++ b/stacker/logger/__init__.py
@@ -1,0 +1,40 @@
+import sys
+import logging
+
+from .handler import LogLoopStreamHandler
+from .formatter import ColorFormatter
+
+DEBUG_FORMAT = ("[%(asctime)s] %(levelname)s %(name)s:%(lineno)d"
+                "(%(funcName)s): %(message)s")
+INFO_FORMAT = ("[%(asctime)s] %(message)s")
+COLOR_FORMAT = ("[%(asctime)s] %(color)s%(message)s")
+
+ISO_8601 = "%Y-%m-%dT%H:%M:%S"
+
+
+def setup_logging(verbosity, interactive):
+    enable_loop_logger = (
+        verbosity == 0 and
+        sys.stdout.isatty() and
+        not interactive
+    )
+    log_level = logging.INFO
+    log_format = INFO_FORMAT
+    if verbosity > 0:
+        log_level = logging.DEBUG
+        log_format = DEBUG_FORMAT
+    if verbosity < 2:
+        logging.getLogger("botocore").setLevel(logging.CRITICAL)
+
+    if enable_loop_logger:
+        fmt = ColorFormatter(COLOR_FORMAT, ISO_8601)
+        hdlr = LogLoopStreamHandler()
+        hdlr.setFormatter(fmt)
+        logging.root.addHandler(hdlr)
+        logging.root.setLevel(log_level)
+    else:
+        logging.basicConfig(
+            format=log_format,
+            datefmt=ISO_8601,
+            level=log_level,
+        )

--- a/stacker/logger/formatter.py
+++ b/stacker/logger/formatter.py
@@ -1,0 +1,11 @@
+from logging import Formatter
+from colorama.ansi import Fore
+
+
+class ColorFormatter(Formatter):
+
+    def format(self, record):
+        if 'color' not in record.__dict__:
+            record.__dict__['color'] = Fore.WHITE
+        msg = super(ColorFormatter, self).format(record)
+        return msg + Fore.RESET

--- a/stacker/logger/handler.py
+++ b/stacker/logger/handler.py
@@ -1,0 +1,35 @@
+from logging import StreamHandler
+from colorama.ansi import (
+    Cursor,
+    clear_line,
+)
+
+
+class LogLoopStreamHandler(StreamHandler):
+
+    def __init__(self, *args, **kwargs):
+        super(LogLoopStreamHandler, self).__init__(*args, **kwargs)
+        self.loops = {}
+
+    def format(self, record):
+        msg = super(LogLoopStreamHandler, self).format(record)
+        if record.__dict__.get("loop"):
+            msg = "{}{}".format(clear_line(), msg)
+        return msg
+
+    def emit(self, record):
+        stream = self.stream
+        loop_id = record.__dict__.get("loop")
+        index = record.__dict__.get("index")
+        if loop_id:
+            first = loop_id not in self.loops
+            if first:
+                self.loops[loop_id] = 0
+
+            count = self.loops[loop_id]
+            if not first and index == 0:
+                self.loops[loop_id] = 0
+                stream.write("{}\n".format(Cursor.UP(count + 1)))
+                stream.flush()
+            self.loops[loop_id] += 1
+        return super(LogLoopStreamHandler, self).emit(record)

--- a/stacker/logger/handler.py
+++ b/stacker/logger/handler.py
@@ -21,6 +21,10 @@ class LogLoopStreamHandler(StreamHandler):
         stream = self.stream
         loop_id = record.__dict__.get("loop")
         reset = record.__dict__.get("reset")
+        last_updated = record.__dict__.get("last_updated")
+        if last_updated:
+            record.__dict__["created"] = last_updated
+
         if loop_id:
             first = loop_id not in self.loops
             if first:

--- a/stacker/logger/handler.py
+++ b/stacker/logger/handler.py
@@ -20,14 +20,14 @@ class LogLoopStreamHandler(StreamHandler):
     def emit(self, record):
         stream = self.stream
         loop_id = record.__dict__.get("loop")
-        index = record.__dict__.get("index")
+        reset = record.__dict__.get("reset")
         if loop_id:
             first = loop_id not in self.loops
             if first:
                 self.loops[loop_id] = 0
 
             count = self.loops[loop_id]
-            if not first and index == 0:
+            if not first and reset:
                 self.loops[loop_id] = 0
                 stream.write("{}\n".format(Cursor.UP(count + 1)))
                 stream.flush()

--- a/stacker/logger/handler.py
+++ b/stacker/logger/handler.py
@@ -6,6 +6,15 @@ from colorama.ansi import (
 
 
 class LogLoopStreamHandler(StreamHandler):
+    """Logging handler that supports updating log lines while in a loop.
+
+    This is used within the Stacker Plan to make the output while waiting for
+    stacks to complete less verbose. Without this handler, the plan status
+    would be logged as N number of lines each time we output the checkpoint.
+    With this handler, we'll output the plan status once and keep updating the
+    same lines with updated values.
+
+    """
 
     def __init__(self, *args, **kwargs):
         super(LogLoopStreamHandler, self).__init__(*args, **kwargs)

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -318,11 +318,25 @@ class Plan(OrderedDict):
             COMPLETE.code: Fore.GREEN,
         }
         logger.info("Plan Status:", extra={"reset": True, "loop": self.id})
+
+        longest = 0
+        messages = []
         for step_name, step in self.iteritems():
-            msg = "  - step \"%s\": %s" % (step_name, step.status.name)
+            length = len(step_name)
+            if length > longest:
+                longest = length
+
+            msg = "%s: %s" % (step_name, step.status.name)
             if step.status.reason:
                 msg += " (%s)" % (step.status.reason)
-            logger.info(msg, extra={
+
+            color = status_to_color.get(step.status.code, Fore.WHITE)
+            messages.append((msg, color))
+
+        for msg, color in messages:
+            parts = msg.split(' ', 1)
+            fmt = "\t{0: <%d}{1}" % (longest + 2,)
+            logger.info(fmt.format(*parts), extra={
                 'loop': self.id,
-                'color': status_to_color.get(step.status.code, Fore.WHITE),
+                'color': color,
             })

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -241,9 +241,13 @@ class Plan(OrderedDict):
         submit them in parallel based on their dependencies.
         """
 
+        attempts = 0
         try:
             while not self.completed:
-                self._check_point()
+                if not attempts % 10:
+                    self._check_point()
+
+                attempts += 1
                 if not self._single_run():
                     self._wait_func(self.sleep_time)
         except CancelExecution:

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -43,6 +43,7 @@ class Step(object):
         self.status = PENDING
         self.requires = requires or []
         self._run_func = run_func
+        self.last_updated = time.time()
 
     def __repr__(self):
         return "<stacker.plan.Step:%s>" % (self.stack.fqn,)
@@ -81,6 +82,7 @@ class Step(object):
             logger.debug("Setting %s state to %s.", self.stack.name,
                          status.name)
             self.status = status
+            self.last_updated = time.time()
 
     def complete(self):
         """A shortcut for set_status(COMPLETE)"""
@@ -330,13 +332,14 @@ class Plan(OrderedDict):
             if step.status.reason:
                 msg += " (%s)" % (step.status.reason)
 
-            color = status_to_color.get(step.status.code, Fore.WHITE)
-            messages.append((msg, color))
+            messages.append((msg, step))
 
-        for msg, color in messages:
+        for msg, step in messages:
             parts = msg.split(' ', 1)
             fmt = "\t{0: <%d}{1}" % (longest + 2,)
+            color = status_to_color.get(step.status.code, Fore.WHITE)
             logger.info(fmt.format(*parts), extra={
                 'loop': self.id,
                 'color': color,
+                'last_updated': step.last_updated,
             })

--- a/stacker/tests/logger.py
+++ b/stacker/tests/logger.py
@@ -4,11 +4,13 @@ import uuid
 
 from colorama.ansi import (
     Cursor,
+    Fore,
     clear_line,
 )
 from mock import MagicMock
 
 from ...logger.handler import LogLoopStreamHandler
+from ...logger.formatter import ColorFormatter
 
 
 class TestLogStreamLoopHandler(unittest.TestCase):
@@ -30,8 +32,8 @@ class TestLogStreamLoopHandler(unittest.TestCase):
             for i in range(3):
                 record = makeLogRecord({
                     'msg': 'test {}'.format(i),
-                    'index': i,
                     'loop': loop_id,
+                    'reset': i == 0,
                 })
                 self.handler.emit(record)
             loop += 1
@@ -45,3 +47,14 @@ class TestLogStreamLoopHandler(unittest.TestCase):
                 self.assertTrue(line.startswith(Cursor.UP(4)))
             else:
                 self.assertTrue(line.startswith(clear_line()))
+
+
+class TestColorFormatter(unittest.TestCase):
+
+    def setUp(self):
+        self.formatter = ColorFormatter()
+
+    def test_always_end_in_reset(self):
+        record = makeLogRecord({'msg': 'test'})
+        fmt = self.formatter.format(record)
+        self.assertTrue(fmt.endswith(Fore.RESET))

--- a/stacker/tests/logger/test_handler.py
+++ b/stacker/tests/logger/test_handler.py
@@ -1,0 +1,47 @@
+from logging import makeLogRecord
+import unittest
+import uuid
+
+from colorama.ansi import (
+    Cursor,
+    clear_line,
+)
+from mock import MagicMock
+
+from ...logger.handler import LogLoopStreamHandler
+
+
+class TestLogStreamLoopHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.stream = MagicMock()
+        self.handler = LogLoopStreamHandler(self.stream)
+
+    def test_emit_normal_record(self):
+        record = makeLogRecord({'msg': 'test'})
+        self.handler.emit(record)
+        self.assertEqual(self.stream.write.call_count, 1)
+        self.assertEqual(self.stream.write.call_args[0][0], 'test\n')
+
+    def test_emit_loop_record(self):
+        loop = 0
+        loop_id = uuid.uuid4()
+        while loop < 2:
+            for i in range(3):
+                record = makeLogRecord({
+                    'msg': 'test {}'.format(i),
+                    'index': i,
+                    'loop': loop_id,
+                })
+                self.handler.emit(record)
+            loop += 1
+
+        self.assertEqual(len(self.stream.write.call_args_list), 7,
+                         'Should have accounted for moving cursor up')
+
+        for index, arg in enumerate(self.stream.write.call_args_list):
+            line = arg[0][0]
+            if index == 3:
+                self.assertTrue(line.startswith(Cursor.UP(4)))
+            else:
+                self.assertTrue(line.startswith(clear_line()))


### PR DESCRIPTION
This leverages colorama and a custom log handler to continually update the same lines when outputting the plan status.

Output looks like:

![image](https://cloud.githubusercontent.com/assets/704593/17419773/cb34e750-5a53-11e6-8e12-cd9d8df9bac7.png)

and will continue to update the same lines as the stack updates, ie:

![image](https://cloud.githubusercontent.com/assets/704593/17419782/dba5d1bc-5a53-11e6-92bb-8ea15e527008.png)

Fixes: https://github.com/remind101/stacker/issues/170