### PR TITLE
Fix traceback on interactive provider when adding resources

### DIFF
--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -80,7 +80,7 @@ def output_summary(fqn, action, changeset, replacements_only=False):
     changes = []
     for change in changeset:
         resource = change['ResourceChange']
-        replacement = resource['Replacement'] == 'True'
+        replacement = resource.get('Replacement') == 'True'
         summary = '- %s %s (%s)' % (
             resource['Action'],
             resource['LogicalResourceId'],


### PR DESCRIPTION
It seems it's possible for resources to omit the 'Replacement' key
instead of setting it to false. Handle that case instead of assuming the
key is always present.

Fixes a traceback like the following: 

```
Traceback (most recent call last):
  File "/home/danielkza/bin/stacker", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/danielkza/src/stacker/scripts/stacker", line 9, in <module>
    args.run(args)
  File "/home/danielkza/src/stacker/stacker/commands/stacker/build.py", line 52, in run
    dump=options.dump)
  File "/home/danielkza/src/stacker/stacker/actions/base.py", line 125, in execute
    self.run(*args, **kwargs)
  File "/home/danielkza/src/stacker/stacker/actions/build.py", line 301, in run
    plan.execute()
  File "/home/danielkza/src/stacker/stacker/plan.py", line 251, in execute
    if not self._single_run():
  File "/home/danielkza/src/stacker/stacker/plan.py", line 219, in _single_run
    status = step.run()
  File "/home/danielkza/src/stacker/stacker/plan.py", line 72, in run
    return self._run_func(self.stack, status=self.status)
  File "/home/danielkza/src/stacker/stacker/actions/build.py", line 220, in _launch_stack
    tags)
  File "/home/danielkza/src/stacker/stacker/providers/aws/interactive.py", line 164, in update_stack
    replacements_only=self.replacements_only)
  File "/home/danielkza/src/stacker/stacker/providers/aws/interactive.py", line 83, in output_summary
    replacement = resource['Replacement'] == 'True'
KeyError: 'Replacement'
```