### PR TITLE
Remove doc references to default output lookups

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -187,7 +187,7 @@ A stack has the following keys:
 **requires:**
   (optional) a list of other stacks this stack requires. This is for explicit
   dependencies - you do not need to set this if you refer to another stack in
-  a Parameter, so this is rarely necessary. See `Using Outputs as Parameters`_
+  a Parameter, so this is rarely necessary.
 
 Here's an example from stacker_blueprints_, used to create a VPC::
 
@@ -263,48 +263,6 @@ could use them, you can just do this instead::
         << : *common_variables
         InstanceType: c4.xlarge # override the InstanceType in this stack
 
-Using Outputs as Parameters
----------------------------
-
-Since stacker encourages the breaking up of your CloudFormation stacks into
-entirely separate stacks, sometimes you'll need to pass values from one stack
-to another. The way this is handled in stacker (and in most of CloudFormation)
-is by having one stack provide Outputs_ for all the values that another
-stack may need, and then using those as the inputs for another stacks
-Parameters_. stacker makes this easier for you by providing a syntax for
-Parameters_ that will cause stacker to automatically look up the values of
-Outputs_ from another stack in its config. To do so, use the following format
-for the Parameter on the target stack::
-
-  MyParameter: OtherStack::OutputName
-
-This example is taken from stacker_blueprints_ example config - when building
-things inside a VPC, you will need to pass the *VpcId* of the VPC that you
-want the resources to be located in.  If the *vpc* stack provides an Output
-called *VpcId*, you can reference it easily::
-
-  domain_name: my_domain &domain
-
-  stacks:
-    - name: vpc
-      class_path: stacker_blueprints.vpc.VPC
-      parameters:
-        DomainName: *domain
-    - name: webservers
-      class_path: stacker_blueprints.asg.AutoscalingGroup
-      parameters:
-        DomainName: *domain
-        VpcId: vpc::VpcId # gets the VpcId Output from the vpc stack
-
-Note: Doing this creates an implicit dependency from the *webservers* stack
-to the *vpc* stack, which will cause stacker to submit the *vpc* stack, and
-then wait until it is complete until it submits the *webservers* stack.
-
-You can also pull multiple Outputs into a single, CommaDelimeted Parameter
-by separating them with commas like::
-
-  SomeParameter: stack1::Output1,stack2::Output2
-
 Variables
 ==========
 
@@ -374,11 +332,7 @@ stacker to automatically look up the values of Outputs_ from another stack
 in its config. To do so, use the following format for the Variable on the
 target stack::
 
-  MyParameter: ${OtherStack::OutputName}
-
-The above syntax is equivalent to the more explicit::
-
-  MyParameter ${output OtherStack::OutputName}
+  MyParameter: ${output OtherStack::OutputName}
 
 Since referencing Outputs_ from stacks is the most common use case,
 `output` is the default lookup type. For more information see Lookups_.
@@ -399,7 +353,7 @@ called *VpcId*, you can reference it easily::
       class_path: stacker_blueprints.asg.AutoscalingGroup
       variables:
         DomainName: *domain
-        VpcId: ${vpc::VpcId} # gets the VpcId Output from the vpc stack
+        VpcId: ${output vpc::VpcId} # gets the VpcId Output from the vpc stack
 
 Note: Doing this creates an implicit dependency from the *webservers* stack
 to the *vpc* stack, which will cause stacker to submit the *vpc* stack, and

--- a/docs/lookups.rst
+++ b/docs/lookups.rst
@@ -20,7 +20,7 @@ data structure and within another lookup itself.
 
   ie. if `custom` returns a list, this would raise an exception::
 
-    Variable: ${custom something}, ${otherStack::Output}
+    Variable: ${custom something}, ${output otherStack::Output}
 
   This is valid::
 
@@ -34,11 +34,11 @@ For example, given the following::
       class_path: some.stack.blueprint.Blueprint
       variables:
         Roles:
-          - ${otherStack::IAMRole}
+          - ${output otherStack::IAMRole}
         Values:
           Env:
-            Custom: ${custom ${otherStack::Output}}
-            DBUrl: postgres://${dbStack::User}@${dbStack::HostName}
+            Custom: ${custom ${output otherStack::Output}}
+            DBUrl: postgres://${output dbStack::User}@${output dbStack::HostName}
 
 The Blueprint would have access to the following resolved variables
 dictionary::
@@ -65,17 +65,16 @@ stacker includes the following lookup types:
 Output Lookup
 -------------
 
-The ``output`` lookup type is the default lookup type. It takes a value of
-the format: ``<stack name>::<output name>`` and retrieves the output from
-the given stack name within the current namespace.
+The ``output`` lookup takes a value of the format:
+``<stack name>::<output name>`` and retrieves the output from the given stack
+name within the current namespace.
 
 stacker treats output lookups differently than other lookups by auto
 adding the referenced stack in the lookup as a requirement to the stack
 whose variable the output value is being passed to.
 
-You can specify an output lookup with the following equivalent syntax::
+You can specify an output lookup with the following syntax::
 
-  ConfVariable: ${someStack::SomeOutput}
   ConfVariable: ${output someStack::SomeOutput}
 
 .. _kms:


### PR DESCRIPTION
We removed the implicit output lookup format, and instead required
explicit lookups in all cases.

Thanks @jonathanunderwood

Fixes #335