### PR TITLE
add ability to load python classes (blueprints, etc) directly from git

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -53,6 +53,36 @@ inside the same repo as config files).
 Adding a path (e.g. ``./``) to the **sys_path** top level key word will allow
 modules from that path location to be used.
 
+Remote Packages
+----------------
+The **package_sources** top level keyword can be used to define remote git
+sources for blueprints (e.g., retrieving ``stacker_blueprints`` on github at
+tag ``v1.0.2``).
+
+The only required key for a git repository config is ``uri``, but ``branch``,
+``tag``, & ``commit`` can also be specified::
+  package_sources:
+    git:
+      - uri: git@github.com:acmecorp/stacker_blueprints.git
+      - uri: git@github.com:remind101/stacker_blueprints.git
+        tag: 1.0.0
+        paths:
+          - stacker_blueprints
+      - uri: git@github.com:contoso/webapp.git
+        branch: staging
+      - uri: git@github.com:contoso/foo.git
+        commit: 12345678
+
+Use the ``paths`` option when subdirectories of the repo should be added to
+Stacker's ``sys.path``.
+
+If no specific commit or tag is specified for a repo, the remote repository
+will be checked for newer commits on every execution of Stacker.
+
+Cloned repositories will be cached between builds; the cache location defaults
+to ~/.stacker but can be manually specified via the **stacker_cache_dir** top
+level keyword.
+
 Pre & Post Hooks
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ install_requires = [
     "PyYAML~=3.11",
     "awacs~=0.6.0",
     "colorama~=0.3.7",
-    "formic~=0.9b"
+    "formic~=0.9b",
+    "gitpython~=2.0"
 ]
 
 tests_require = [

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import sys
 
+from stacker.util import SourceProcessor
 from .config import parse_config
 from .exceptions import MissingEnvironment
 from .stack import Stack
@@ -89,6 +90,12 @@ class Context(object):
         lookups = self.config.get("lookups", {})
         for key, handler in lookups.iteritems():
             register_lookup_handler(key, handler)
+        sources = self.config.get("package_sources")
+        if sources is not None:
+            processor = SourceProcessor(
+                stacker_cache_dir=self.config.get("stacker_cache_dir")
+            )
+            processor.get_package_sources(sources=sources)
 
     def _get_stack_definitions(self):
         if not self.stack_names:

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -1,4 +1,7 @@
+import os
+import shutil
 import sys
+import tempfile
 import textwrap
 import unittest
 
@@ -161,6 +164,32 @@ class TestContext(unittest.TestCase):
         stage = "pre_build"
         handle_hooks(stage, context.config[stage], "mock-region-1", context)
         self.assertEqual("mockResult", context.hook_data["myHook"]["result"])
+
+    def test_package_sources_in_config(self):
+        tmp_dir = tempfile.mkdtemp(prefix='stackerunittest')
+        try:
+            context = Context({"namespace": "test"})
+            config = textwrap.dedent("""\
+                stacker_cache_dir: %s
+                package_sources:
+                  git:
+                    - uri: https://github.com/remind101/stacker_blueprints.git
+                      tag: 1.0.0
+                      paths:
+                        - stacker_blueprints
+            """ % tmp_dir)
+            context.load_config(config)
+            self.assertEqual(
+                sys.path[-1],
+                os.path.join(
+                    tmp_dir,
+                    'packages',
+                    'https___github.com_remind101_stacker_blueprints-1.0.0',
+                    'stacker_blueprints'
+                )
+            )
+        finally:
+            shutil.rmtree(tmp_dir)
 
 
 class TestFunctions(unittest.TestCase):

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -1,7 +1,4 @@
-# import os
-# import shutil
 import sys
-# import tempfile
 import textwrap
 import unittest
 
@@ -164,32 +161,6 @@ class TestContext(unittest.TestCase):
         stage = "pre_build"
         handle_hooks(stage, context.config[stage], "mock-region-1", context)
         self.assertEqual("mockResult", context.hook_data["myHook"]["result"])
-
-#     def test_package_sources_in_config(self):
-#         tmp_dir = tempfile.mkdtemp(prefix='stackerunittest')
-#         try:
-#             context = Context({"namespace": "test"})
-#             config = textwrap.dedent("""\
-#                 stacker_cache_dir: %s
-#                 package_sources:
-#                   git:
-#                     - uri: git@github.com:remind101/stacker_blueprints.git
-#                       tag: 1.0.0
-#                       paths:
-#                         - stacker_blueprints
-#             """ % tmp_dir)
-#             context.load_config(config)
-#             self.assertEqual(
-#                 sys.path[-1],
-#                 os.path.join(
-#                     tmp_dir,
-#                     'packages',
-#                     'git_github.com_remind101_stacker_blueprints-1.0.0',
-#                     'stacker_blueprints'
-#                 )
-#             )
-#         finally:
-#             shutil.rmtree(tmp_dir)
 
 
 class TestFunctions(unittest.TestCase):

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -1,7 +1,7 @@
-import os
-import shutil
+# import os
+# import shutil
 import sys
-import tempfile
+# import tempfile
 import textwrap
 import unittest
 
@@ -165,31 +165,31 @@ class TestContext(unittest.TestCase):
         handle_hooks(stage, context.config[stage], "mock-region-1", context)
         self.assertEqual("mockResult", context.hook_data["myHook"]["result"])
 
-    def test_package_sources_in_config(self):
-        tmp_dir = tempfile.mkdtemp(prefix='stackerunittest')
-        try:
-            context = Context({"namespace": "test"})
-            config = textwrap.dedent("""\
-                stacker_cache_dir: %s
-                package_sources:
-                  git:
-                    - uri: https://github.com/remind101/stacker_blueprints.git
-                      tag: 1.0.0
-                      paths:
-                        - stacker_blueprints
-            """ % tmp_dir)
-            context.load_config(config)
-            self.assertEqual(
-                sys.path[-1],
-                os.path.join(
-                    tmp_dir,
-                    'packages',
-                    'https___github.com_remind101_stacker_blueprints-1.0.0',
-                    'stacker_blueprints'
-                )
-            )
-        finally:
-            shutil.rmtree(tmp_dir)
+#     def test_package_sources_in_config(self):
+#         tmp_dir = tempfile.mkdtemp(prefix='stackerunittest')
+#         try:
+#             context = Context({"namespace": "test"})
+#             config = textwrap.dedent("""\
+#                 stacker_cache_dir: %s
+#                 package_sources:
+#                   git:
+#                     - uri: git@github.com:remind101/stacker_blueprints.git
+#                       tag: 1.0.0
+#                       paths:
+#                         - stacker_blueprints
+#             """ % tmp_dir)
+#             context.load_config(config)
+#             self.assertEqual(
+#                 sys.path[-1],
+#                 os.path.join(
+#                     tmp_dir,
+#                     'packages',
+#                     'git_github.com_remind101_stacker_blueprints-1.0.0',
+#                     'stacker_blueprints'
+#                 )
+#             )
+#         finally:
+#             shutil.rmtree(tmp_dir)
 
 
 class TestFunctions(unittest.TestCase):

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -2,9 +2,9 @@ import unittest
 
 import string
 import os
-import shutil
-import sys
-import tempfile
+# import shutil
+# import sys
+# import tempfile
 import Queue
 
 import mock
@@ -128,26 +128,26 @@ class TestUtil(unittest.TestCase):
                 '857b4834980e582874d70feef77bb064b60762d1'
             )
 
