### PR TITLE
1.0: Stop people from accidentally using old parameters

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -231,6 +231,11 @@ class Blueprint(object):
         self.reset_template()
         self.resolved_variables = None
 
+        if hasattr(self, "PARAMETERS") or hasattr(self, "LOCAL_PARAMETERS"):
+            raise AttributeError("Blueprint %s uses deprecated PARAMETERS or "
+                                 "LOCAL_PARAMETERS, rather than VARIABLES. "
+                                 "Please update your blueprints.")
+
     def get_required_parameter_definitions(self):
         """Returns all template parameters that do not have a default value.
 

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -234,7 +234,7 @@ class Blueprint(object):
         if hasattr(self, "PARAMETERS") or hasattr(self, "LOCAL_PARAMETERS"):
             raise AttributeError("Blueprint %s uses deprecated PARAMETERS or "
                                  "LOCAL_PARAMETERS, rather than VARIABLES. "
-                                 "Please update your blueprints.")
+                                 "Please update your blueprints." % name)
 
     def get_required_parameter_definitions(self):
         """Returns all template parameters that do not have a default value.

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -42,7 +42,7 @@ def _gather_variables(stack_def, context_variables):
     if "parameters" in stack_def:
         raise AttributeError("Stack definition %s contains deprecated "
                              "'parameters', rather than 'variables'. Please "
-                             "update your config.")
+                             "update your config." % stack_name)
     variable_values = copy.deepcopy(stack_def.get('variables', {}))
     stack_specific_variables = {}
     for key, value in context_variables.iteritems():

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -33,7 +33,16 @@ def _gather_variables(stack_def, context_variables):
     Returns:
         dict: Contains key/value pairs of the collected variables.
 
+    Raises:
+        AttributeError: Raised when the stack definitition contains an invalid
+            attribute. Currently only when using old parameters, rather than
+            variables.
     """
+    stack_name = stack_def["name"]
+    if "parameters" in stack_def:
+        raise AttributeError("Stack definition %s contains deprecated "
+                             "'parameters', rather than 'variables'. Please "
+                             "update your config.")
     variable_values = copy.deepcopy(stack_def.get('variables', {}))
     stack_specific_variables = {}
     for key, value in context_variables.iteritems():
@@ -45,7 +54,7 @@ def _gather_variables(stack_def, context_variables):
             variable_values[key] = value
             continue
         # Gather stack specific params for later
-        if stack == stack_def["name"]:
+        if stack == stack_name:
             stack_specific_variables[key] = value
 
     # Now update stack definition variables with the stack specific variables

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -479,3 +479,20 @@ class TestVariables(unittest.TestCase):
         self.assertFalse(valid)
         valid = validate_allowed_values(allowed_values, "allowed")
         self.assertTrue(valid)
+
+    def test_blueprint_with_parameters_fails(self):
+        class TestBlueprint(Blueprint):
+            PARAMETERS = {
+                "Param2": {"default": 0, "type": "Integer"},
+            }
+
+        with self.assertRaises(AttributeError):
+            TestBlueprint(name="test", context=MagicMock())
+
+        class TestBlueprint(Blueprint):
+            LOCAL_PARAMETERS = {
+                "Param2": {"default": 0, "type": "Integer"},
+            }
+
+        with self.assertRaises(AttributeError):
+            TestBlueprint(name="test", context=MagicMock())

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -22,10 +22,6 @@ def generate_definition(base_name, stack_id, **overrides):
         "class_path": "stacker.tests.fixtures.mock_blueprints.%s" % (
             base_name.upper()),
         "namespace": "example-com",
-        "parameters": {
-            "InstanceType": "m3.medium",
-            "AZCount": 2,
-        },
         "requires": []
     }
     definition.update(overrides)

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -97,3 +97,42 @@ class Bastion(Blueprint):
 
     def create_template(self):
         return
+
+
+class PreOneOhBastion(Blueprint):
+    """Used to ensure old blueprints won't be usable in 1.0"""
+    PARAMETERS = {
+        "VpcId": {"type": "AWS::EC2::VPC::Id", "description": "Vpc Id"},
+        "DefaultSG": {"type": "AWS::EC2::SecurityGroup::Id",
+                      "description": "Top level security group."},
+        "PublicSubnets": {"type": "List<AWS::EC2::Subnet::Id>",
+                          "description": "Subnets to deploy public "
+                                         "instances in."},
+        "PrivateSubnets": {"type": "List<AWS::EC2::Subnet::Id>",
+                           "description": "Subnets to deploy private "
+                                          "instances in."},
+        "AvailabilityZones": {"type": "CommaDelimitedList",
+                              "description": "Availability Zones to deploy "
+                                             "instances in."},
+        "InstanceType": {"type": "String",
+                         "description": "EC2 Instance Type",
+                         "default": "m3.medium"},
+        "MinSize": {"type": "Number",
+                    "description": "Minimum # of instances.",
+                    "default": "1"},
+        "MaxSize": {"type": "Number",
+                    "description": "Maximum # of instances.",
+                    "default": "5"},
+        "SshKeyName": {"type": "AWS::EC2::KeyPair::KeyName"},
+        "OfficeNetwork": {
+            "type": "String",
+            "description": "CIDR block allowed to connect to bastion hosts."},
+        "ImageName": {
+            "type": "String",
+            "description": "The image name to use from the AMIMap (usually "
+                           "found in the config file.)",
+            "default": "bastion"},
+    }
+
+    def create_template(self):
+        return

