### PR TITLE
fix file handler lookups with pseudo parameters (1.0)

### DIFF
--- a/stacker/lookups/handlers/file.py
+++ b/stacker/lookups/handlers/file.py
@@ -92,7 +92,7 @@ def handler(value, **kwargs):
 
 
 def parameterized_codec(raw, b64):
-    pattern = re.compile(r'{{(\w+)}}')
+    pattern = re.compile(r'{{([::|\w]+)}}')
 
     parts = []
     s_index = 0

--- a/stacker/tests/lookups/handlers/test_file.py
+++ b/stacker/tests/lookups/handlers/test_file.py
@@ -58,11 +58,24 @@ class TestFileTranslator(unittest.TestCase):
             self.assertEqual(troposphere.GenericHelperFn, type(out))
 
     def test_handler_parameterized_b64(self):
-        expected = 'Hello, world'
+        expected = 'Regular text {{Psuedo::Var}} {{RegVar}} {{Non-Var}}'
+        processed = {
+            'Fn::Base64': {
+                'Fn::Join': [
+                    '',
+                    ['Regular text ',
+                     {'Ref': 'Psuedo::Var'},
+                     ' ',
+                     {'Ref': 'RegVar'},
+                     ' {{Non-Var}}']
+                ]
+            }
+        }
         with mock.patch('stacker.lookups.handlers.file.read_value_from_path',
                         return_value=expected):
             out = handler('parameterized-b64:file://tmp/test')
             self.assertEqual(troposphere.Base64, type(out))
+            self.assertEqual(processed, out.data)
 
     def test_unknown_codec(self):
         expected = 'Hello, world'


### PR DESCRIPTION
If the file lookup includes a reference with `::` in it (e.g. `AWS::Region`), the regex currently doesn't extract it.

(this is just #239 rebased on top of 1.0)