### PR TITLE
Support lookups returning non-string values

### DIFF
--- a/docs/lookups.rst
+++ b/docs/lookups.rst
@@ -14,6 +14,19 @@ Lookups are only resolved within `Variables
 <terminology.html#variables>`_. They can be nested in any part of a YAML
 data structure and within another lookup itself.
 
+.. note::
+  If a lookup has a non-string return value, it can be the only lookup
+  within a value.
+
+  ie. if `custom` returns a list, this would raise an exception::
+
+    Variable: ${custom something}, ${otherStack::Output}
+
+  This is valid::
+
+    Variable: ${custom something}
+
+
 For example, given the following::
 
   stacks:

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -285,11 +285,12 @@ class Blueprint(object):
                 if isinstance(var_type, CFNType):
                     value = CFNParameter(name=var_name, value=value)
                 else:
-                    try:
-                        value = var_type(value)
-                    except ValueError:
-                        raise ValueError("Variable %s must be %s.", var_name,
-                                         var_type)
+                    if not isinstance(value, var_type):
+                        try:
+                            value = var_type(value)
+                        except ValueError:
+                            raise ValueError("Variable %s must be %s.",
+                                             var_name, var_type)
             self.resolved_variables[var_name] = value
 
     def import_mappings(self):

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -1,3 +1,13 @@
+class InvalidLookupCombination(Exception):
+
+    def __init__(self, lookup, lookups, value, *args, **kwargs):
+        message = (
+            "Lookup: \"{}\" has non-string return value, must be only lookup "
+            "present (not {}) in \"{}\""
+        ).format(lookup.raw, len(lookups), value)
+        super(InvalidLookupCombination, self).__init__(message, *args, **kwargs)
+
+
 class UnknownLookupType(Exception):
 
     def __init__(self, lookup, *args, **kwargs):

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -1,3 +1,4 @@
+from stacker.lookups import Lookup
 
 
 def generate_definition(base_name, stack_id, **overrides):
@@ -14,3 +15,9 @@ def generate_definition(base_name, stack_id, **overrides):
     }
     definition.update(overrides)
     return definition
+
+
+def mock_lookup(lookup_input, lookup_type='output', raw=None):
+    if raw is None:
+        raw = lookup_input
+    return Lookup(type=lookup_type, input=lookup_input, raw=raw)

--- a/stacker/tests/test_variables.py
+++ b/stacker/tests/test_variables.py
@@ -2,16 +2,9 @@ from mock import MagicMock
 import unittest
 
 from stacker.variables import Variable
-from stacker.lookups import (
-    Lookup,
-    register_lookup_handler,
-)
+from stacker.lookups import register_lookup_handler
 
-
-def mock_lookup(lookup_input, lookup_type='output', raw=None):
-    if raw is None:
-        raw = lookup_input
-    return Lookup(type=lookup_type, input=lookup_input, raw=raw)
+from .factories import mock_lookup
 
 
 class TestVariables(unittest.TestCase):

--- a/stacker/variables.py
+++ b/stacker/variables.py
@@ -1,5 +1,6 @@
 from string import Template
 
+from .exceptions import InvalidLookupCombination
 from .lookups import (
     extract_lookups,
     resolve_lookups,
@@ -22,6 +23,13 @@ def resolve_string(value, replacements):
         str: value with any lookups resolved
 
     """
+    lookups = extract_lookups(value)
+    for lookup in lookups:
+        lookup_value = replacements.get(lookup.raw)
+        if not isinstance(lookup_value, basestring):
+            if len(lookups) > 1:
+                raise InvalidLookupCombination(lookup, lookups, value)
+            return lookup_value
     # we use safe_substitute to support resolving nested lookups
     return LookupTemplate(value).safe_substitute(replacements)
 


### PR DESCRIPTION
Fixes: https://github.com/remind101/stacker/issues/214

One caveat is that you need to make sure the variable definition uses the correct type in the blueprint. 

ie: https://github.com/remind101/stacker/pull/216/files#diff-a5840ad0d3853c3a46851aabf2324832R150