### PR TITLE
Update example to work with current stacker version

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -192,18 +192,27 @@ A stack has the following keys:
 Here's an example from stacker_blueprints_, used to create a VPC::
 
   stacks:
-    - name: vpc
+    - name: vpc-example
       class_path: stacker_blueprints.vpc.VPC
       locked: false
       enabled: true
-      parameters:
-        InstanceType: m3.medium
+      variables:
+        InstanceType: t2.small
         SshKeyName: default
         ImageName: NAT
         AZCount: 2
-        PublicSubnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
-        PrivateSubnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22
+        PublicSubnets:
+          - 10.128.0.0/24
+          - 10.128.1.0/24
+          - 10.128.2.0/24
+          - 10.128.3.0/24
+        PrivateSubnets:
+          - 10.128.8.0/22
+          - 10.128.12.0/22
+          - 10.128.16.0/22
+          - 10.128.20.0/22
         CidrBlock: 10.128.0.0/16
+
 
 Parameters
 ==========


### PR DESCRIPTION
I tried to run this example, and got the following error:

`AttributeError: Stack definition vpc-example contains deprecated 'parameters', rather than 'variables'. Please update your config.`

I've updated the documentation to use `variables` instead of `parameters`.