--- a/stacker/tests/fixtures/vpc-bastion-db-web-pre-1.0.yaml
+++ b/stacker/tests/fixtures/vpc-bastion-db-web-pre-1.0.yaml
@@ -49,7 +49,8 @@ stacks:
       #InternalDomain: internal
   - name: bastion
     class_path: stacker.tests.fixtures.mock_blueprints.Bastion
-    variables:
+    ## !! This should break, parameters not allowed in 1.0
+    parameters:
       # Extends the parameters dict with the contents of the vpc_parameters
       # anchor. Basically we're including all VPC Outputs in the parameters
       # of the bastion stack. Note: Stacker figures out, automatically, which

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -113,3 +113,10 @@ class TestStack(unittest.TestCase):
         variable_dict = dict((v.name, v.value) for v in result)
         self.assertEqual(variable_dict["Address"], "192.168.1.1")
         self.assertEqual(variable_dict["Foo"], "BAR")
+
+    def test_gather_variables_fails_on_parameters_in_stack_def(self):
+        sdef = self.sd
+        sdef["parameters"] = {"Address": "10.0.0.1", "Foo": "BAR"}
+        build_action_variables = {"Address": "192.168.1.1"}
+        with self.assertRaises(AttributeError):
+            _gather_variables(sdef, build_action_variables)

--- a/stacker/tests/test_stacker.py
+++ b/stacker/tests/test_stacker.py
@@ -70,3 +70,15 @@ class TestStacker(unittest.TestCase):
         stacker.configure(args)
         stacks = args.context.get_stacks()
         self.assertEqual(len(stacks), 2)
+
+    def test_stacker_build_fail_when_parameters_in_stack_def(self):
+        stacker = Stacker()
+        args = stacker.parse_args(
+            ["build", "-var", "BaseDomain=mike.com", "-r", "us-west-2", "-var",
+             "AZCount=2", "-var", "CidrBlock=10.128.0.0/16",
+             "stacker/tests/fixtures/basic.env",
+             "stacker/tests/fixtures/vpc-bastion-db-web-pre-1.0.yaml"]
+        )
+        stacker.configure(args)
+        with self.assertRaises(AttributeError):
+            args.context.get_stacks_dict()


### PR DESCRIPTION
I ran into an issue while testing the change from Parameters to
Variables while updating the firehose blueprint in stacker_blueprints.
All the variables are optional, which means if you don't provide any
of them, it'll happily move along.  This is bad, since say before you
had a parameter for `BucketName`.  Now you haven't provided one for
the Variable `BucketName`, so CF assumes it should create a new bucket
with a random name, and then it will delete your old bucket.

Since Parameters, as they stood, no longer exist in 1.0, I think this
extra level of protection is a good idea.  I might be missing somewhere
else that we should protect people as well, so any ideas on that would
be greatly appreciated.
