### PR TITLE
Remove default aws region

### DIFF
--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -126,9 +126,8 @@ class BaseCommand(object):
                                  "the command line. Overrides your "
                                  "environment file settings. Can be specified "
                                  "more than once.")
-        parser.add_argument("-r", "--region", default="us-east-1",
-                            help="The AWS region to launch in. Default: "
-                                 "%(default)s")
+        parser.add_argument("-r", "--region",
+                            help="The AWS region to launch in.")
         parser.add_argument("-v", "--verbose", action="count", default=0,
                             help="Increase output verbosity. May be specified "
                                  "up to twice.")

--- a/stacker/lookups/handlers/kms.py
+++ b/stacker/lookups/handlers/kms.py
@@ -12,7 +12,8 @@ def handler(value, **kwargs):
 
         [<region>@]<base64 encrypted value>
 
-    Note: The region is optional, and defaults to us-east-1 if not given.
+    Note: The region is optional, and defaults to the environment's
+    `AWS_DEFAULT_REGION` if not specified.
 
     For example:
 
@@ -42,7 +43,7 @@ def handler(value, **kwargs):
     """
     value = read_value_from_path(value)
 
-    region = "us-east-1"
+    region = None
     if "@" in value:
         region, value = value.split("@", 1)
 

--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -16,7 +16,8 @@ def get_session(region):
             credential caching
     """
     session = botocore.session.get_session()
-    session.set_config_variable('region',  region)
+    if region is not None:
+        session.set_config_variable('region',  region)
     c = session.get_component('credential_provider')
     provider = c.get_provider('assume-role')
     provider.cache = CredentialCache()

--- a/stacker/tests/test_stacker.py
+++ b/stacker/tests/test_stacker.py
@@ -19,6 +19,16 @@ class TestStacker(unittest.TestCase):
         # verify namespace was modified
         self.assertEqual(args.environment["namespace"], "test.override")
 
+    def test_stacker_build_parse_args_region_from_env(self):
+        stacker = Stacker()
+        args = stacker.parse_args(
+            ["build",
+             "-e", "namespace=test.override",
+             "stacker/tests/fixtures/basic.env",
+             "stacker/tests/fixtures/vpc-bastion-db-web.yaml"]
+        )
+        self.assertEqual(args.region, None)
+
     def test_stacker_build_context_passed_to_blueprint(self):
         stacker = Stacker()
         args = stacker.parse_args(


### PR DESCRIPTION
This will still allow the region to be specified via '-r', but adds the
additional option to set it via `AWS_DEFAULT_ENVIRONMENT`.

A failure to provide either will generate a fairly clear stacktrace
like:
```
...
  File "/Users/troyready/Library/Python/2.7/lib/python/site-packages/botocore/regions.py", line 135, in _endpoint_for_partition
    raise NoRegionError()
botocore.exceptions.NoRegionError: You must specify a region.
```

This does introduce an additional unit testing requirement to set the environment variable; not sure if there's a better way to handle that for the kms lookup?

It's a fairly major change, but this follows alongside the logic of #298 and will help keep mistakes from happening (a NoRegionError is more clear than an xref failing with a output lookup stacktrace, or a bunch of stuff deployed to the wrong region).
