### PR TITLE
Add custom validator to blueprint variables

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -45,6 +45,13 @@ supports the following optional keys:
 **description:**
   A string that describes the purpose of the variable.
 
+**validator:**
+  An optional function that can do custom validation of the variable. A
+  validator function should take a single argument, the value being validated,
+  and should return the value if validation is successful. If there is an
+  issue validating the value, an exception (``ValueError``, ``TypeError``, etc)
+  should be raised by the function.
+
 **no_echo:**
   Only valid for variables whose type subclasses ``CFNType``. Whether to
   mask the parameter value whenever anyone makes a call that describes the
@@ -80,6 +87,7 @@ supports the following optional keys:
   Only valid for variables whose type subclasses ``CFNType``. A string
   that explains the constraint when the constraint is violated for the
   CloudFormation Parameter.
+
 
 Variable Types
 ==============

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -13,6 +13,7 @@ from ..exceptions import (
     MissingVariable,
     UnresolvedVariable,
     UnresolvedVariables,
+    ValidatorError,
     VariableTypeRequired,
 )
 from .variables.types import CFNType
@@ -206,7 +207,10 @@ def resolve_variable(var_name, var_def, provided_variable, blueprint_name):
 
     # If no validator, return the value as is, otherwise apply validator
     validator = var_def.get("validator", lambda v: v)
-    value = validator(value)
+    try:
+        value = validator(value)
+    except Exception as exc:
+        raise ValidatorError(var_name, validator.__name__, value, exc)
 
     # Ensure that the resulting value is the correct type
     var_type = var_def.get("type")

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -185,6 +185,8 @@ def resolve_variable(var_name, var_def, provided_variable, blueprint_name):
         ValueError: Raised when the value is not the right type and cannot be
             cast as the correct type. Raised by
             :func:`stacker.blueprints.base.validate_variable_type`
+        ValidatorError: Raised when a validator raises an exception. Wraps the
+            original exception.
     """
 
     try:

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -117,3 +117,22 @@ class StackDidNotChange(Exception):
 
 class CancelExecution(Exception):
     """Exception raised when we want to cancel executing the plan."""
+
+
+class ValidatorError(Exception):
+    """Used for errors raised by custom validators of blueprint variables.
+    """
+    def __init__(self, variable, validator, value, exception=None):
+        self.variable = variable
+        self.validator = validator
+        self.value = value
+        self.exception = exception
+        self.message = ("Validator '%s' failed for variable '%s' with value "
+                        "'%s'") % (self.validator, self.variable, self.value)
+
+        if self.exception:
+            self.message += ": %s: %s" % (self.exception.__class__.__name__,
+                                          str(self.exception))
+
+    def __str__(self):
+        return self.message

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -5,7 +5,8 @@ class InvalidLookupCombination(Exception):
             "Lookup: \"{}\" has non-string return value, must be only lookup "
             "present (not {}) in \"{}\""
         ).format(lookup.raw, len(lookups), value)
-        super(InvalidLookupCombination, self).__init__(message, *args, **kwargs)
+        super(InvalidLookupCombination, self).__init__(message, *args,
+                                                       **kwargs)
 
 
 class UnknownLookupType(Exception):
@@ -17,26 +18,39 @@ class UnknownLookupType(Exception):
 
 class UnresolvedVariables(Exception):
 
-    def __init__(self, blueprint, *args, **kwargs):
+    def __init__(self, blueprint_name, *args, **kwargs):
         message = "Blueprint: \"%s\" hasn't resolved it's variables" % (
-            blueprint.name)
+            blueprint_name)
         super(UnresolvedVariables, self).__init__(message, *args, **kwargs)
 
 
 class UnresolvedVariable(Exception):
 
-    def __init__(self, blueprint, variable, *args, **kwargs):
-        message = "Variable \"%s\" in blueprint \"%s\" hasn't been resolved" % (
-            variable.name, blueprint.name)
+    def __init__(self, blueprint_name, variable, *args, **kwargs):
+        message = (
+            "Variable \"%s\" in blueprint \"%s\" hasn't been resolved" % (
+                variable.name, blueprint_name
+            )
+        )
         super(UnresolvedVariable, self).__init__(message, *args, **kwargs)
 
 
 class MissingVariable(Exception):
 
-    def __init__(self, blueprint, variable_name, *args, **kwargs):
+    def __init__(self, blueprint_name, variable_name, *args, **kwargs):
         message = "Variable \"%s\" in blueprint \"%s\" is missing" % (
-            variable_name, blueprint.name)
+            variable_name, blueprint_name)
         super(MissingVariable, self).__init__(message, *args, **kwargs)
+
+
+class VariableTypeRequired(Exception):
+
+    def __init__(self, blueprint_name, variable_name, *args, **kwargs):
+        message = (
+            "Variable \"%s\" in blueprint \"%s\" does not have a type" % (
+                variable_name, blueprint_name)
+        )
+        super(VariableTypeRequired, self).__init__(message, *args, **kwargs)
 
 
 class StackDoesNotExist(Exception):

--- a/stacker/lookups/__init__.py
+++ b/stacker/lookups/__init__.py
@@ -27,7 +27,7 @@ def extract_lookups_from_string(value):
         value (str): string value we're extracting lookups from
 
     Returns:
-        list: list of lookups if any
+        list: list of :class:`stacker.lookups.Lookup` if any
 
     """
     lookups = set()

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -24,6 +24,7 @@ from stacker.exceptions import (
     MissingVariable,
     UnresolvedVariable,
     UnresolvedVariables,
+    ValidatorError,
     VariableTypeRequired,
 )
 from stacker.variables import Variable
@@ -215,7 +216,7 @@ class TestVariables(unittest.TestCase):
     def test_resolve_variable_validator_invalid_value(self):
         def triple_validator(value):
             if len(value) != 3:
-                raise ValueError
+                raise ValueError("Must be a triple.")
             return value
 
         var_name = "testVar"
@@ -224,9 +225,12 @@ class TestVariables(unittest.TestCase):
         provided_variable = Variable(var_name, var_value)
         blueprint_name = "testBlueprint"
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValidatorError) as cm:
             resolve_variable(var_name, var_def, provided_variable,
                              blueprint_name)
+
+        exc = cm.exception.exception  # The wrapped exception
+        self.assertIsInstance(exc, ValueError)
 
     def test_resolve_variables(self):
         class TestBlueprint(Blueprint):

--- a/stacker/variables.py
+++ b/stacker/variables.py
@@ -94,6 +94,13 @@ class Variable(object):
         return extract_lookups(self.value)
 
     @property
+    def needs_resolution(self):
+        """Return True if the value has any lookups that need resolving."""
+        if self.lookups:
+            return True
+        return False
+
+    @property
     def value(self):
         """Return the current value of the Variable.
 
@@ -109,7 +116,7 @@ class Variable(object):
         Variables only need to be resolved if they contain lookups.
 
         """
-        if self.lookups:
+        if self.needs_resolution:
             return self._resolved_value is not None
         return True
 


### PR DESCRIPTION
- Now all blueprint variables must provide a `type`, otherwise an
  exception is thrown.

Before it wasn't required, and the type was ignored if it wasn't
provided. That didn't seem right to me, but I realize I may just not
have understood the implications.

Other changes:

- variable resolution now done in a function not a class method
- moved variable type validation to a function
- instead of passing the whole blueprint just to use it's name, I just
  pass the blueprints name into the exceptions that use them (that was
  all the blueprint was used for it appeared)

I'll add docs in the next checkin.