### PR TITLE
Make lambda hook deterministic

### DIFF
--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -78,14 +78,16 @@ def _calculate_hash(files, root):
     Returns:
         str: A hash of the hashes of the given files.
     """
-    file_hashes = []
+    file_hash = hashlib.md5()
     for fname in files:
         f = os.path.join(root, fname)
+        file_hash.update(fname + "\0")
         with open(f, "rb") as fd:
-            file_hashes.append("%s:%s" % (fname,
-                                          hashlib.md5(fd.read()).hexdigest()))
+            for chunk in iter(lambda: fd.read(4096), ""):
+                file_hash.update(chunk)
+            file_hash.update("\0")
 
-    return hashlib.md5(' '.join(file_hashes)).hexdigest()
+    return file_hash.hexdigest()
 
 
 def _find_files(root, includes, excludes):

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -36,6 +36,7 @@ def _zip_files(files, root):
 
     Returns:
         str: content of the ZIP file as a byte string.
+        str: A calculated hash of all the files.
 
     """
     zip_data = StringIO()
@@ -61,8 +62,29 @@ def _zip_files(files, root):
 
     contents = zip_data.getvalue()
     zip_data.close()
+    content_hash = _calculate_hash(files, root)
 
-    return contents
+    return contents, content_hash
+
+
+def _calculate_hash(files, root):
+    """ Returns a hash of all of the given files at the given root.
+
+    Args:
+        files (list[str]): file names to include in the hash calculation,
+            relative to ``root``.
+        root (str): base directory to analyze files in.
+
+    Returns:
+        str: A hash of the hashes of the given files.
+    """
+    file_hashes = []
+    for fname in files:
+        f = os.path.join(root, fname)
+        with open(f) as fd:
+            file_hashes.append(hashlib.md5(fd.read()).hexdigest())
+
+    return hashlib.md5(' '.join(file_hashes)).hexdigest()
 
 
 def _find_files(root, includes, excludes):
@@ -137,7 +159,7 @@ def _head_object(s3_conn, bucket, key):
 
     Returns:
         dict: S3 object information, or None if the object does not exist.
-        See the AWS documentation for explanation of the contents.
+            See the AWS documentation for explanation of the contents.
 
     Raises:
         botocore.exceptions.ClientError: any error from boto3 other than key
@@ -181,7 +203,7 @@ def _ensure_bucket(s3_conn, bucket):
                              e.response)
 
 
-def _upload_code(s3_conn, bucket, name, contents):
+def _upload_code(s3_conn, bucket, name, contents, content_hash):
     """Upload a ZIP file to S3 for use by Lambda.
 
     The key used for the upload will be unique based on the checksum of the
@@ -194,6 +216,7 @@ def _upload_code(s3_conn, bucket, name, contents):
         name (str): desired name of the Lambda function. Will be used to
             construct a key name for the uploaded file.
         contents (str): byte string with the content of the file upload.
+        content_hash (str): md5 hash of the contents to be uploaded.
 
     Returns:
         troposphere.awslambda.Code: CloudFormation Lambda Code object,
@@ -204,15 +227,11 @@ def _upload_code(s3_conn, bucket, name, contents):
             through.
     """
 
-    hsh = hashlib.md5(contents)
-    logger.debug('lambda: ZIP hash: %s', hsh.hexdigest())
+    logger.debug('lambda: ZIP hash: %s', content_hash)
 
-    key = 'lambda-{}-{}.zip'.format(name, hsh.hexdigest())
+    key = 'lambda-{}-{}.zip'.format(name, content_hash)
 
-    info = _head_object(s3_conn, bucket, key)
-    expected_etag = '"{}"'.format(hsh.hexdigest())
-
-    if info and info['ETag'] == expected_etag:
+    if _head_object(s3_conn, bucket, key):
         logger.info('lambda: object %s already exists, not uploading', key)
     else:
         logger.info('lambda: uploading object %s', key)
