### PR TITLE
add default lookup

### DIFF
--- a/stacker/lookups/handlers/default.py
+++ b/stacker/lookups/handlers/default.py
@@ -1,0 +1,32 @@
+TYPE_NAME = "default"
+
+
+def handler(value, **kwargs):
+    """Use a value from the environment or fall back to a default if the
+       environment doesn't contain the variable.
+
+    Format of value:
+
+        <env_var>::<default value>
+
+    For example:
+
+        Groups: ${default app_security_groups::sg-12345,sg-67890}
+
+    If `app_security_groups` is defined in the environment, its defined value
+    will be returned. Otherwise, `sg-12345,sg-67890` will be the returned
+    value.
+
+    This allows defaults to be set at the config file level.
+    """
+
+    try:
+        env_var_name, default_val = value.split("::", 1)
+    except ValueError:
+        raise ValueError("Invalid value for default: %s. Must be in "
+                         "<env_var>::<default value> format." % value)
+
+    if env_var_name in kwargs['context'].environment:
+        return kwargs['context'].environment[env_var_name]
+    else:
+        return default_val

--- a/stacker/lookups/registry.py
+++ b/stacker/lookups/registry.py
@@ -7,6 +7,7 @@ from .handlers import xref
 from .handlers import ssmstore
 from .handlers import file as file_handler
 from .handlers import split
+from .handlers import default
 
 LOOKUP_HANDLERS = {}
 DEFAULT_LOOKUP = output.TYPE_NAME
@@ -73,3 +74,4 @@ register_lookup_handler(ssmstore.TYPE_NAME, ssmstore.handler)
 register_lookup_handler(xref.TYPE_NAME, xref.handler)
 register_lookup_handler(file_handler.TYPE_NAME, file_handler.handler)
 register_lookup_handler(split.TYPE_NAME, split.handler)
+register_lookup_handler(default.TYPE_NAME, default.handler)

--- a/stacker/tests/lookups/handlers/test_default.py
+++ b/stacker/tests/lookups/handlers/test_default.py
@@ -1,0 +1,35 @@
+from mock import MagicMock
+import unittest
+
+from stacker.context import Context
+from stacker.lookups.handlers.default import handler
+
+
+class TestDefaultLookup(unittest.TestCase):
+
+    def setUp(self):
+        self.provider = MagicMock()
+        self.context = Context(
+            environment={
+                'namespace': 'test',
+                'env_var': 'val_in_env'}
+        )
+
+    def test_env_var_present(self):
+        lookup_val = "env_var::fallback"
+        value = handler(lookup_val,
+                        provider=self.provider,
+                        context=self.context)
+        assert value == 'val_in_env'
+
+    def test_env_var_missing(self):
+        lookup_val = "bad_env_var::fallback"
+        value = handler(lookup_val,
+                        provider=self.provider,
+                        context=self.context)
+        assert value == 'fallback'
+
+    def test_invalid_value(self):
+        value = "env_var:fallback"
+        with self.assertRaises(ValueError):
+            handler(value)


### PR DESCRIPTION
**Updated**: See next comment instead.

I'd like the ability to reference environment variables that might not
be specified.

~~However, it doesn't appear to be working yet; specifying something like:~~
```
Variables:
  InstanceType: ${default ${nonpresent_env_var}::t2.micro}
```
~~in the config yaml results in a stacktrace:~~
```
Traceback (most recent call last):
  File "/Users/troyready/Library/Python/2.7/bin/stacker", line 9, in <module>
    args.run(args)
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/stacker/commands/stacker/build.py", line 52, in run
    dump=options.dump)
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/stacker/actions/base.py", line 122, in execute
    self.run(*args, **kwargs)
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/stacker/actions/build.py", line 279, in run
    plan = self._generate_plan(tail=tail)
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/stacker/actions/build.py", line 243, in _generate_plan
    dependencies = self._get_dependencies()
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/stacker/actions/build.py", line 255, in _get_dependencies
    dependencies[stack.fqn] = stack.requires
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/stacker/stack.py", line 87, in requires
    d = deconstruct(lookup.input)
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/stacker/lookups/handlers/output.py", line 44, in deconstruct
    stack_name, output_name = value.split("::")
ValueError: need more than 1 value to unpack
```

~~I'm think this might be related to #298 , so this might 'just work' after it's resolved?~~