### PR TITLE
Allow use of later boto3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ src_dir = os.path.dirname(__file__)
 
 install_requires = [
     "troposphere~=1.8.1",
-    "boto3~=1.3.1",
+    "boto3>=1.3.1<1.5.0",
     "botocore~=1.4.38",
     "PyYAML~=3.11",
     "awacs~=0.6.0",


### PR DESCRIPTION
This PR just broadens the range of required boto3 to include the 1.4.n release series. 