### PR TITLE
Ignore too many arguments from pylint

### DIFF
--- a/stacker/context.py
+++ b/stacker/context.py
@@ -39,7 +39,8 @@ class Context(object):
 
     """
 
-    def __init__(self, environment, stack_names=None,
+    def __init__(self, environment,  # pylint: disable-msg=too-many-arguments
+                 stack_names=None,
                  parameters=None, mappings=None, config=None,
                  force_stacks=None):
         try:


### PR DESCRIPTION
We actually have a good reason for these arguments, and I don't think
that changing the code to accept a dictionary or list instead of
individual arguments actually cleans it up.