-    def test_SourceProcessor_operation(self):
-        tmp_dir = tempfile.mkdtemp(prefix='stackerunittest')
-        try:
-            sp = SourceProcessor(stacker_cache_dir=tmp_dir)
-            sp.get_package_sources(
-                {'git': [{
-                    'uri': 'https://github.com/remind101/'
-                           'stacker_blueprints.git',
-                    'tag': '1.0.0',
-                    'paths': ['stacker_blueprints']}]}
-            )
-            self.assertEqual(
-                sys.path[-1],
-                os.path.join(
-                    sp.package_cache_dir,
-                    'https___github.com_remind101_stacker_blueprints-1.0.0',
-                    'stacker_blueprints')
-            )
-        finally:
-            shutil.rmtree(tmp_dir)
+    # def test_SourceProcessor_operation(self):
+    #     tmp_dir = tempfile.mkdtemp(prefix='stackerunittest')
+    #     try:
+    #         sp = SourceProcessor(stacker_cache_dir=tmp_dir)
+    #         sp.get_package_sources(
+    #             {'git': [{
+    #                 'uri': 'https://github.com/remind101/'
+    #                        'stacker_blueprints.git',
+    #                 'tag': '1.0.0',
+    #                 'paths': ['stacker_blueprints']}]}
+    #         )
+    #         self.assertEqual(
+    #             sys.path[-1],
+    #             os.path.join(
+    #                 sp.package_cache_dir,
+    #                 'https___github.com_remind101_stacker_blueprints-1.0.0',
+    #                 'stacker_blueprints')
+    #         )
+    #     finally:
+    #         shutil.rmtree(tmp_dir)
 
 
 hook_queue = Queue.Queue()

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -2,9 +2,6 @@ import unittest
 
 import string
 import os
