### PR TITLE
A lookup to get values out of context hook_data

### DIFF
--- a/stacker/lookups/handlers/hook_data.py
+++ b/stacker/lookups/handlers/hook_data.py
@@ -1,0 +1,17 @@
+TYPE_NAME = "hook_data"
+
+
+def handler(value, context, **kwargs):
+    """Returns the value of a key for a given hook in hook_data.
+
+    Format of value:
+
+        <hook_name>::<key>
+    """
+    try:
+        hook_name, key = value.split("::")
+    except ValueError:
+        raise ValueError("Invalid value for hook_data: %s. Must be in "
+                         "<hook_name>::<key> format." % value)
+
+    return context.hook_data[hook_name][key]

--- a/stacker/lookups/registry.py
+++ b/stacker/lookups/registry.py
@@ -9,9 +9,9 @@ from .handlers import rxref
 from .handlers import file as file_handler
 from .handlers import split
 from .handlers import default
+from .handlers import hook_data
 
 LOOKUP_HANDLERS = {}
-DEFAULT_LOOKUP = output.TYPE_NAME
 
 
 def register_lookup_handler(lookup_type, handler_or_path):
@@ -77,3 +77,4 @@ register_lookup_handler(rxref.TYPE_NAME, rxref.handler)
 register_lookup_handler(file_handler.TYPE_NAME, file_handler.handler)
 register_lookup_handler(split.TYPE_NAME, split.handler)
 register_lookup_handler(default.TYPE_NAME, default.handler)
+register_lookup_handler(hook_data.TYPE_NAME, hook_data.handler)

--- a/stacker/tests/lookups/handlers/test_hook_data.py
+++ b/stacker/tests/lookups/handlers/test_hook_data.py
@@ -1,0 +1,24 @@
+import unittest
+
+
+from stacker.context import Context
+from stacker.lookups.handlers.hook_data import handler
+
+
+class TestHookDataLookup(unittest.TestCase):
+
+    def setUp(self):
+        self.ctx = Context({"namespace": "test-ns"})
+        self.ctx.set_hook_data("fake_hook", {"result": "good"})
+
+    def test_valid_hook_data(self):
+        value = handler("fake_hook::result", context=self.ctx)
+        self.assertEqual(value, "good")
+
+    def test_invalid_hook_data(self):
+        with self.assertRaises(KeyError):
+            handler("fake_hook::bad_key", context=self.ctx)
+
+    def test_bad_value_hook_data(self):
+        with self.assertRaises(ValueError):
+            handler("fake_hook", context=self.ctx)


### PR DESCRIPTION
This seems like a natural next step for this - lets you get the values
from hook data that is returned from the hooks themselves.