### PR TITLE
Updated raise statement, typo?

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -134,8 +134,9 @@ def validate_variable_type(var_name, var_type, value):
             raise ValidatorError(var_name, name, value, exc)
     else:
         if not isinstance(value, var_type):
-            raise ValueError("Variable %s must be of type %s.",
-                             var_name, var_type)
+            raise ValueError("Variable %s must be of type %s or is missing"
+                             " from your config with no blueprint default set."
+                             % (var_name, var_type))
 
     return value
 


### PR DESCRIPTION
...and added more info if a user gets stuck.


So today we had an issue where a user of one of my blueprints tried to do a Stacker build. The resulting error with 1.0.0 was this:

ValueError: ('Variable %s must be of type %s.', 'DNS', <type 'list'>)

Seems obvious to me since I wrote the blueprint what's wrong, but it was not so obvious to the other user actually trying to perform the stacker build that that they were missing the DNS variable in their config. It might have been more obvious if the output actually interpolated, so I fixed what appeared to me to be a typo in this PR.

I also added extra text in the error message itself to be more obvious as to this specific situation that there was a chance they needed to set the variable in the config. It's a little more wordy now, but gets the point across.  Let me know if you want me to put that back.  Now the resulting error will be:

ValueError: Variable DNS must be of type <type 'list'> or is missing from your config with no blueprint default set.