-# import shutil
-# import sys
-# import tempfile
 import Queue
 
 import mock
@@ -128,26 +125,32 @@ class TestUtil(unittest.TestCase):
                 '857b4834980e582874d70feef77bb064b60762d1'
             )
 
-    # def test_SourceProcessor_operation(self):
-    #     tmp_dir = tempfile.mkdtemp(prefix='stackerunittest')
-    #     try:
-    #         sp = SourceProcessor(stacker_cache_dir=tmp_dir)
-    #         sp.get_package_sources(
-    #             {'git': [{
-    #                 'uri': 'https://github.com/remind101/'
-    #                        'stacker_blueprints.git',
-    #                 'tag': '1.0.0',
-    #                 'paths': ['stacker_blueprints']}]}
-    #         )
-    #         self.assertEqual(
-    #             sys.path[-1],
-    #             os.path.join(
-    #                 sp.package_cache_dir,
-    #                 'https___github.com_remind101_stacker_blueprints-1.0.0',
-    #                 'stacker_blueprints')
-    #         )
-    #     finally:
-    #         shutil.rmtree(tmp_dir)
+            bad_configs = [{'uri': 'x',
+                            'commit': '1234',
+                            'tag': 'v1',
+                            'branch': 'x'},
+                           {'uri': 'x', 'commit': '1234', 'tag': 'v1'},
+                           {'uri': 'x', 'commit': '1234', 'branch': 'x'},
+                           {'uri': 'x', 'tag': 'v1', 'branch': 'x'},
+                           {'uri': 'x', 'commit': '1234', 'branch': 'x'}]
+            for i in bad_configs:
+                with self.assertRaises(ImportError):
+                    sp.determine_git_ref(i)
+
+            self.assertEqual(
+                sp.determine_git_ref({'uri': 'https://github.com/remind101/'
+                                             'stacker.git',
+                                      'branch': 'release-1.0'}),
+                '857b4834980e582874d70feef77bb064b60762d1'
+            )
+            self.assertEqual(
+                sp.determine_git_ref({'uri': 'git@foo', 'commit': '1234'}),
+                '1234'
+            )
+            self.assertEqual(
+                sp.determine_git_ref({'uri': 'git@foo', 'tag': 'v1.0.0'}),
+                'v1.0.0'
+            )
 
 
 hook_queue = Queue.Queue()

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -5,8 +5,12 @@ import importlib
 import logging
 import os
 import re
+import shutil
+import subprocess
 import sys
+import tempfile
 import time
+from git import Repo
 
 import botocore.exceptions
 
@@ -448,3 +452,168 @@ def ensure_s3_bucket(s3_client, bucket_name, bucket_region):
             logger.exception("Error creating bucket %s. Error %s",
                              bucket_name, e.response)
             raise
