### PR TITLE
Make the new release-1.0 more clear.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,4 +6,4 @@ build:
 test:
 	flake8 --exclude stacker/tests/ stacker
 	flake8 --ignore N802 stacker/tests # ignore setUp naming
-	python setup.py test
+	AWS_DEFAULT_REGION=us-east-1 python setup.py test

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -46,24 +46,31 @@ class CFNParameter(object):
 
         Args:
             name (str): the name of the CloudFormation Parameter
-            value (str or list): the value we're going to submit as a
-                CloudFormation Parameter.
+            value (str, list, int or bool): the value we're going to submit as
+                a CloudFormation Parameter.
 
         """
-        acceptable_types = [basestring, list, int]
+        acceptable_types = [basestring, bool, list, int]
         acceptable = False
         for acceptable_type in acceptable_types:
             if isinstance(value, acceptable_type):
-                # Convert integers to strings
-                if acceptable_type == int:
-                    value = str(value)
-
                 acceptable = True
+                if acceptable_type == bool:
+                    logger.debug("Converting parameter %s boolean '%s' "
+                                 "to string.", name, value)
+                    value = str(value).lower()
+                    break
+
+                if acceptable_type == int:
+                    logger.debug("Converting parameter %s integer '%s' "
+                                 "to string.", name, value)
+                    value = str(value)
+                    break
 
         if not acceptable:
             raise ValueError(
                 "CFNParameter (%s) value must be one of %s got: %s" % (
-                    name, "str, int, or list", value))
+                    name, "str, int, bool, or list", value))
 
         self.name = name
         self.value = value

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -17,6 +17,14 @@ class UnknownLookupType(Exception):
         super(UnknownLookupType, self).__init__(message, *args, **kwargs)
 
 
+class FailedVariableLookup(Exception):
+
+    def __init__(self, variable_name, error, *args, **kwargs):
+        message = "Couldn't resolve lookups in variable `%s`. " % variable_name
+        message += "%s" % error
+        super(FailedVariableLookup, self).__init__(message, *args, **kwargs)
+
+
 class InvalidUserdataPlaceholder(Exception):
 
     def __init__(self, blueprint_name, exception_message, *args, **kwargs):

--- a/stacker/lookups/__init__.py
+++ b/stacker/lookups/__init__.py
@@ -38,10 +38,11 @@ def extract_lookups_from_string(value):
         raw = match.groups()[0]
         lookup_type = groupdict["type"]
         if not lookup_type:
-            raise ValueError("stacker only allows explicit lookup types "
+            raise ValueError("on value `%s`\n"
+                             "stacker only allows explicit lookup types "
                              "now, and no longer uses `output` as the "
                              "default if not specified. Please update your "
-                             "output lookups.")
+                             "output lookups." % groupdict["input"])
         lookup_input = groupdict["input"]
         lookups.add(Lookup(lookup_type, lookup_input, raw))
     return lookups

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -28,6 +28,7 @@ def handler(value, provider=None, context=None, fqn=False, **kwargs):
         raise ValueError('Context is required')
 
     d = deconstruct(value)
+
     stack_fqn = d.stack_name
     if not fqn:
         stack_fqn = context.get_fqn(d.stack_name)
@@ -37,5 +38,11 @@ def handler(value, provider=None, context=None, fqn=False, **kwargs):
 
 
 def deconstruct(value):
-    stack_name, output_name = value.split("::")
+
+    try:
+        stack_name, output_name = value.split("::")
+    except:
+        raise ValueError(
+            'Could not parse value in output lookup `%s`.' % value)
+
     return Output(stack_name, output_name)

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -42,7 +42,7 @@ def deconstruct(value):
     try:
         stack_name, output_name = value.split("::")
     except:
-        raise ValueError(
-            'Could not parse value in output lookup `%s`.' % value)
+        raise ValueError("output handler requires syntax "
+                         "of <stack>::<output>.  Got: %s" % value)
 
     return Output(stack_name, output_name)

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -37,11 +37,5 @@ def handler(value, provider=None, context=None, fqn=False, **kwargs):
 
 
 def deconstruct(value):
-
-    # Probably an undefined environment variable
-    # Provides a clearer statement for debugging
-    if "::" not in value:
-        raise ValueError("Unknown variable in config file: %s" % value)
-
     stack_name, output_name = value.split("::")
     return Output(stack_name, output_name)

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -10,6 +10,8 @@ from .lookups.handlers.output import (
     deconstruct,
 )
 
+from .exceptions import FailedVariableLookup
+
 
 def _gather_variables(stack_def):
     """Merges context provided & stack defined variables.
@@ -46,6 +48,7 @@ def _gather_variables(stack_def):
 
 
 class Stack(object):
