### PR TITLE
Benchmarks

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,1 @@
+benchmark.env

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,12 @@
+This is a stacker config for benchmarking stackers performance, you can run it with:
+
+```
+$ cp benchmark.env.example benchmark.env # change the namespace
+$ time stacker build benchmark.env benchmark.yaml
+```
+
+When you're done:
+
+```
+$ stacker destroy --force benchmark.env benchmark.yaml
+```

--- a/benchmark/benchmark.env.example
+++ b/benchmark/benchmark.env.example
@@ -1,0 +1,1 @@
+namespace: stacker-benchmark

--- a/benchmark/benchmark.yaml
+++ b/benchmark/benchmark.yaml
@@ -1,0 +1,67 @@
+# This config sets up a fairly large, and mostly fake, dependency graph, for
+# testing performance of Stacker.
+stacks:
+  - name: vpc
+    class_path: stacker.tests.blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db1
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db1Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db1::DummyOutput}
+  - name: db2
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db2Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db2::DummyOutput}
+  - name: db3
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db3Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db3::DummyOutput}
+  - name: db4
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db4Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db4::DummyOutput}
+  - name: rabbitmqYellow
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: cluster
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: app1
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+  - name: app2
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+      App1: ${output app1::DummyOutput}
+  - name: app3
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+  - name: app4
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+      RabbitMQ: ${output rabbitmqYellow::DummyOutput}

--- a/stacker/tests/blueprints/__init__.py
+++ b/stacker/tests/blueprints/__init__.py
@@ -1,0 +1,10 @@
+from troposphere import Output, Ref
+from stacker.blueprints.base import Blueprint
+from troposphere.cloudformation import WaitConditionHandle
+
+
+class Dummy(Blueprint):
+    def create_template(self):
+        handle = self.template.add_resource(
+            WaitConditionHandle("DummyResource"))
+        self.template.add_output(Output("DummyOutput", Value=Ref(handle)))


### PR DESCRIPTION
I've been using this to benchmark performance between the `master` and the [dag-1.0](https://github.com/remind101/stacker/compare/dag-1.0) branch. Also serves as a nice dummy dev config for manual testing.

For the record, a no-op run through of `time stacker build` takes about 1 minute where I'm located.