### PR TITLE
Pass provider and context to hooks

### DIFF
--- a/stacker/hooks/ecs.py
+++ b/stacker/hooks/ecs.py
@@ -8,14 +8,21 @@ import boto3
 logger = logging.getLogger(__name__)
 
 
-def create_clusters(region, namespace, mappings, parameters, **kwargs):
+def create_clusters(provider, context, **kwargs):
     """Creates ECS clusters.
 
     Expects a "clusters" argument, which should contain a list of cluster
     names to create.
 
+    Args:
+        provider (:class:`stacker.providers.base.BaseProvider`): provider
+            instance
+        context (:class:`stacker.context.Context`): context instance
+
+    Returns: boolean for whether or not the hook succeeded.
+
     """
-    conn = boto3.client("ecs", region_name=region)
+    conn = boto3.client("ecs", region_name=provider.region)
 
     try:
         clusters = kwargs["clusters"]

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -13,16 +13,22 @@ from . import utils
 logger = logging.getLogger(__name__)
 
 
-def create_ecs_service_role(region, namespace, mappings, parameters,
-                            **kwargs):
+def create_ecs_service_role(provider, context, **kwargs):
     """Used to create the ecsServieRole, which has to be named exactly that
     currently, so cannot be created via CloudFormation. See:
 
     http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAM_policies.html#service_IAM_role
 
+    Args:
+        provider (:class:`stacker.providers.base.BaseProvider`): provider
+            instance
+        context (:class:`stacker.context.Context`): context instance
+
+    Returns: boolean for whether or not the hook succeeded.
+
     """
     role_name = kwargs.get("role_name", "ecsServiceRole")
