### PR TITLE
Make --stacks flag build dependencies

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -270,9 +270,9 @@ class Action(BaseAction):
 
         return params.items()
 
-    def _generate_plan(self, tail=False):
+    def _generate_plan(self, tail=False, stack_names=None):
         plan = Plan(description="Create/Update stacks")
-        plan.build(self.context.get_stacks())
+        plan.build(self.context.get_stacks(), stack_names=stack_names)
         return plan
 
     def pre_run(self, outline=False, *args, **kwargs):
@@ -282,13 +282,14 @@ class Action(BaseAction):
             util.handle_hooks("pre_build", pre_build, self.provider.region,
                               self.context)
 
-    def run(self, outline=False, tail=False, dump=False, *args, **kwargs):
+    def run(self, outline=False, tail=False,
+            dump=False, stack_names=None, *args, **kwargs):
         """Kicks off the build/update of the stacks in the stack_definitions.
 
         This is the main entry point for the Builder.
 
         """
-        plan = self._generate_plan(tail=tail)
+        plan = self._generate_plan(tail=tail, stack_names=stack_names)
         if not outline and not dump:
             plan.outline(logging.DEBUG)
             logger.debug("Launching stacks: %s", ", ".join(plan.keys()))

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -33,10 +33,10 @@ class Build(BaseCommand):
                                  "the config.")
         parser.add_argument("--stacks", action="append",
                             metavar="STACKNAME", type=str,
-                            help="Only work on the stacks given. Can be "
-                                 "specified more than once. If not specified "
-                                 "then stacker will work on all stacks in the "
-                                 "config file.")
+                            help="Only work on the given stacks, and their "
+                                 "dependencies. Can be specified more than "
+                                 "once. If not specified then stacker will "
+                                 "work on all stacks in the config file.")
         parser.add_argument("-t", "--tail", action="store_true",
                             help="Tail the CloudFormation logs while working"
                                  "with stacks")
@@ -49,7 +49,8 @@ class Build(BaseCommand):
         action = build.Action(options.context, provider=options.provider)
         action.execute(outline=options.outline,
                        tail=options.tail,
-                       dump=options.dump)
+                       dump=options.dump,
+                       stack_names=options.stacks)
 
     def get_context_kwargs(self, options, **kwargs):
-        return {"stack_names": options.stacks, "force_stacks": options.force}
+        return {"force_stacks": options.force}

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -29,8 +29,6 @@ class Context(object):
         namespace (str): A unique namespace for the stacks being built.
         environment (dict): A dictionary used to pass in information about
             the environment. Useful for templating.
-        stack_names (list): A list of stack_names to operate on. If not passed,
-            usually all stacks defined in the config will be operated on.
         parameters (dict): Parameters from the command line passed down to each
             blueprint to parameterize the templates.
         mappings (dict): Used as Cloudformation mappings for the blueprint.
@@ -42,7 +40,6 @@ class Context(object):
     """
 
     def __init__(self, environment,  # pylint: disable-msg=too-many-arguments
-                 stack_names=None,
                  parameters=None, mappings=None, config=None,
                  force_stacks=None):
         try:
@@ -51,7 +48,6 @@ class Context(object):
             raise MissingEnvironment(["namespace"])
 
         self.environment = environment
-        self.stack_names = stack_names or []
         self.parameters = parameters or {}
         self.mappings = mappings or {}
         self.namespace_delimiter = "-"
@@ -83,10 +79,7 @@ class Context(object):
             register_lookup_handler(key, handler)
 
     def _get_stack_definitions(self):
-        if not self.stack_names:
-            return self.config["stacks"]
-        return [s for s in self.config["stacks"] if s["name"] in
-                self.stack_names]
+        return self.config["stacks"]
 
     def get_stacks(self):
         """Get the stacks for the current action.

--- a/stacker/dag/__init__.py
+++ b/stacker/dag/__init__.py
@@ -150,6 +150,28 @@ class DAG(object):
                 lambda node: node
                 in nodes_seen, self.topological_sort(graph=graph))
 
+    def filter(self, nodes, graph=None):
+        """ Returns a new DAG with only the given nodes and their
+        dependencies.
+        """
+
+        if graph is None:
+            graph = self.graph
+        dag = DAG()
+
+        # Add only the nodes we need.
+        for node in nodes:
+            dag.add_node_if_not_exists(node)
+            for edge in self.all_downstreams(node, graph=graph):
+                dag.add_node_if_not_exists(edge)
+
+        # Now, rebuild the graph for each node that's present.
+        for node, edges in graph.items():
+            if node in dag.graph:
+                dag.graph[node] = edges
+
+        return dag
+
     def all_leaves(self, graph=None):
         """ Return a list of all leaves (nodes with no downstreams) """
         if graph is None:

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -114,12 +114,13 @@ class Plan(object):
         self._sleep_func = sleep_func
         self.id = uuid.uuid4()
 
-    def build(self, stacks):
+    def build(self, stacks, stack_names=None):
         """ Builds an internal dag from the stacks and their dependencies.
 
         Args:
             stacks (list): a list of :class:`stacker.stack.Stack` objects
                 to build the plan with.
+            stack_names (list): a list of stack names to filter on.
         """
         dag = DAG()
 
@@ -137,6 +138,14 @@ class Plan(object):
                     raise GraphError(e, stack.fqn, dep)
                 except DAGValidationError as e:
                     raise GraphError(e, stack.fqn, dep)
+
+        if stack_names:
+            nodes = []
+            for stack_name in stack_names:
+                for stack in stacks:
+                    if stack.name == stack_name:
+                        nodes.append(stack.fqn)
+            dag = dag.filter(nodes)
 
         self._dag = dag
         return None

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -24,21 +24,11 @@ class TestContext(unittest.TestCase):
     def test_context_optional_keys_set(self):
         context = Context(
             environment=self.environment,
-            stack_names=["stack"],
             mappings={},
             config={},
         )
         for key in ["mappings", "config"]:
             self.assertEqual(getattr(context, key), {})
-        self.assertEqual(context.stack_names, ["stack"])
-
-    def test_context_get_stacks_specific_stacks(self):
-        context = Context(
-            environment=self.environment,
-            config=self.config,
-            stack_names=["stack2"],
-        )
-        self.assertEqual(len(context.get_stacks()), 1)
 
     def test_context_get_stacks(self):
         context = Context(self.environment, config=self.config)

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -135,6 +135,14 @@ def test_predecessors():
 
 
 @with_setup(start_with_graph)
+def test_filter():
+    dag2 = dag.filter(['b', 'c'])
+    assert dag2.graph == {'b': set('d'),
+                          'c': set('d'),
+                          'd': set()}
+
+
+@with_setup(start_with_graph)
 def test_all_leaves():
     assert dag.all_leaves() == ['d']
 


### PR DESCRIPTION
Closes https://github.com/remind101/stacker/issues/186

This allows the --stacks flag to support building the stacks dependencies, so you don't need to do it manually. For example, say you had this configuration:

```yaml
stacks:
  - name: a
    class_path: stacker.dev.blueprints.Dummy
  - name: b
    class_path: stacker.dev.blueprints.Dummy
    parameters:
      DummyParameter: a::DummyOutput
  - name: c
    class_path: stacker.dev.blueprints.Dummy
    parameters:
      DummyParameter: b::DummyOutput
```

Previously, if I wanted to build only `c`, I would have to specify `--stacks a --stacks b --stacks c`. With this change, you only need to specify `--stacks c` and stacker will build `a` and and `b` implicitly.

This depends on the DAG refactor in https://github.com/remind101/stacker/pull/280