### PR TITLE
Support resolving variables when calling `dump`

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -256,7 +256,12 @@ class Action(BaseAction):
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
         pre_build = self.context.config.get("pre_build")
-        if not outline and not dump and pre_build:
+        should_run_hooks = (
+            not outline and
+            not dump and
+            pre_build
+        )
+        if should_run_hooks:
             util.handle_hooks("pre_build", pre_build, self.provider.region,
                               self.context)
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -253,10 +253,10 @@ class Action(BaseAction):
             dependencies[stack.fqn] = stack.requires
         return dependencies
 
-    def pre_run(self, outline=False, *args, **kwargs):
+    def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
         pre_build = self.context.config.get("pre_build")
-        if not outline and pre_build:
+        if not outline and not dump and pre_build:
             util.handle_hooks("pre_build", pre_build, self.provider.region,
                               self.context)
 
@@ -277,9 +277,9 @@ class Action(BaseAction):
             if dump:
                 plan.dump(dump)
 
-    def post_run(self, outline=False, *args, **kwargs):
+    def post_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""
         post_build = self.context.config.get("post_build")
-        if not outline and post_build:
+        if not outline and not dump and post_build:
             util.handle_hooks("post_build", post_build, self.provider.region,
                               self.context)

--- a/stacker/lookups/registry.py
+++ b/stacker/lookups/registry.py
@@ -24,6 +24,19 @@ def register_lookup_handler(lookup_type, handler_or_path):
     LOOKUP_HANDLERS[lookup_type] = handler
 
 
+def unregister_lookup_handler(lookup_type):
+    """Unregister the specified lookup type.
+
+    This is useful when testing various lookup types if you want to unregister
+    the lookup type after the test runs.
+
+    Args:
+        lookup_type (str): Name of the lookup type to unregister
+
+    """
+    LOOKUP_HANDLERS.pop(lookup_type, None)
+
+
 def resolve_lookups(lookups, context, provider):
     """Resolve a set of lookups.
 

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -296,7 +296,7 @@ class Plan(OrderedDict):
         for _, step in self.iteritems():
             step.status = PENDING
 
-    def dump(self, directory):
+    def dump(self, directory, context):
         steps = 1
         logger.info("Dumping \"%s\"...", self.description)
         directory = os.path.expanduser(directory)
@@ -305,6 +305,10 @@ class Plan(OrderedDict):
 
         while not self.completed:
             step_name, step = self.list_pending()[0]
+            step.stack.resolve(
+                context=context,
+                provider=None,
+            )
             blueprint = step.stack.blueprint
             filename = stack_template_key_name(blueprint)
             path = os.path.join(directory, filename)

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -4,6 +4,10 @@ import mock
 
 from stacker.context import Context
 from stacker.exceptions import ImproperlyConfigured
+from stacker.lookups.registry import (
+    register_lookup_handler,
+    unregister_lookup_handler,
+)
 from stacker.plan import (
     Step,
     Plan,
@@ -50,6 +54,10 @@ class TestPlan(unittest.TestCase):
         self.count = 0
         self.environment = {"namespace": "namespace"}
         self.context = Context(self.environment)
+        register_lookup_handler("noop", lambda **kwargs: "test")
+
+    def tearDown(self):
+        unregister_lookup_handler("noop")
 
     def _run_func(self, stack, **kwargs):
         self.count += 1
@@ -251,14 +259,20 @@ class TestPlan(unittest.TestCase):
         plan.outline()
         self.assertEqual(len(plan.list_pending()), len(plan))
 
-    @unittest.skip
     @mock.patch("stacker.plan.os")
     @mock.patch("stacker.plan.open", mock.mock_open(), create=True)
     def test_reset_after_dump(self, *args):
         plan = Plan(description="Test", sleep_time=0)
         previous_stack = None
         for i in range(5):
-            overrides = {}
+            overrides = {
+                "variables": {
+                    "PublicSubnets": "1",
+                    "SshKeyName": "1",
+                    "PrivateSubnets": "1",
+                    "Random": "${noop something}",
+                },
+            }
             if previous_stack:
                 overrides["requires"] = [previous_stack.fqn]
             stack = Stack(
@@ -272,5 +286,33 @@ class TestPlan(unittest.TestCase):
                 requires=stack.requires,
             )
 
-        plan.dump("test")
+        plan.dump("test", context=self.context)
         self.assertEqual(len(plan.list_pending()), len(plan))
+
+    @mock.patch("stacker.plan.os")
+    @mock.patch("stacker.plan.open", mock.mock_open(), create=True)
+    def test_dump_no_provider_lookups(self, *args):
+        plan = Plan(description="Test", sleep_time=0)
+        previous_stack = None
+        for i in range(5):
+            overrides = {
+                "variables": {
+                    "Var1": "${fakeStack::FakeOutput}",
+                    "Var2": "${xref fakeStack::FakeOutput2}",
+                },
+            }
+            if previous_stack:
+                overrides["requires"] = [previous_stack.fqn]
+            stack = Stack(
+                definition=generate_definition("vpc", i, **overrides),
+                context=self.context,
+            )
+            previous_stack = stack
+            plan.add(
+                stack=stack,
+                run_func=self._run_func,
+                requires=stack.requires,
+            )
+
+        with self.assertRaises(ValueError):
+            plan.dump("test", context=self.context)


### PR DESCRIPTION
We now resolve variables when calling `dump`.

We resolve the variables with a `provider` set to`None` to prevent calls to the provider. `dump` is analogous to "dry run without building anything", so there should be no need to access the provider, run `pre_build` or `post_build` hooks. 