-    client = boto3.client("iam", region_name=region)
+    client = boto3.client("iam", region_name=provider.region)
 
     try:
         client.create_role(

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -15,9 +15,21 @@ def find(lst, key, value):
     return False
 
 
-def ensure_keypair_exists(region, namespace, mappings, parameters, **kwargs):
-    client = boto3.client('ec2', region_name=region)
-    keypair_name = kwargs.get("keypair", parameters.get("SshKeyName"))
+def ensure_keypair_exists(provider, context, **kwargs):
+    """Ensure a specific keypair exists within AWS.
+
+    If the key doesn't exist, upload it.
+
+    Args:
+        provider (:class:`stacker.providers.base.BaseProvider`): provider
+            instance
+        context (:class:`stacker.context.Context`): context instance
+
+    Returns: boolean for whether or not the hook succeeded.
+
+    """
+    client = boto3.client('ec2', region_name=provider.region)
+    keypair_name = kwargs.get("keypair", context.parameters.get("SshKeyName"))
     resp = client.describe_key_pairs()
     keypair = find(resp['KeyPairs'], 'KeyName', keypair_name)
     message = "keypair: %s (%s) %s"

--- a/stacker/hooks/route53.py
+++ b/stacker/hooks/route53.py
@@ -7,9 +7,19 @@ from stacker.util import create_route53_zone
 logger = logging.getLogger(__name__)
 
 
-def create_domain(region, namespace, mappings, parameters, **kwargs):
-    client = boto3.client("route53", region_name=region)
-    domain = kwargs.get('domain', parameters.get('BaseDomain'))
+def create_domain(provider, context, **kwargs):
+    """Create a domain within route53.
+
+    Args:
+        provider (:class:`stacker.providers.base.BaseProvider`): provider
+            instance
+        context (:class:`stacker.context.Context`): context instance
+
+    Returns: boolean for whether or not the hook succeeded.
+
+    """
+    client = boto3.client("route53", region_name=provider.region)
+    domain = kwargs.get('domain', context.parameters.get('BaseDomain'))
     if not domain:
         logger.error("domain argument or BaseDomain parameter not provided.")
         return False

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -1,4 +1,19 @@
+from mock import MagicMock
+
+from stacker.context import Context
 from stacker.lookups import Lookup
+
+
+def mock_provider(**kwargs):
+    return MagicMock(**kwargs)
+
+
+def mock_context(namespace=None, **kwargs):
+    environment = kwargs.get("environment", {})
+    if namespace is not None:
+        environment["namespace"] = namespace
+
+    return Context(environment, **kwargs)
 
 
 def generate_definition(base_name, stack_id, **overrides):

--- a/stacker/tests/hooks/test_ecs.py
+++ b/stacker/tests/hooks/test_ecs.py
@@ -5,11 +5,20 @@ from moto import mock_ecs
 from testfixtures import LogCapture
 
 from stacker.hooks.ecs import create_clusters
+from ..factories import (
+    mock_context,
+    mock_provider,
+)
 
 REGION = "us-east-1"
 
 
 class TestECSHooks(unittest.TestCase):
+
+    def setUp(self):
+        self.provider = mock_provider(region=REGION)
+        self.context = mock_context(namespace="fake")
+
     def test_create_single_cluster(self):
         with mock_ecs():
             cluster = "test-cluster"
@@ -21,11 +30,9 @@ class TestECSHooks(unittest.TestCase):
             with LogCapture(logger) as logs:
                 self.assertTrue(
                     create_clusters(
-                        region=REGION,
-                        namespace="fake",
-                        mappings={},
-                        parameters={},
-                        clusters=cluster
+                        provider=self.provider,
+                        context=self.context,
+                        clusters=cluster,
                     )
                 )
 
@@ -52,11 +59,9 @@ class TestECSHooks(unittest.TestCase):
                 with LogCapture(logger) as logs:
                     self.assertTrue(
                         create_clusters(
-                            region=REGION,
-                            namespace="fake",
-                            mappings={},
-                            parameters={},
-                            clusters=cluster
+                            provider=self.provider,
+                            context=self.context,
+                            clusters=cluster,
                         )
                     )
 

--- a/stacker/tests/hooks/test_iam.py
+++ b/stacker/tests/hooks/test_iam.py
@@ -10,6 +10,11 @@ from stacker.hooks.iam import (
     _get_cert_arn_from_response,
 )
 
+from ..factories import (
+    mock_context,
+    mock_provider,
+)
+
 
 REGION = "us-east-1"
 
@@ -19,6 +24,11 @@ REGION = "us-east-1"
 
 
 class TestIAMHooks(unittest.TestCase):
+
+    def setUp(self):
+        self.context = mock_context(namespace="fake")
+        self.provider = mock_provider(region=REGION)
+
     def test_get_cert_arn_from_response(self):
         arn = "fake-arn"
         # Creation response
@@ -45,10 +55,8 @@ class TestIAMHooks(unittest.TestCase):
 
             self.assertTrue(
                 create_ecs_service_role(
-                    region=REGION,
-                    namespace="fake",
-                    mappings={},
-                    parameters={}
+                    context=self.context,
+                    provider=self.provider,
                 )
             )
 

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -4,7 +4,6 @@ import string
 import os
 import Queue
 
-from stacker.context import Context
 from stacker.util import (
     cf_safe_name, load_object_from_string,
     camel_to_snake, handle_hooks, retry_with_backoff)

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -275,7 +275,7 @@ def cf_safe_name(name):
 
 
 # TODO: perhaps make this a part of the builder?
-def handle_hooks(stage, hooks, region, context):
+def handle_hooks(stage, hooks, provider, context):
     """ Used to handle pre/post_build hooks.
 
     These are pieces of code that we want to run before/after the builder
@@ -284,8 +284,8 @@ def handle_hooks(stage, hooks, region, context):
     Args:
         stage (string): The current stage (pre_run, post_run, etc).
         hooks (list): A list of dictionaries containing the hooks to execute.
-        region (string): The AWS region the current stacker run is executing
-            in.
+        provider (:class:`stacker.provider.base.BaseProvider`): The provider
+            the current stack is using.
         context (:class:`stacker.context.Context`): The current stacker
             context.
     """
@@ -312,13 +312,7 @@ def handle_hooks(stage, hooks, region, context):
                 raise
             continue
         try:
-            result = method(
-                region,
-                context.namespace,
-                context.mappings,
-                context.parameters,
-                **kwargs
-            )
+            result = method(context=context, provider=provider, **kwargs)
         except Exception:
             logger.exception("Method %s threw an exception:", hook["path"])
             if required:


### PR DESCRIPTION
Fixes: https://github.com/remind101/stacker/issues/207

In a backwards incompatible, but cleaner way IMO. Slated for 1.0.