### PR TITLE
added rxref lookup

### DIFF
--- a/docs/lookups.rst
+++ b/docs/lookups.rst
@@ -59,6 +59,7 @@ stacker includes the following lookup types:
   - output_
   - kms_
   - xref_
+  - rxref
 
 .. _output:
 
@@ -138,6 +139,30 @@ requirements.
 For example::
 
   ConfVariable: ${xref fully-qualified-stack::SomeOutput}
+
+.. file:
+
+.. _rxref:
+
+RXRef Lookup
+-----------
+
+The ``rxref`` lookup type is very similar to the ``output`` and ``xref`` lookup
+type, the difference being that ``rxref`` resolves output values from stacks
+that are relative to the current namespace but external to the stack.
+
+The ``output`` type will take a stack name prefixed by the namespace
+and use the current context to expand the fully qualified stack name
+based on the namespace. ``rxref`` skips this expansion because it assumes
+you've provided it with the fully qualified stack name already. This allows
+you to reference output values from any CloudFormation stack.
+
+Also, unlike the ``output`` lookup type, ``rxref`` doesn't impact stack
+requirements.
+
+For example::
+
+  ConfVariable: ${rxref fully-qualified-stack::SomeOutput}
 
 .. file:
 

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -4,8 +4,7 @@ TYPE_NAME = "output"
 
 Output = namedtuple("Output", ("stack_name", "output_name"))
 
-
-def handler(value, provider=None, context=None, fqn=False, **kwargs):
+def handler(value, provider=None, context=None, fqn=False, rfqn=False, **kwargs):
     """Fetch an output from the designated stack.
 
     Args:
@@ -17,11 +16,18 @@ def handler(value, provider=None, context=None, fqn=False, **kwargs):
         fqn (bool): boolean for whether or not the
             :class:`stacker.context.Context` should resolve the `fqn` of the
             stack.
+        rfqn (bool): boolean for whether or not the
+            :class:`stacker.context.Context` should resolve the `fqn` of the
+            stack prefixed by the namespace variable
 
     Returns:
         str: output from the specified stack
 
     """
