### PR TITLE
Add default value for provider_stack in build_parameters

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -151,7 +151,7 @@ class Action(BaseAction):
 
     """
 
-    def build_parameters(self, stack, provider_stack):
+    def build_parameters(self, stack, provider_stack=None):
         """Builds the CloudFormation Parameters for our stack.
 
         Args:


### PR DESCRIPTION
`stacker diff` hasn't worked since 942a73a1.

This is like remind101/stacker#344 but pep8-compliant.

Fixes remind101/stacker#343.