### PR TITLE
Better handling of rollback errors with stacks

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -232,7 +232,7 @@ them taking it as a Parameter. Rather than having to enter the domain into
 each stack (and hopefully not typo'ing any of them) you could do the
 following::
 
-  domain_name: mydomain.com &domain
+  domain_name: &domain mydomain.com
 
 Now you have an anchor called **domain** that you can use in place of any value
 in the config to provide the value **mydomain.com**. You use the anchor with
@@ -241,7 +241,7 @@ a reference::
   stacks:
     - name: vpc
       class_path: stacker_blueprints.vpc.VPC
-      parameters:
+      variables:
         DomainName: *domain
 
 Even more powerful is the ability to anchor entire dictionaries, and then

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -70,6 +70,7 @@ class BaseAction(object):
     def ensure_cfn_bucket(self):
         """The CloudFormation bucket where templates will be stored."""
         try:
+            logger.debug("Head on bucket %s", self.bucket_name)
             self.s3_conn.head_bucket(Bucket=self.bucket_name)
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Message'] == "Not Found":
@@ -79,8 +80,13 @@ class BaseAction(object):
                 logger.exception("Access denied for bucket %s.",
                                  self.bucket_name)
                 raise
+            elif e.response['Error']['Message'] == "Bad Request":
+                logger.exception(
+                    "Bucket name in used by another AWS customer bucket=%s.",
+                    self.bucket_name)
+                raise
             else:
-                logger.exception("Error creating bucket %s. Error %s",
+                logger.exception("Error checking bucket %s. Error %s",
                                  self.bucket_name, e.response)
                 raise
 

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -76,6 +76,11 @@ class Provider(BaseProvider):
     """AWS CloudFormation Provider"""
 
     DELETED_STATUS = "DELETE_COMPLETE"
+    ROLLBACK_COMPLETE_STATUS = "ROLLBACK_COMPLETE"
+    IN_ROLLBACK_STATUSES = (
+        "ROLLBACK_IN_PROGRESS",
+        "UPDATE_ROLLBACK_IN_PROGRESS",
+    )
     IN_PROGRESS_STATUSES = (
         "CREATE_IN_PROGRESS",
         "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
@@ -85,7 +90,12 @@ class Provider(BaseProvider):
     COMPLETE_STATUSES = (
         "CREATE_COMPLETE",
         "UPDATE_COMPLETE",
+        "UPDATE_ROLLBACK_COMPLETE",
     )
+
+    # Unhandled status codes
+    #   CREATE_FAILED, ROLLBACK_FAILED, DELETE_FAILED,
+    #   UPDATE_ROLLBACK_FAILED, REVIEW_IN_PROGRESS,
 
     def __init__(self, region, **kwargs):
         self.region = region
@@ -127,6 +137,12 @@ class Provider(BaseProvider):
 
     def is_stack_destroyed(self, stack, **kwargs):
         return self.get_stack_status(stack) == self.DELETED_STATUS
+
+    def is_stack_rollback_complete(self, stack, **kwargs):
+        return self.get_stack_status(stack) == self.ROLLBACK_COMPLETE_STATUS
+
+    def is_stack_rollback(self, stack, **kwargs):
+        return self.get_stack_status(stack) in self.IN_ROLLBACK_STATUSES
 
     def tail_stack(self, stack, retries=0, **kwargs):
         def log_func(e):

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -202,9 +202,9 @@ class TestBuildAction(unittest.TestCase):
             step.set_status(PENDING)
             status = step.run()
             step.set_status(status)
-            self.assertEqual(status, SUBMITTED)
-            self.assertEqual(status.reason, "updating existing stack")
-            self.assertEqual(mock_provider.update_stack.call_count, 1)
+            self.assertEqual(status, COMPLETE)
+            self.assertEqual(status.reason, "Failed to create/update stack")
+            self.assertEqual(mock_provider.update_stack.call_count, 0)
 
     def test_should_update(self):
         test_scenario = namedtuple("test_scenario",


### PR DESCRIPTION
In the process of trying to get stacker working, I found that it didn't handle ROLLBACK states very well. When a stack fails to create you end up having to go to the console to delete it, rather than having stacker understand that the stack is "not-real".

Also, this covers more states in CF when displaying update progress.