+
     """Represents gathered information about a stack to be built/updated.
 
     Args:
@@ -84,7 +87,12 @@ class Stack(object):
         for variable in self.variables:
             for lookup in variable.lookups:
                 if lookup.type == OUTPUT_LOOKUP_TYPE_NAME:
-                    d = deconstruct(lookup.input)
+
+                    try:
+                        d = deconstruct(lookup.input)
+                    except ValueError as e:
+                        raise FailedVariableLookup(self.name, e)
+
                     if d.stack_name == self.name:
                         message = (
                             "Variable %s in stack %s has a ciruclar reference "

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -535,6 +535,19 @@ class TestVariables(unittest.TestCase):
         with self.assertRaises(AttributeError):
             TestBlueprint(name="test", context=MagicMock())
 
+
+class TestCFNParameter(unittest.TestCase):
+    def test_cfnparameter_convert_boolean(self):
+        p = CFNParameter("myParameter", True)
+        self.assertEqual(p.value, "true")
+        p = CFNParameter("myParameter", False)
+        self.assertEqual(p.value, "false")
+        # Test to make sure other types aren't affected
+        p = CFNParameter("myParameter", 0)
+        self.assertEqual(p.value, "0")
+        p = CFNParameter("myParameter", "myString")
+        self.assertEqual(p.value, "myString")
+
     def test_parse_user_data(self):
         expected = 'name: tom, last: taubkin and $'
         variables = {

--- a/stacker/tests/lookups/handlers/test_kms.py
+++ b/stacker/tests/lookups/handlers/test_kms.py
@@ -26,7 +26,6 @@ class TestKMSHandler(unittest.TestCase):
     def test_kms_handler_with_region(self):
         region = "us-east-1"
         value = "%s@%s" % (region, self.secret)
-        print value
         with mock_kms():
             decrypted = handler(value)
             self.assertEqual(decrypted, self.plain)

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 from stacker.context import Context
-from stacker.exceptions import ImproperlyConfigured
+from stacker.exceptions import ImproperlyConfigured, FailedVariableLookup
 from stacker.lookups.registry import (
     register_lookup_handler,
     unregister_lookup_handler,
@@ -320,7 +320,7 @@ class TestPlan(unittest.TestCase):
                 requires=stack.requires,
             )
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FailedVariableLookup):
             plan.dump("test", context=self.context)
 
     def test_plan_checkpoint_interval(self):

--- a/stacker/tests/test_variables.py
+++ b/stacker/tests/test_variables.py
@@ -1,12 +1,18 @@
-from mock import MagicMock
+from mock import MagicMock, patch
 import unittest
 
 from troposphere import s3
 from stacker.blueprints.variables.types import TroposphereType
 from stacker.variables import Variable
 from stacker.lookups import register_lookup_handler
+from stacker.exceptions import FailedVariableLookup
+
 
 from .factories import mock_lookup
+
+
+def lookup_error(a, b):
+    return ValueError('Not Valid')
 
 
 class TestVariables(unittest.TestCase):
@@ -149,6 +155,13 @@ class TestVariables(unittest.TestCase):
                 "mixed": "something:resolved3",
             },
         })
+
+    @patch('stacker.variables.resolve_lookups', ValueError('bob'))
+    def test_resolve_catch_exception(self):
+        var = Variable("Param1", "${output fakeStack::FakeOutput}")
+
+        with self.assertRaises(FailedVariableLookup):
+            var.resolve(self.context, self.provider)
 
     def test_variable_resolve_nested_lookup(self):
 

--- a/stacker/variables.py
+++ b/stacker/variables.py
@@ -6,8 +6,11 @@ from .lookups import (
     resolve_lookups,
 )
 
+from exceptions import FailedVariableLookup
+
 
 class LookupTemplate(Template):
+
     """A custom string template we use to replace lookup values"""
     idpattern = r'[_a-z][^\$\{\}]*'
 
@@ -75,6 +78,7 @@ def resolve_variables(variables, context, provider):
 
 
 class Variable(object):
+
     """Represents a variable passed to a stack.
 
     Args:
@@ -130,8 +134,16 @@ class Variable(object):
                 the base provider
 
         """
+
+        print self.lookups
+
         while self.lookups:
-            resolved_lookups = resolve_lookups(self.lookups, context, provider)
+            try:
+                resolved_lookups = resolve_lookups(
+                    self.lookups, context, provider)
+            except Exception as e:
+                raise FailedVariableLookup(self.name, e)
+
             self.replace(resolved_lookups)
 
     def replace(self, resolved_lookups):


### PR DESCRIPTION
The new error:

```
stacker only allows explicit lookup types now, and no longer uses `output` as the default if not specified. Please update your output lookups.
```

was preventing my old error which explicitly mentioned what variable it was failing on from being raised. So I just, added the new info the the error.