### PR TITLE
Allow `=` in lookup input

### DIFF
--- a/stacker/lookups/__init__.py
+++ b/stacker/lookups/__init__.py
@@ -13,7 +13,7 @@ LOOKUP_REGEX = re.compile("""
                                        # "output" type
 ?\s*                                   # any number of spaces separating the
                                        # type from the input
-(?P<input>[@\+\/,\._\-a-zA-Z0-9\:\s]+) # the input value to the lookup
+(?P<input>[@\+\/,\._\-a-zA-Z0-9\:\s=]+) # the input value to the lookup
 )\}                                    # closing brace of the lookup
 """, re.VERBOSE)
 

--- a/stacker/tests/test_lookups.py
+++ b/stacker/tests/test_lookups.py
@@ -59,6 +59,13 @@ class TestLookupExtraction(unittest.TestCase):
         self.assertEqual(lookup.type, "kms")
         self.assertEqual(lookup.input, "CiADsGxJp1mCR21fjsVjVxr7RwuO2FE3ZJqC4iG0Lm+HkRKwAQEBAgB4A7BsSadZgkdtX47FY1ca+0cLjthRN2SaguIhtC5vh5EAAACHMIGEBgkqhkiG9w0BBwagdzB1AgEAMHAGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3IKyEoNEQVxN3BaaAgEQgEOpqa0rcl3WpHOmblAqL1rOPRyokO3YXcJAAB37h/WKLpZZRAWV2h9C67xjlsj3ebg+QIU91T/")  # NOQA
 
+    def test_kms_lookup_with_equals(self):
+        lookups = extract_lookups("${kms us-east-1@AQECAHjLp186mZ+mgXTQSytth/ibiIdwBm8CZAzZNSaSkSRqswAAAG4wbAYJKoZIhvcNAQcGoF8wXQIBADBYBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLNmhGU6fe4vp175MAIBEIAr+8tUpi7SDzOZm+FFyYvWXhs4hEEyaazIn2dP8a+yHzZYDSVYGRpfUz34bQ==}")  # NOQA
+        self.assertEqual(len(lookups), 1)
+        lookup = list(lookups)[0]
+        self.assertEqual(lookup.type, "kms")
+        self.assertEqual(lookup.input, "us-east-1@AQECAHjLp186mZ+mgXTQSytth/ibiIdwBm8CZAzZNSaSkSRqswAAAG4wbAYJKoZIhvcNAQcGoF8wXQIBADBYBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLNmhGU6fe4vp175MAIBEIAr+8tUpi7SDzOZm+FFyYvWXhs4hEEyaazIn2dP8a+yHzZYDSVYGRpfUz34bQ==")  # NOQA
+
     def test_kms_lookup_with_region(self):
         lookups = extract_lookups("${kms us-west-2@CiADsGxJp1mCR21fjsVjVxr7RwuO2FE3ZJqC4iG0Lm+HkRKwAQEBAgB4A7BsSadZgkdtX47FY1ca+0cLjthRN2SaguIhtC5vh5EAAACHMIGEBgkqhkiG9w0BBwagdzB1AgEAMHAGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3IKyEoNEQVxN3BaaAgEQgEOpqa0rcl3WpHOmblAqL1rOPRyokO3YXcJAAB37h/WKLpZZRAWV2h9C67xjlsj3ebg+QIU91T/}")  # NOQA
         self.assertEqual(len(lookups), 1)


### PR DESCRIPTION
Fixes https://github.com/remind101/stacker/issues/250.

Would it be better relax the regex to just something like:

```
\$\{(.*\)}
```

And then then just split the capture group on spaces?
