### PR TITLE
Require explicit lookup name

### DIFF
--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -55,9 +55,11 @@ class TestBuildAction(unittest.TestCase):
     def _get_context(self, **kwargs):
         config = {"stacks": [
             {"name": "vpc"},
-            {"name": "bastion", "variables": {"test": "${vpc::something}"}},
-            {"name": "db", "variables": {"test": "${vpc::something}",
-                                         "else": "${bastion::something}"}},
+            {"name": "bastion",
+             "variables": {"test": "${output vpc::something}"}},
+            {"name": "db",
+             "variables": {"test": "${output vpc::something}",
+                           "else": "${output bastion::something}"}},
             {"name": "other", "variables": {}}
         ]}
         return Context({"namespace": "namespace"}, config=config, **kwargs)

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -264,11 +264,11 @@ class TestVariables(unittest.TestCase):
         blueprint = TestBlueprint(name="test", context=MagicMock())
         variables = [
             Variable("Param1", 1),
-            Variable("Param2", "${other-stack::Output}"),
+            Variable("Param2", "${output other-stack::Output}"),
             Variable("Param3", 3),
         ]
         resolved_lookups = {
-            mock_lookup("other-stack::Output"): "Test Output",
+            mock_lookup("other-stack::Output", "output"): "Test Output",
         }
         for var in variables:
             var.replace(resolved_lookups)
@@ -326,7 +326,7 @@ class TestVariables(unittest.TestCase):
         variables = [
             Variable(
                 "Param1",
-                "${custom non-string-return-val},${some-stack::Output}",
+                "${custom non-string-return-val},${output some-stack::Output}",
             )
         ]
         lookup = mock_lookup("non-string-return-val", "custom",

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -28,7 +28,7 @@ def generate_definition(base_name, stack_id, **overrides):
     return definition
 
 
-def mock_lookup(lookup_input, lookup_type='output', raw=None):
+def mock_lookup(lookup_input, lookup_type, raw=None):
     if raw is None:
-        raw = lookup_input
+        raw = "%s %s" % (lookup_type, lookup_input)
     return Lookup(type=lookup_type, input=lookup_input, raw=raw)

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -303,7 +303,7 @@ class TestPlan(unittest.TestCase):
         for i in range(5):
             overrides = {
                 "variables": {
-                    "Var1": "${fakeStack::FakeOutput}",
+                    "Var1": "${output fakeStack::FakeOutput}",
                     "Var2": "${xref fakeStack::FakeOutput2}",
                 },
             }

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -23,10 +23,10 @@ class TestStack(unittest.TestCase):
             variables={
                 "Var1": "${noop fakeStack3::FakeOutput}",
                 "Var2": (
-                    "some.template.value:${fakeStack2::FakeOutput}:"
-                    "${fakeStack::FakeOutput}"
+                    "some.template.value:${output fakeStack2::FakeOutput}:"
+                    "${output fakeStack::FakeOutput}"
                 ),
-                "Var3": "${fakeStack::FakeOutput},"
+                "Var3": "${output fakeStack::FakeOutput},"
                         "${output fakeStack2::FakeOutput}",
             },
             requires=[self.context.get_fqn("fakeStack")],
@@ -47,7 +47,7 @@ class TestStack(unittest.TestCase):
             base_name="vpc",
             stack_id=1,
             variables={
-                "Var1": "${vpc.1::FakeOutput}",
+                "Var1": "${output vpc.1::FakeOutput}",
             },
         )
         stack = Stack(definition=definition, context=self.context)
@@ -59,7 +59,7 @@ class TestStack(unittest.TestCase):
             base_name="vpc",
             stack_id=1,
             variables={
-                "Param1": "${fakeStack::FakeOutput}",
+                "Param1": "${output fakeStack::FakeOutput}",
             },
         )
         stack = Stack(definition=definition, context=self.context)

--- a/stacker/tests/test_variables.py
+++ b/stacker/tests/test_variables.py
@@ -19,7 +19,7 @@ class TestVariables(unittest.TestCase):
         var = Variable("Param1", "2")
         self.assertEqual(len(var.lookups), 0)
         resolved_lookups = {
-            mock_lookup("fakeStack::FakeOutput"): "resolved",
+            mock_lookup("fakeStack::FakeOutput", "output"): "resolved",
         }
         var.replace(resolved_lookups)
         self.assertEqual(var.value, "2")
@@ -32,16 +32,16 @@ class TestVariables(unittest.TestCase):
         self.assertEqual(var.value, "2")
 
     def test_variable_replace_simple_lookup(self):
-        var = Variable("Param1", "${fakeStack::FakeOutput}")
+        var = Variable("Param1", "${output fakeStack::FakeOutput}")
         self.assertEqual(len(var.lookups), 1)
         resolved_lookups = {
-            mock_lookup("fakeStack::FakeOutput"): "resolved",
+            mock_lookup("fakeStack::FakeOutput", "output"): "resolved",
         }
         var.replace(resolved_lookups)
         self.assertEqual(var.value, "resolved")
 
     def test_variable_resolve_simple_lookup(self):
-        var = Variable("Param1", "${fakeStack::FakeOutput}")
+        var = Variable("Param1", "${output fakeStack::FakeOutput}")
         self.assertEqual(len(var.lookups), 1)
         self.provider.get_output.return_value = "resolved"
         var.resolve(self.context, self.provider)
