### PR TITLE
Use sys_path for hooks and lookups

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import sys
 
 import boto3
 import botocore.exceptions
@@ -119,8 +118,6 @@ class BaseAction(object):
         return template_url
 
     def execute(self, *args, **kwargs):
-        if "sys_path" in self.context.config:
-            sys.path.append(self.context.config["sys_path"])
         self.pre_run(*args, **kwargs)
         self.run(*args, **kwargs)
         self.post_run(*args, **kwargs)

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -1,4 +1,5 @@
 import collections
+import sys
 
 from .config import parse_config
 from .exceptions import MissingEnvironment
@@ -69,6 +70,8 @@ class Context(object):
         self.config = parse_config(conf_string, environment=self.environment)
         self.mappings = self.config.get("mappings", {})
         namespace_delimiter = self.config.get("namespace_delimiter", None)
+        if "sys_path" in self.config:
+            sys.path.append(self.config["sys_path"])
         if namespace_delimiter is not None:
             self.namespace_delimiter = namespace_delimiter
         bucket_name = self.config.get("stacker_bucket", None)

--- a/stacker/tests/fixtures/mock_hooks.py
+++ b/stacker/tests/fixtures/mock_hooks.py
@@ -1,0 +1,2 @@
+def mock_hook(region, namespace, mappings, parameters, **kwargs):
+    return {"result": kwargs["value"]}

--- a/stacker/tests/fixtures/mock_lookups.py
+++ b/stacker/tests/fixtures/mock_lookups.py
@@ -1,0 +1,5 @@
+TYPE_NAME = "mock"
+
+
+def handler(value, **kwargs):
+    return "mock"


### PR DESCRIPTION
Fixes #283

This causes the `sys_path` config setting to be appended to `sys.path`
at the context level when it loads the config, rather than at the action
level.  This means it can be used everywhere, including lookups & hooks.