@@ -305,9 +324,11 @@ def _upload_function(s3_conn, bucket, name, options):
     # absolute path, which is exactly what we want.
     if not os.path.isabs(root):
         root = os.path.abspath(os.path.join(get_config_directory(), root))
-    zip_contents = _zip_from_file_patterns(root, includes, excludes)
+    zip_contents, content_hash = _zip_from_file_patterns(root,
+                                                         includes,
+                                                         excludes)
 
-    return _upload_code(s3_conn, bucket, name, zip_contents)
+    return _upload_code(s3_conn, bucket, name, zip_contents, content_hash)
 
 
 def upload_lambda_functions(context, provider, **kwargs):

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -79,7 +79,7 @@ def _calculate_hash(files, root):
         str: A hash of the hashes of the given files.
     """
     file_hash = hashlib.md5()
-    for fname in files:
+    for fname in sorted(files):
         f = os.path.join(root, fname)
         file_hash.update(fname + "\0")
         with open(f, "rb") as fd:

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -81,8 +81,9 @@ def _calculate_hash(files, root):
     file_hashes = []
     for fname in files:
         f = os.path.join(root, fname)
-        with open(f) as fd:
-            file_hashes.append(hashlib.md5(fd.read()).hexdigest())
+        with open(f, "rb") as fd:
+            file_hashes.append("%s:%s" % (fname,
+                                          hashlib.md5(fd.read()).hexdigest()))
 
     return hashlib.md5(' '.join(file_hashes)).hexdigest()
 

--- a/stacker/tests/hooks/test_lambda.py
+++ b/stacker/tests/hooks/test_lambda.py
@@ -1,4 +1,5 @@
 import os.path
+import os
 import unittest
 import mock
 from StringIO import StringIO
@@ -11,7 +12,11 @@ from moto import mock_s3
 from testfixtures import TempDirectory, ShouldRaise, compare
 
 from stacker.context import Context
-from stacker.hooks.aws_lambda import upload_lambda_functions, ZIP_PERMS_MASK
+from stacker.hooks.aws_lambda import (
+    upload_lambda_functions,
+    ZIP_PERMS_MASK,
+    _calculate_hash
+)
 from ..factories import mock_provider
 
 
@@ -28,6 +33,14 @@ ALL_FILES = (
 )
 F1_FILES = [p[3:] for p in ALL_FILES if p.startswith('f1')]
 F2_FILES = [p[3:] for p in ALL_FILES if p.startswith('f2')]
+
+
+def touch(filenames):
+    """Changes update time on a list of files without changing their contents.
+    """
+    for fname in filenames:
+        with open(fname, "a"):
+            os.utime(fname, None)
 
 
 class TestLambdaHooks(unittest.TestCase):
@@ -272,16 +285,9 @@ class TestLambdaHooks(unittest.TestCase):
                 }
             }
 
-            # Force the bucket to keep track of versions for us. This is more
-            # complicated than using LastModified, but much more reliable,
-            # since the date only has a 1-second granularity, and dates could
-            # seem equal because insufficient time has elapsed between runs.
             self.s3.create_bucket(Bucket=bucket_name)
-            self.s3.put_bucket_versioning(
-                Bucket=bucket_name,
-                VersioningConfiguration={'Status': 'Enabled'})
 
-            version = None
+            previous = None
             for i in range(2):
                 results = self.run_hook(bucket=bucket_name,
                                         functions=functions)
@@ -290,11 +296,29 @@ class TestLambdaHooks(unittest.TestCase):
                 code = results.get('MyFunction')
                 self.assertIsInstance(code, Code)
 
-                info = self.s3.head_object(Bucket=code.S3Bucket,
-                                           Key=code.S3Key)
-                if not version:
-                    version = info['VersionId']
-                else:
-                    compare(version, info['VersionId'],
-                            prefix='S3 object must not be modified in '
-                                   'repeated runs')
+                if not previous:
+                    previous = code.S3Key
+                    continue
+
+                compare(previous, code.S3Key,
+                        prefix="zipfile name should not be modified in "
+                               "repeated runs.")
+
+    def test_calculate_hash(self):
+        with self.temp_directory_with_files() as d1:
+            root = d1.path
+            hash1 = _calculate_hash(ALL_FILES, root)
+
+        with self.temp_directory_with_files() as d2:
+            root = d2.path
+            hash2 = _calculate_hash(ALL_FILES, root)
+
+        with self.temp_directory_with_files() as d3:
+            root = d3.path
+            with open(os.path.join(root, ALL_FILES[0]), "w") as fd:
+                fd.write("modified file data")
+            hash3 = _calculate_hash(ALL_FILES, root)
+
+        self.assertEqual(hash1, hash2)
+        self.assertNotEqual(hash1, hash3)
+        self.assertNotEqual(hash2, hash3)

--- a/stacker/tests/hooks/test_lambda.py
+++ b/stacker/tests/hooks/test_lambda.py
@@ -314,3 +314,14 @@ class TestLambdaHooks(unittest.TestCase):
         self.assertEqual(hash1, hash2)
         self.assertNotEqual(hash1, hash3)
         self.assertNotEqual(hash2, hash3)
+
+    def test_calculate_hash_diff_filename_same_contents(self):
+        files = ["file1.txt", "f2/file2.txt"]
+        file1, file2 = files
+        with TempDirectory() as d:
+            root = d.path
+            for fname in files:
+                d.write(fname, "data")
+            hash1 = _calculate_hash([file1], root)
+            hash2 = _calculate_hash([file2], root)
+        self.assertNotEqual(hash1, hash2)

--- a/stacker/tests/hooks/test_lambda.py
+++ b/stacker/tests/hooks/test_lambda.py
@@ -2,6 +2,7 @@ import os.path
 import os
 import unittest
 import mock
+import random
 from StringIO import StringIO
 from zipfile import ZipFile
 
@@ -325,3 +326,18 @@ class TestLambdaHooks(unittest.TestCase):
             hash1 = _calculate_hash([file1], root)
             hash2 = _calculate_hash([file2], root)
         self.assertNotEqual(hash1, hash2)
+
+    def test_calculate_hash_different_ordering(self):
+        files1 = ALL_FILES
+        files2 = random.sample(ALL_FILES, k=len(ALL_FILES))
+        with TempDirectory() as d1:
+            root1 = d1.path
+            for fname in files1:
+                d1.write(fname, "")
+            with TempDirectory() as d2:
+                root2 = d2.path
+                for fname in files2:
+                    d2.write(fname, "")
+                hash1 = _calculate_hash(files1, root1)
+                hash2 = _calculate_hash(files2, root2)
+                self.assertEqual(hash1, hash2)

--- a/stacker/tests/hooks/test_lambda.py
+++ b/stacker/tests/hooks/test_lambda.py
@@ -35,14 +35,6 @@ F1_FILES = [p[3:] for p in ALL_FILES if p.startswith('f1')]
 F2_FILES = [p[3:] for p in ALL_FILES if p.startswith('f2')]
 
 
-def touch(filenames):
-    """Changes update time on a list of files without changing their contents.
-    """
-    for fname in filenames:
-        with open(fname, "a"):
-            os.utime(fname, None)
-
-
 class TestLambdaHooks(unittest.TestCase):
     @classmethod
     def temp_directory_with_files(cls, files=ALL_FILES):


### PR DESCRIPTION
The old method would cause issues if the mtime of the files was
different, since it was using the hash of the zipfile (and the zipfile
includes headers for mtime for each file).

This relies on generating a hash of all the files to be uploaded, then
hashes all those hashes. As long as the content hasn't changed, it
should return the same hash each time.

This also stops relying on the ETAGs from s3, and instead just uses the
calculated hash to create the key name, and doesn't re-upload if the key
already exists.

Fixes #370