### PR TITLE
Execute plan in parallel

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,10 +1,26 @@
 import logging
 import sys
+import threading
+import signal
 
 import boto3
 import botocore.exceptions
 
 logger = logging.getLogger(__name__)
+
+
+def cancel():
+    """Returns a threading.Event() that will get set when SIGTERM, or
+    SIGINT are triggered. This can be used to cancel execution of threads.
+    """
+    cancel = threading.Event()
+
+    def cancel_execution(signum, frame):
+        cancel.set()
+
+    signal.signal(signal.SIGINT, cancel_execution)
+    signal.signal(signal.SIGTERM, cancel_execution)
+    return cancel
 
 
 def stack_template_key_name(blueprint):

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -292,7 +292,9 @@ class Action(BaseAction):
         if not outline and not dump:
             plan.outline(logging.DEBUG)
             logger.debug("Launching stacks: %s", ", ".join(plan.keys()))
-            plan.execute(self._launch_stack)
+            plan.execute(
+                self._launch_stack,
+                parallel=self.provider.supports_parallel)
         else:
             if outline:
                 plan.outline()

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -1,6 +1,6 @@
 import logging
 
-from .base import BaseAction
+from .base import BaseAction, cancel
 from .. import exceptions, util
 from ..exceptions import StackDidNotChange
 from ..plan import Plan
@@ -294,7 +294,8 @@ class Action(BaseAction):
             logger.debug("Launching stacks: %s", ", ".join(plan.keys()))
             plan.execute(
                 self._launch_stack,
-                parallel=self.provider.supports_parallel)
+                parallel=self.provider.supports_parallel,
+                cancel=cancel())
         else:
             if outline:
                 plan.outline()

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -77,7 +77,9 @@ class Action(BaseAction):
             # steps to COMPLETE in order to log them
             debug_plan = self._generate_plan()
             debug_plan.outline(logging.DEBUG)
-            plan.execute(self._destroy_stack)
+            plan.execute(
+                self._destroy_stack,
+                parallel=self.provider.supports_parallel)
         else:
             plan.outline(message="To execute this plan, run with \"--force\" "
                                  "flag.")

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -1,6 +1,6 @@
 import logging
 
-from .base import BaseAction
+from .base import BaseAction, cancel
 from ..exceptions import StackDoesNotExist
 from .. import util
 from ..status import (
@@ -79,7 +79,8 @@ class Action(BaseAction):
             debug_plan.outline(logging.DEBUG)
             plan.execute(
                 self._destroy_stack,
-                parallel=self.provider.supports_parallel)
+                parallel=self.provider.supports_parallel,
+                cancel=cancel())
         else:
             plan.outline(message="To execute this plan, run with \"--force\" "
                                  "flag.")

--- a/stacker/dag/__init__.py
+++ b/stacker/dag/__init__.py
@@ -91,7 +91,7 @@ class DAG(object):
                 transposed.add_edge(edge, node)
         return transposed
 
-    def walk(self, walk_func, graph=None):
+    def walk(self, walk_func, graph=None, cancel=None):
         """ Walks each node of the graph in reverse topological order.
 
         This can be used to perform a set of operations, where the next
@@ -106,7 +106,7 @@ class DAG(object):
         for n in nodes:
             walk_func(n)
 
-    def walk_parallel(self, walk_func, graph=None):
+    def walk_parallel(self, walk_func, graph=None, cancel=None):
         """ Walks each node of the graph, in parallel if it can.
 
         The walk_func is only called when the nodes dependencies have been
@@ -122,7 +122,8 @@ class DAG(object):
         completed = {}
         for node in nodes:
             completed[node] = threading.Event()
-        cancel = threading.Event()
+        if not cancel:
+            cancel = threading.Event()
 
         # Blocks until all dependencies have been satisfied, or another
         # thread errored. Returns True if all deps have been satisfied.

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -144,7 +144,7 @@ class Plan(object):
         self._dag = dag
         return None
 
