### PR TITLE
Normal errors

### DIFF
--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -37,5 +37,11 @@ def handler(value, provider=None, context=None, fqn=False, **kwargs):
 
 
 def deconstruct(value):
+
+    # Probably an undefined environment variable
+    # Provides a clearer statement for debugging
+    if "::" not in value:
+        raise ValueError("Unknown variable in config file: %s" % value)
+
     stack_name, output_name = value.split("::")
     return Output(stack_name, output_name)


### PR DESCRIPTION
It actually outputs the name of the env variable that is not recognized 