### PR TITLE
Convert booleans to strings for CFNTypes

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -72,7 +72,6 @@ class CFNParameter(object):
                 "CFNParameter (%s) value must be one of %s got: %s" % (
                     name, "str, int, bool, or list", value))
 
-        print value
         self.name = name
         self.value = value
 

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -43,25 +43,33 @@ class CFNParameter(object):
 
         Args:
             name (str): the name of the CloudFormation Parameter
-            value (str or list): the value we're going to submit as a
-                CloudFormation Parameter.
+            value (str, list, int or bool): the value we're going to submit as
+                a CloudFormation Parameter.
 
         """
-        acceptable_types = [basestring, list, int]
+        acceptable_types = [basestring, bool, list, int]
         acceptable = False
         for acceptable_type in acceptable_types:
             if isinstance(value, acceptable_type):
-                # Convert integers to strings
-                if acceptable_type == int:
-                    value = str(value)
-
                 acceptable = True
+                if acceptable_type == bool:
+                    logger.debug("Converting parameter %s boolean '%s' "
+                                 "to string.", name, value)
+                    value = str(value).lower()
+                    break
+
+                if acceptable_type == int:
+                    logger.debug("Converting parameter %s integer '%s' "
+                                 "to string.", name, value)
+                    value = str(value)
+                    break
 
         if not acceptable:
             raise ValueError(
                 "CFNParameter (%s) value must be one of %s got: %s" % (
-                    name, "str, int, or list", value))
+                    name, "str, int, bool, or list", value))
 
+        print value
         self.name = name
         self.value = value
 

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -542,6 +542,11 @@ class TestCFNParameter(unittest.TestCase):
         self.assertEqual(p.value, "true")
         p = CFNParameter("myParameter", False)
         self.assertEqual(p.value, "false")
+        # Test to make sure other types aren't affected
+        p = CFNParameter("myParameter", 0)
+        self.assertEqual(p.value, "0")
+        p = CFNParameter("myParameter", "myString")
+        self.assertEqual(p.value, "myString")
 
     def test_parse_user_data(self):
         expected = 'name: tom, last: taubkin and $'

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -529,3 +529,11 @@ class TestVariables(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             TestBlueprint(name="test", context=MagicMock())
+
+
+class TestCFNParameter(unittest.TestCase):
+    def test_cfnparameter_convert_boolean(self):
+        p = CFNParameter("myParameter", True)
+        self.assertEqual(p.value, "true")
+        p = CFNParameter("myParameter", False)
+        self.assertEqual(p.value, "false")

--- a/stacker/tests/lookups/handlers/test_kms.py
+++ b/stacker/tests/lookups/handlers/test_kms.py
@@ -26,7 +26,6 @@ class TestKMSHandler(unittest.TestCase):
     def test_kms_handler_with_region(self):
         region = "us-east-1"
         value = "%s@%s" % (region, self.secret)
-        print value
         with mock_kms():
             decrypted = handler(value)
             self.assertEqual(decrypted, self.plain)


### PR DESCRIPTION
This is old functionality that was lost with the conversion to Variables
& CFNTypes.

Fixes #290