+
+
+class SourceProcessor():
+    """Makes remote python package sources available in the running python
+       environment."""
+
+    def __init__(self, stacker_cache_dir=None):
+        """
+        Processes a config's list of package sources
+
+        Args:
+            stacker_cache_dir (string): Directory of stacker local cache.
+                                        Default to $HOME/.stacker
+        """
+        stacker_cache_dir = (stacker_cache_dir or
+                             os.path.join(os.environ['HOME'], '.stacker'))
+        package_cache_dir = os.path.join(stacker_cache_dir, 'packages')
+        self.stacker_cache_dir = stacker_cache_dir
+        self.package_cache_dir = package_cache_dir
+        self.create_cache_directories()
+
+    def create_cache_directories(self):
+        """Ensures that SourceProcessor cache directories exist.
+
+           Returns True to indicate the cache directories are present."""
+        if not os.path.isdir(self.package_cache_dir):
+            if not os.path.isdir(self.stacker_cache_dir):
+                os.mkdir(self.stacker_cache_dir)
+            os.mkdir(self.package_cache_dir)
+        return True
+
+    def get_package_sources(self, sources):
+        """Makes remote python packages available for local use
+
+        Args:
+            sources (dict): Dictionary of remote sources from config.
+                            Currently supports git repositories
+            Example:
+              {'git': [
+                  {'uri': 'git@github.com:remind101/stacker_blueprints.git',
+                   'tag': '1.0.0',
+                   'paths': ['stacker_blueprints']},
+                  {'uri': 'git@github.com:acmecorp/stacker_blueprints.git'},
+                  {'uri': 'git@github.com:contoso/webapp.git',
+                   'branch': 'staging'},
+                  {'uri': 'git@github.com:contoso/foo.git',
+                   'commit': '12345678'}
+              ]}
+
+        """
+        # Checkout git repositories specified in config
+        if 'git' in sources:
+            for config in sources['git']:
+                self.fetch_git_package(config=config)
+
+    def fetch_git_package(self, config):
+        """Makes a remote git repository available for local use
+
+        Args:
+            config (dict): Dictionary of git repo configuration
+
+        """
+        # If a specific commit or tag is defined, first check to see if it is
+        # already cached.
+        if config.get('commit'):
+            ref = config['commit']
+            dir_name = self.sanitize_git_path(uri=config['uri'],
+                                              ref=ref)
+        elif config.get('tag'):
+            ref = config['tag']
+            dir_name = self.sanitize_git_path(uri=config['uri'],
+                                              ref=ref)
+        else:
+            ref = self.git_ls_remote(
+                config['uri'],
+                self.determine_git_ls_remote_ref(config)
+            )
+            dir_name = self.sanitize_git_path(uri=config['uri'],
+                                              ref=ref)
+
+        cached_dir_path = os.path.join(self.package_cache_dir, dir_name)
+
+        # Clone the repo if it doesn't already exist
+        if not os.path.isdir(cached_dir_path):
+            tmp_dir = tempfile.mkdtemp(prefix='stacker')
+            try:
+                tmp_repo_path = os.path.join(tmp_dir, dir_name)
+                with Repo.clone_from(config['uri'], tmp_repo_path) as repo:
+                    repo.head.reference = ref
+                    repo.head.reset(index=True, working_tree=True)
+                shutil.move(tmp_repo_path, self.package_cache_dir)
+            finally:
+                shutil.rmtree(tmp_dir)
+
+        # Cloning (if necessary) is complete. Now add the appropriate
+        # directory (or directories) to sys.path
+        if 'paths' in config:
+            for path in config['paths']:
+                path_to_append = os.path.join(self.package_cache_dir,
+                                              dir_name,
+                                              path)
+                logger.debug("Appending \"%s\" to python sys.path",
+                             path_to_append)
+                sys.path.append(os.path.join(self.package_cache_dir,
+                                             dir_name,
+                                             path))
+        else:
+            sys.path.append(cached_dir_path)
+
+    def git_ls_remote(self, uri, ref):
+        """Determines the latest commit id for a given ref.
+
+        Args:
+            uri (string): git URI
+            ref (string): git ref
+
+        Returns: string (commit id)
+        """
+        logger.debug("Invoking git to retrieve commit id for repo %s...", uri)
+        lsremote_output = subprocess.check_output(['git',
+                                                   'ls-remote',
+                                                   uri,
+                                                   ref])
+        if "\t" in lsremote_output:
+            commit_id = lsremote_output.split("\t")[0]
+            logger.debug("Matching commit id found: %s", commit_id)
+            return commit_id
+        else:
+            raise ValueError("Ref \"%s\" not found for repo %d." % (ref, uri))
+
+    def determine_git_ls_remote_ref(self, config):
+        """Takes a dict describing a git repo and determines the ref to be used
+           with the "git ls-remote" command
+
+        Args:
+            config (dict): git config dictionary; 'branch' key is optional
+
+        Returns: string (a branch reference or "HEAD")
+        """
+        if 'branch' in config:
+            ref = "refs/heads/%s" % config.get('branch')
+        else:
+            ref = "HEAD"
+
+        return ref
+
+    def sanitize_git_path(self, uri, ref=None):
+        """Takes a git URI and ref and converts it to a directory safe path
+
+        Args:
+            uri (string): git URI
+                          (e.g. git@github.com:foo/bar.git)
+            ref (string): optional git ref to be appended to the path
+
+        Returns: string (directory name for the supplied uri)
+        """
+        if uri.endswith('.git'):
+            dir_name = uri[:-4]  # drop .git
+        else:
+            dir_name = uri
+        for i in ['@', '/', ':']:
+            dir_name = dir_name.replace(i, '_')
+        if ref is not None:
+            dir_name += "-%s" % ref
+        return dir_name


### PR DESCRIPTION
Provides the ability to separate blueprints from config code while still explicitly referencing the code location/revision (somewhat emulating the style of https://www.terraform.io/docs/modules/sources.html)