### PR TITLE
Cleanup misc flake8 errors in prep for auto-running

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -98,8 +98,8 @@ class BaseAction(object):
         template_url = self.stack_template_url(blueprint)
         self.ensure_cfn_bucket()
         try:
-            template_exists = self.s3_conn.head_object(Bucket=self.bucket_name,
-                                                       Key=key_name) is not None
+            template_exists = self.s3_conn.head_object(
+                Bucket=self.bucket_name, Key=key_name) is not None
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == '404':
                 template_exists = False

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -166,11 +166,15 @@ class Action(BaseAction):
         parameters = self._handle_missing_parameters(parameters,
                                                      required_params,
                                                      provider_stack)
-        return [{'ParameterKey': p[0], 'ParameterValue': str(p[1])} for p in parameters]
+        return [
+            {'ParameterKey': p[0],
+             'ParameterValue': str(p[1])} for p in parameters
+        ]
 
     def _build_stack_tags(self, stack):
         """Builds a common set of tags to attach to a stack"""
-        return [{'Key': t[0], 'Value': t[1]} for t in self.context.tags.items()]
+        return [
+            {'Key': t[0], 'Value': t[1]} for t in self.context.tags.items()]
 
     def _launch_stack(self, stack, **kwargs):
         """Handles the creating or updating of a stack in CloudFormation.
@@ -238,8 +242,8 @@ class Action(BaseAction):
         Args:
             params (dict): key/value dictionary of stack definition parameters
             required_params (list): A list of required parameter names.
-            existing_stack (dict): A dict representation of the stack. If provided, will be searched for any missing
-                parameters.
+            existing_stack (dict): A dict representation of the stack. If
+                provided, will be searched for any missing parameters.
 
         Returns:
             list of tuples: The final list of key/value pairs returned as a

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -107,7 +107,9 @@ class Action(build.Action):
     def _print_new_stack(self, stack, parameters):
         """Prints out the parameters & stack contents of a new stack"""
         print "New template parameters:"
-        for param in sorted(parameters, key=lambda param: param['ParameterKey']):
+        for param in sorted(
+                parameters,
+                key=lambda param: param['ParameterKey']):
             print "%s = %s" % (param['ParameterKey'], param['ParameterValue'])
 
         print "\nNew template contents:"

--- a/stacker/actions/info.py
+++ b/stacker/actions/info.py
@@ -25,4 +25,8 @@ class Action(BaseAction):
             logger.info('%s:', stack.fqn)
             if 'Outputs' in provider_stack:
                 for output in provider_stack['Outputs']:
-                    logger.info('\t%s: %s', output['OutputKey'], output['OutputValue'])
+                    logger.info(
+                        '\t%s: %s',
+                        output['OutputKey'],
+                        output['OutputValue']
+                    )

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -153,9 +153,10 @@ class BaseCommand(object):
                             "will use the AWS interactive provider, which "
                             "leverages Cloudformation Change Sets to display "
                             "changes before running cloudformation templates. "
-                            "You'll be asked if you want to execute each change "
-                            "set. If you only want to authorize replacements, "
-                            "run with \"--replacements-only\" as well.")
+                            "You'll be asked if you want to execute each "
+                            "change set. If you only want to authorize "
+                            "replacements, run with \"--replacements-only\" "
+                            "as well.")
         parser.add_argument("--replacements-only", action="store_true",
-                            help="If interactive mode is enabled, stacker will "
-                            "only prompt to authorize replacements.")
+                            help="If interactive mode is enabled, stacker "
+                            "will only prompt to authorize replacements.")

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -5,7 +5,9 @@ class InvalidLookupCombination(Exception):
             "Lookup: \"{}\" has non-string return value, must be only lookup "
             "present (not {}) in \"{}\""
         ).format(lookup.raw, len(lookups), value)
-        super(InvalidLookupCombination, self).__init__(message, *args, **kwargs)
+        super(InvalidLookupCombination, self).__init__(message,
+                                                       *args,
+                                                       **kwargs)
 
 
 class UnknownLookupType(Exception):
@@ -26,8 +28,9 @@ class UnresolvedVariables(Exception):
 class UnresolvedVariable(Exception):
 
     def __init__(self, blueprint, variable, *args, **kwargs):
-        message = "Variable \"%s\" in blueprint \"%s\" hasn't been resolved" % (
-            variable.name, blueprint.name)
+        message = (
+            "Variable \"%s\" in blueprint \"%s\" hasn't been resolved"
+        ) % (variable.name, blueprint.name)
         super(UnresolvedVariable, self).__init__(message, *args, **kwargs)
 
 

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -7,11 +7,13 @@ from . import utils
 
 logger = logging.getLogger(__name__)
 
+
 def find(lst, key, value):
     for i, dic in enumerate(lst):
         if dic[key] == value:
             return lst[i]
     return False
+
 
 def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
     client = boto3.client('ec2', region_name=region)

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -60,7 +60,8 @@ def retry_on_throttling(fn, attempts=3, args=None, kwargs=None):
         Returns:
              boolean: indicating whether this error is a throttling error
         """