+
+    if rfqn and context.environment.get('namespace'):
+        value = "%s%s%s" % (context.environment['namespace'], context.environment.get('namespace_delimiter') or '-', value)
+
     if provider is None:
         raise ValueError('Provider is required')
     if context is None:

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -27,11 +27,11 @@ def handler(value, provider=None, context=None, fqn=False, rfqn=False,
 
     """
 
-    if rfqn and context.environment.get('namespace'):
+    if rfqn and context.environment['namespace']:
             value = "%s%s%s" % (
                     context.environment['namespace'],
-                    context.environment.get('namespace_delimiter')
-                    or '-', value
+                    context.environment.get('namespace_delimiter', '-'),
+                    value
             )
 
     if provider is None:

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -27,7 +27,7 @@ def handler(value, provider=None, context=None, fqn=False, rfqn=False,
 
     """
 
-    if rfqn and context.environment['namespace']:
+    if rfqn:
             value = "%s%s%s" % (
                     context.environment['namespace'],
                     context.environment.get('namespace_delimiter', '-'),

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -4,7 +4,9 @@ TYPE_NAME = "output"
 
 Output = namedtuple("Output", ("stack_name", "output_name"))
 
-def handler(value, provider=None, context=None, fqn=False, rfqn=False, **kwargs):
+
+def handler(value, provider=None, context=None, fqn=False, rfqn=False,
+            **kwargs):
     """Fetch an output from the designated stack.
 
     Args:
@@ -26,7 +28,11 @@ def handler(value, provider=None, context=None, fqn=False, rfqn=False, **kwargs)
     """
 
     if rfqn and context.environment.get('namespace'):
-        value = "%s%s%s" % (context.environment['namespace'], context.environment.get('namespace_delimiter') or '-', value)
+            value = "%s%s%s" % (
+                    context.environment['namespace'],
+                    context.environment.get('namespace_delimiter')
+                    or '-', value
+            )
 
     if provider is None:
         raise ValueError('Provider is required')

--- a/stacker/lookups/handlers/rxref.py
+++ b/stacker/lookups/handlers/rxref.py
@@ -1,0 +1,23 @@
+"""Handler for fetching outputs from fully qualified stacks.
+
+The `output` handler supports fetching outputs from stacks created within a
+sigle config file. Sometimes it's useful to fetch outputs from stacks created
+outside of the current config file. `rxref` supports this by not using the
+:class:`stacker.context.Context` to expand the fqn of the stack.
+
+Example:
+
+    conf_value: ${rxref some-relative-fully-qualified-stack-name::SomeOutputName}
+
+"""
+from functools import partial
+
+from .output import handler as output_handler
+
+TYPE_NAME = "rxref"
+
+import sys
+
+# rxref is the same as the `output` handler, except the value already contains
+# the relative fully qualified name for the stack we're fetching the output from.
+handler = partial(output_handler, rfqn=True)

--- a/stacker/lookups/handlers/rxref.py
+++ b/stacker/lookups/handlers/rxref.py
@@ -7,7 +7,8 @@ outside of the current config file. `rxref` supports this by not using the
 
 Example:
 
-    conf_value: ${rxref some-relative-fully-qualified-stack-name::SomeOutputName}
+    conf_value: ${rxref
+        some-relative-fully-qualified-stack-name::SomeOutputName}
 
 """
 from functools import partial
@@ -16,8 +17,7 @@ from .output import handler as output_handler
 
 TYPE_NAME = "rxref"
 
-import sys
-
 # rxref is the same as the `output` handler, except the value already contains
-# the relative fully qualified name for the stack we're fetching the output from.
+# the relative fully qualified name for the stack we're fetching the output
+# from.
 handler = partial(output_handler, rfqn=True)

--- a/stacker/lookups/registry.py
+++ b/stacker/lookups/registry.py
@@ -5,6 +5,7 @@ from .handlers import output
 from .handlers import kms
 from .handlers import xref
 from .handlers import ssmstore
+from .handlers import rxref
 from .handlers import file as file_handler
 
 LOOKUP_HANDLERS = {}
@@ -57,4 +58,5 @@ register_lookup_handler(output.TYPE_NAME, output.handler)
 register_lookup_handler(kms.TYPE_NAME, kms.handler)
 register_lookup_handler(ssmstore.TYPE_NAME, ssmstore.handler)
 register_lookup_handler(xref.TYPE_NAME, xref.handler)
+register_lookup_handler(rxref.TYPE_NAME, rxref.handler)
 register_lookup_handler(file_handler.TYPE_NAME, file_handler.handler)

--- a/stacker/tests/lookups/handlers/test_rxref.py
+++ b/stacker/tests/lookups/handlers/test_rxref.py
@@ -1,0 +1,25 @@
+from mock import MagicMock
+import unittest
+
+from stacker.lookups.handlers.rxref import handler
+from ....context import Context
+
+
+class TestRxrefHandler(unittest.TestCase):
+
+    def setUp(self):
+        self.provider = MagicMock()
+        self.context = Context(
+            environment={"namespace": "ns"}
+        )
+
+    def test_rxref_handler(self):
+        self.provider.get_output.return_value = "Test Output"
+
+        value = handler("fully-qualified-stack-name::SomeOutput",
+                        provider=self.provider, context=self.context)
+        self.assertEqual(value, "Test Output")
+
+        args = self.provider.get_output.call_args
+        self.assertEqual(args[0][0], "ns-fully-qualified-stack-name")
+        self.assertEqual(args[0][1], "SomeOutput")


### PR DESCRIPTION
The new rxref lookup will search for stack names relative to the current `namespace` identified in the environment file.

This encourages reuse of stacks in multiple environments within the same AWS account.

Thanks for building some great software!