### PR TITLE
add UsePreviousValue support for NoEcho parameters

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -166,10 +166,19 @@ class Action(BaseAction):
         parameters = self._handle_missing_parameters(parameters,
                                                      required_params,
                                                      provider_stack)
-        return [
+
+        # Handle values that shouldn't be sent ('UsePreviousValue')
+        final_list = []
+        for p in [
             {'ParameterKey': p[0],
-             'ParameterValue': str(p[1])} for p in parameters
-        ]
+             'ParameterValue': str(p[1])} for p in parameters]:
+            stack_p = stack.blueprint.parameters[p['ParameterKey']]
+            if p['ParameterValue'] == '****' and stack_p.properties['NoEcho']:
+                final_list.append({'ParameterKey': p['ParameterKey'],
+                                   'UsePreviousValue': True})
+            else:
+                final_list.append(p)
+        return final_list
 
     def _build_stack_tags(self, stack):
         """Builds a common set of tags to attach to a stack"""


### PR DESCRIPTION
Some values (e.g. passwords) are useful to pass in once during stack
creation with a NoEcho flag. In future stack updates, it should then be
possible to omit those parameters and have CFN use the previous value
submitted.

This commit enables that functionality, when using NoEcho parameters.