-        if exc.response['ResponseMetadata']['HTTPStatusCode'] == 400 and exc.response['Error']['Code'] == "Throttling":
+        if exc.response['ResponseMetadata']['HTTPStatusCode'] == 400 and \
+                exc.response['Error']['Code'] == "Throttling":
             logger.debug("AWS throttling calls.")
             return True
         return False
@@ -105,8 +106,9 @@ class Provider(BaseProvider):
 
     def get_stack(self, stack_name, **kwargs):
         try:
-            return retry_on_throttling(self.cloudformation.describe_stacks,
-                                       kwargs=dict(StackName=stack_name))['Stacks'][0]
+            return retry_on_throttling(
+                self.cloudformation.describe_stacks,
+                kwargs=dict(StackName=stack_name))['Stacks'][0]
         except botocore.exceptions.ClientError as e:
             if "does not exist" not in e.message:
                 raise
@@ -151,7 +153,9 @@ class Provider(BaseProvider):
 
     @staticmethod
     def _tail_print(e):
-        print("%s %s %s" % (e['ResourceStatus'], e['ResourceType'], e['EventId']))
+        print("%s %s %s" % (e['ResourceStatus'],
+                            e['ResourceType'],
+                            e['EventId']))
 
     def get_events(self, stackname):
         """Get the events in batches and return in chronological order"""
@@ -159,9 +163,13 @@ class Provider(BaseProvider):
         event_list = []
         while 1:
             if next_token is not None:
-                events = self.cloudformation.describe_stack_events(StackName=stackname, NextToken=next_token)
+                events = self.cloudformation.describe_stack_events(
+                    StackName=stackname, NextToken=next_token
+                )
             else:
-                events = self.cloudformation.describe_stack_events(StackName=stackname)
+                events = self.cloudformation.describe_stack_events(
+                    StackName=stackname
+                )
             event_list.append(events['StackEvents'])
             next_token = events.get('NextToken', None)
             if next_token is None:

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -152,7 +152,8 @@ class Provider(AWSProvider):
             )
 
         if response["ExecutionStatus"] != "AVAILABLE":
-            raise Exception("Unable to execute change set: {}".format(response))
+            raise Exception("Unable to execute change set: "
+                            "{}".format(response))
 
         action = "replacements" if self.replacements_only else "changes"
         changeset = response["Changes"]

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -19,7 +19,10 @@ from stacker.status import (
 
 def mock_stack(parameters):
     return {
-        'Parameters': [{'ParameterKey': k, 'ParameterValue': v} for k, v in parameters.items()]
+        'Parameters': [
+            {'ParameterKey': k, 'ParameterValue': v} for k, v in
+            parameters.items()
+        ]
     }
 
 

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -1,6 +1,5 @@
 import unittest
 
-from mock import patch
 from stacker.config import parse_config
 from stacker.environment import parse_environment
 from stacker import exceptions


### PR DESCRIPTION
In preparing for running flake8 during CI, go ahead and cleanup all the flake8 errors I could find.  The only case I have not cleaned up is the use of setUp not being capitalized correctly per pylint when used in unittest. I have other plans for fixing that.