### PR TITLE
Relax troposphere dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ VERSION = "0.8.5"
 src_dir = os.path.dirname(__file__)
 
 install_requires = [
-    "troposphere~=1.9.0",
+    "troposphere>=1.8.0",
     "boto3>=1.3.1,<1.5.0",
     "PyYAML~=3.11",
     "awacs~=0.6.0",


### PR DESCRIPTION
This could probably be relaxed even more, since there's nothing that stacker explicitly depends on in troposphere 1.9.

stacker_blueprints still has a troposphere dependency on ~=1.8.1, which makes them incompatible with each other right now.