-    def execute(self, fn, parallel=True):
+    def execute(self, fn, parallel=True, cancel=None):
         """ Executes the plan by walking the graph and executing dependencies
         first.
 
@@ -171,7 +171,7 @@ class Plan(object):
                 if sleep_func and not step.done:
                     sleep_func()
 
-        self._walk_steps(step_func, parallel=parallel)
+        self._walk_steps(step_func, parallel=parallel, cancel=cancel)
         return True
 
     def dump(self, directory):
@@ -219,7 +219,7 @@ class Plan(object):
         if message:
             logger.log(level, message)
 
-    def _walk_steps(self, step_func, parallel=False):
+    def _walk_steps(self, step_func, parallel=False, cancel=None):
         steps = self._steps
 
         def walk_func(fqn):
@@ -234,7 +234,7 @@ class Plan(object):
         if parallel:
             walk = dag.walk_parallel
 
-        return walk(walk_func)
+        return walk(walk_func, cancel=cancel)
 
     def _check_point(self):
         lock = self._check_point_lock

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -95,6 +95,10 @@ class Provider(BaseProvider):
         self._pid = os.getpid()
 
     @property
+    def supports_parallel(self):
+        return True
+
+    @property
     def cloudformation(self):
         # deals w/ multiprocessing issues w/ sharing ssl conns
         # see https://github.com/remind101/stacker/issues/196

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -106,6 +106,10 @@ def output_summary(fqn, action, changeset, replacements_only=False):
 class Provider(AWSProvider):
     """AWS Cloudformation Change Set Provider"""
 
+    @property
+    def supports_parallel(self):
+        return False
+
     def __init__(self, *args, **kwargs):
         self.replacements_only = kwargs.pop('replacements_only', False)
         super(Provider, self).__init__(*args, **kwargs)

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -127,8 +127,9 @@ class TestBuildAction(unittest.TestCase):
             self.assertEqual(mock_generate_plan().execute.call_count, 0)
 
     def test_execute_plan_when_outline_not_specified(self):
+        mock_provider = mock.MagicMock()
         context = self._get_context()
-        build_action = build.Action(context)
+        build_action = build.Action(context, provider=mock_provider)
         with mock.patch.object(build_action, "_generate_plan") as \
                 mock_generate_plan:
             build_action.run(outline=False)

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -4,6 +4,7 @@ from nose import with_setup
 from nose.tools import nottest, raises
 from stacker.dag import DAG, DAGValidationError
 import threading
+import time
 
 dag = None
 
@@ -94,6 +95,7 @@ def test_walk_parallel():
     c_submitted = threading.Event()
 
     def walk_func(n):
+        time.sleep(0.2)
         # Wait for c to get submitted first
         if n == 'b':
             c_submitted.wait()
@@ -104,8 +106,38 @@ def test_walk_parallel():
             c_submitted.set()
         lock.release()
 
-    dag.walk_parallel(walk_func)
+    ok = dag.walk_parallel(walk_func)
+    assert ok == True  # noqa: E712
     assert nodes == ['d', 'c', 'b', 'a']
+
+
+@with_setup(blank_setup)
+def test_walk_parallel_exception():
+    dag = DAG()
+
+    # b and c should be executed at the same time.
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+    lock = threading.Lock()  # Protects nodes from concurrent access
+    nodes = []
+
+    def walk_func(n):
+        lock.acquire()
+        nodes.append(n)
+        lock.release()
+        # Wait for c to get submitted first
+        if n == 'd':
+            raise Exception('well shit')
+
+    ok = dag.walk_parallel(walk_func)
+
+    # Only 2 should have been hit. The rest are canceled because they depend on
+    # the success of d.
+    assert ok == False  # noqa: E712
+    assert nodes == ['d']
 
 
 @with_setup(start_with_graph)

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -140,6 +140,36 @@ def test_walk_parallel_exception():
     assert nodes == ['d']
 
 
+@with_setup(blank_setup)
+def test_walk_parallel_cancel():
+    dag = DAG()
+
+    # b and c should be executed at the same time.
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+    cancel = threading.Event()
+    lock = threading.Lock()  # Protects nodes from concurrent access
+    nodes = []
+
+    def walk_func(n):
+        lock.acquire()
+        nodes.append(n)
+        lock.release()
+        # Wait for c to get submitted first
+        if n == 'd':
+            cancel.set()
+
+    ok = dag.walk_parallel(walk_func, cancel=cancel)
+
+    # Only 2 should have been hit. The rest are canceled because they depend on
+    # the success of d.
+    assert ok == False  # noqa: E712
+    assert nodes == ['d']
+
+
 @with_setup(start_with_graph)
 def test_ind_nodes():
     assert dag.ind_nodes(dag.graph) == ['a']


### PR DESCRIPTION
https://asciinema.org/a/37li2129w03khzxdqt4pacq77

This allows for parallel executions of plans, by walking each node in a thread.

Each thread blocks and waits for it's dependencies to complete, using a condition variable. When it executes it's walk function, it notifies other threads waiting on it so that they can continue.

Fixes https://github.com/remind101/stacker/issues/279. I tested this under the same conditions and it took ~2 minutes. Even that still seems to long to me, so there's probably some more areas that can be improved.

**TODO**

* [x] Exception handling in threads
* [x] Disable parallel walk in interactive mode.
* [x] Synchronization around calling `check_point`.
* [x] Cancel execution when a stack errors
* [x] Handle SIGINT