@@ -51,12 +51,13 @@ class TestVariables(unittest.TestCase):
     def test_variable_replace_multiple_lookups_string(self):
         var = Variable(
             "Param1",
-            "url://${fakeStack::FakeOutput}@${fakeStack::FakeOutput2}",
+            "url://${output fakeStack::FakeOutput}@"
+            "${output fakeStack::FakeOutput2}",
         )
         self.assertEqual(len(var.lookups), 2)
         resolved_lookups = {
-            mock_lookup("fakeStack::FakeOutput"): "resolved",
-            mock_lookup("fakeStack::FakeOutput2"): "resolved2",
+            mock_lookup("fakeStack::FakeOutput", "output"): "resolved",
+            mock_lookup("fakeStack::FakeOutput2", "output"): "resolved2",
         }
         var.replace(resolved_lookups)
         self.assertEqual(var.value, "url://resolved@resolved2")
@@ -64,7 +65,8 @@ class TestVariables(unittest.TestCase):
     def test_variable_resolve_multiple_lookups_string(self):
         var = Variable(
             "Param1",
-            "url://${fakeStack::FakeOutput}@${fakeStack::FakeOutput2}",
+            "url://${output fakeStack::FakeOutput}@"
+            "${output fakeStack::FakeOutput2}",
         )
         self.assertEqual(len(var.lookups), 2)
 
@@ -84,33 +86,33 @@ class TestVariables(unittest.TestCase):
         var = Variable("Param1", ["something", "here"])
         self.assertEqual(len(var.lookups), 0)
         resolved_lookups = {
-            mock_lookup("fakeStack::FakeOutput"): "resolved",
+            mock_lookup("fakeStack::FakeOutput", "output"): "resolved",
         }
         var.replace(resolved_lookups)
         self.assertEqual(var.value, ["something", "here"])
 
     def test_variable_replace_lookups_list(self):
-        value = ["something", "${fakeStack::FakeOutput}",
-                 "${fakeStack::FakeOutput2}"]
+        value = ["something", "${output fakeStack::FakeOutput}",
+                 "${output fakeStack::FakeOutput2}"]
         var = Variable("Param1", value)
         self.assertEqual(len(var.lookups), 2)
         resolved_lookups = {
-            mock_lookup("fakeStack::FakeOutput"): "resolved",
-            mock_lookup("fakeStack::FakeOutput2"): "resolved2",
+            mock_lookup("fakeStack::FakeOutput", "output"): "resolved",
+            mock_lookup("fakeStack::FakeOutput2", "output"): "resolved2",
         }
         var.replace(resolved_lookups)
         self.assertEqual(var.value, ["something", "resolved", "resolved2"])
 
     def test_variable_replace_lookups_dict(self):
         value = {
-            "something": "${fakeStack::FakeOutput}",
-            "other": "${fakeStack::FakeOutput2}",
+            "something": "${output fakeStack::FakeOutput}",
+            "other": "${output fakeStack::FakeOutput2}",
         }
         var = Variable("Param1", value)
         self.assertEqual(len(var.lookups), 2)
         resolved_lookups = {
-            mock_lookup("fakeStack::FakeOutput"): "resolved",
-            mock_lookup("fakeStack::FakeOutput2"): "resolved2",
+            mock_lookup("fakeStack::FakeOutput", "output"): "resolved",
+            mock_lookup("fakeStack::FakeOutput2", "output"): "resolved2",
         }
         var.replace(resolved_lookups)
         self.assertEqual(var.value, {"something": "resolved", "other":
@@ -119,21 +121,21 @@ class TestVariables(unittest.TestCase):
     def test_variable_replace_lookups_mixed(self):
         value = {
             "something": [
-                "${fakeStack::FakeOutput}",
+                "${output fakeStack::FakeOutput}",
                 "other",
             ],
             "here": {
-                "other": "${fakeStack::FakeOutput2}",
-                "same": "${fakeStack::FakeOutput}",
-                "mixed": "something:${fakeStack::FakeOutput3}",
+                "other": "${output fakeStack::FakeOutput2}",
+                "same": "${output fakeStack::FakeOutput}",
+                "mixed": "something:${output fakeStack::FakeOutput3}",
             },
         }
         var = Variable("Param1", value)
         self.assertEqual(len(var.lookups), 3)
         resolved_lookups = {
-            mock_lookup("fakeStack::FakeOutput"): "resolved",
-            mock_lookup("fakeStack::FakeOutput2"): "resolved2",
-            mock_lookup("fakeStack::FakeOutput3"): "resolved3",
+            mock_lookup("fakeStack::FakeOutput", "output"): "resolved",
+            mock_lookup("fakeStack::FakeOutput2", "output"): "resolved2",
+            mock_lookup("fakeStack::FakeOutput3", "output"): "resolved3",
         }
         var.replace(resolved_lookups)
         self.assertEqual(var.value, {


### PR DESCRIPTION
This removes the old functionality where if a lookup was called, but no
lookup handler was given, it would default to using `output`.  IE:

```
SomeVariable: ${vpc::PublicSubnets}
```

must now explicitly call to the output lookup handler:

```
SomeVariable: ${output vpc::PublicSubnets}
```

Fixes #298