### PR TITLE
Update hooks to use the provider for aws interactions

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -2,7 +2,6 @@ import copy
 import logging
 
 import botocore.exceptions
-from stacker.session_cache import get_session
 
 logger = logging.getLogger(__name__)
 
@@ -62,8 +61,7 @@ class BaseAction(object):
     def s3_conn(self):
         """The boto s3 connection object used for communication with S3."""
         if not hasattr(self, "_s3_conn"):
-            session = get_session(self.provider.region)
-            self._s3_conn = session.client('s3')
+            self._s3_conn = self.provider.s3
 
         return self._s3_conn
 

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -69,20 +69,7 @@ class BaseAction(object):
 
     def ensure_cfn_bucket(self):
         """The CloudFormation bucket where templates will be stored."""
-        try:
-            self.s3_conn.head_bucket(Bucket=self.bucket_name)
-        except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Message'] == "Not Found":
-                logger.debug("Creating bucket %s.", self.bucket_name)
-                self.s3_conn.create_bucket(Bucket=self.bucket_name)
-            elif e.response['Error']['Message'] == "Forbidden":
-                logger.exception("Access denied for bucket %s.",
-                                 self.bucket_name)
-                raise
-            else:
-                logger.exception("Error creating bucket %s. Error %s",
-                                 self.bucket_name, e.response)
-                raise
+        return self.provider.ensure_bucket(self.bucket_name)
 
     def stack_template_url(self, blueprint):
         return stack_template_url(self.bucket_name, blueprint)

--- a/stacker/hooks/ecs.py
+++ b/stacker/hooks/ecs.py
@@ -1,9 +1,4 @@
-# A lot of this code exists to deal w/ the broken ECS connect_to_region
-# function, and will be removed once this pull request is accepted:
-#   https://github.com/boto/boto/pull/3143
 import logging
-
-from stacker.session_cache import get_session
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +17,7 @@ def create_clusters(provider, context, **kwargs):
     Returns: boolean for whether or not the hook succeeded.
 
     """
-    conn = get_session(provider.region).client('ecs')
+    conn = provider.ecs
 
     try:
         clusters = kwargs["clusters"]

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 
-from stacker.session_cache import get_session
 from botocore.exceptions import ClientError
 
 from awacs.aws import Statement, Allow, Policy
@@ -28,7 +27,7 @@ def create_ecs_service_role(provider, context, **kwargs):
 
     """
     role_name = kwargs.get("role_name", "ecsServiceRole")
-    client = get_session(provider.region).client('iam')
+    client = provider.iam
 
     try:
         client.create_role(
@@ -121,7 +120,7 @@ def get_cert_contents(kwargs):
 
 
 def ensure_server_cert_exists(provider, context, **kwargs):
-    client = get_session(provider.region).client('iam')
+    client = provider.iam
     cert_name = kwargs["cert_name"]
     status = "unknown"
     try:

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -1,11 +1,5 @@
-from mock import MagicMock
-
 from stacker.context import Context
 from stacker.lookups import Lookup
-
-
-def mock_provider(**kwargs):
-    return MagicMock(**kwargs)
 
 
 def mock_context(namespace=None, **kwargs):

--- a/stacker/tests/hooks/test_ecs.py
+++ b/stacker/tests/hooks/test_ecs.py
@@ -5,9 +5,9 @@ from moto import mock_ecs
 from testfixtures import LogCapture
 
 from stacker.hooks.ecs import create_clusters
+from stacker.providers.aws.default import Provider
 from ..factories import (
     mock_context,
-    mock_provider,
 )
 
 REGION = "us-east-1"
@@ -16,7 +16,7 @@ REGION = "us-east-1"
 class TestECSHooks(unittest.TestCase):
 
     def setUp(self):
-        self.provider = mock_provider(region=REGION)
+        self.provider = Provider(region=REGION)
         self.context = mock_context(namespace="fake")
 
     def test_create_single_cluster(self):

--- a/stacker/tests/hooks/test_iam.py
+++ b/stacker/tests/hooks/test_iam.py
@@ -5,6 +5,7 @@ from botocore.exceptions import ClientError
 
 from moto import mock_iam
 
+from stacker.providers.aws.default import Provider
 from stacker.hooks.iam import (
     create_ecs_service_role,
     _get_cert_arn_from_response,
@@ -12,7 +13,6 @@ from stacker.hooks.iam import (
 
 from ..factories import (
     mock_context,
-    mock_provider,
 )
 
 
@@ -27,7 +27,7 @@ class TestIAMHooks(unittest.TestCase):
 
     def setUp(self):
         self.context = mock_context(namespace="fake")
-        self.provider = mock_provider(region=REGION)
+        self.provider = Provider(region=REGION)
 
     def test_get_cert_arn_from_response(self):
         arn = "fake-arn"

--- a/stacker/tests/hooks/test_lambda.py
+++ b/stacker/tests/hooks/test_lambda.py
@@ -12,7 +12,7 @@ from testfixtures import TempDirectory, ShouldRaise, compare
 
 from stacker.context import Context
 from stacker.hooks.aws_lambda import upload_lambda_functions, ZIP_PERMS_MASK
-from ..factories import mock_provider
+from stacker.providers.aws.default import Provider
 
 
 REGION = "us-east-1"
@@ -60,7 +60,7 @@ class TestLambdaHooks(unittest.TestCase):
 
     def assert_s3_bucket(self, bucket, present=True):
         try:
-            self.s3.head_bucket(Bucket=bucket)
+            self.provider.s3.head_bucket(Bucket=bucket)
             if not present:
                 self.fail('s3: bucket {} should not exist'.format(bucket))
         except botocore.exceptions.ClientError as e:
@@ -71,7 +71,7 @@ class TestLambdaHooks(unittest.TestCase):
     def setUp(self):
         self.context = Context(environment={'namespace': 'test'})
         self.context.bucket_name = 'test'
-        self.provider = mock_provider(region="us-east-1")
+        self.provider = Provider(region="us-east-1")
 
     def run_hook(self, **kwargs):
         real_kwargs = {

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -8,9 +8,9 @@ from stacker.util import (
     cf_safe_name, load_object_from_string,
     camel_to_snake, handle_hooks, retry_with_backoff)
 
+from stacker.providers.aws.default import Provider
 from .factories import (
     mock_context,
-    mock_provider,
 )
 
 regions = ["us-east-1", "cn-north-1", "ap-northeast-1", "eu-west-1",
@@ -77,7 +77,7 @@ class TestHooks(unittest.TestCase):
 
     def setUp(self):
         self.context = mock_context(namespace="namespace")
-        self.provider = mock_provider(region="us-east-1")
+        self.provider = Provider(region="us-east-1")
 
     def test_empty_hook_stage(self):
         hooks = []


### PR DESCRIPTION
Rather than setting up their own sessions, we already pass the provider
in.  By standardizing on using the provider for all interactions, we can
share logic between all the connections, which I think is beneficial.

In doing this I discovered that the mock_provider really wasn't
necessary any longer, and we could use an actual Provider class for all
our tests.

This is all in preparation for trying to get to #374, and make it less
likely that we'll regress once again.