### PR TITLE
Add support for Property objects in TroposphereType variables

### DIFF
--- a/docs/blueprints.rst
+++ b/docs/blueprints.rst
@@ -9,7 +9,9 @@ Blueprints in the stacker_blueprints_ package.
 
 Making your own should be easy, and you can take a lot of examples from
 stacker_blueprints_. In the end, all that is required is that the Blueprint
-is a subclass of *stacker.blueprints.base* and it have the following methods::
+is a subclass of *stacker.blueprints.base* and it have the following methods:
+
+.. code-block:: python
 
     # Initializes the blueprint
     def __init__(self, name, context, mappings=None):
@@ -94,67 +96,146 @@ You can also use the following custom types:
 TroposphereType
 ---------------
 
-The ``TroposphereType`` can be used to create one or more Troposphere
-types by directly passing in the value from the config to the specified
-Troposphere type.
+The ``TroposphereType`` can be used to generate resources for use in the
+blueprint directly from user-specified configuration. Which case applies depends
+on what ``type`` was chosen, and how it would be normally used in the blueprint
+(and CloudFormation in general).
+
+Resource Types
+^^^^^^^^^^^^^^
+
+When ``type`` is a `Resource Type`_, the value specified by the user in the
+configuration file must be a dictionary, but with two possible structures.
+
+When ``many`` is disabled, the top-level dictionary keys correspond to
+parameters of the ``type`` constructor. The key-value pairs will be used
+directly, and one object will be created and stored in the variable.
+
+When ``many`` is enabled, the top-level dictionary *keys* are resource titles,
+and the corresponding *values* are themselves dictionaries, to be used as
+parameters for creating each of multiple ``type`` objects. A list of those
+objects will be stored in the variable.
+
+Property Types
+^^^^^^^^^^^^^^
+
+When ``type`` is a `Property Type`_ the value specified by the user in the
+configuration file must be a dictionary or a list of dictionaries.
+
+When ``many`` is disabled, the top-level dictionary keys correspond to
+parameters of the ``type`` constructor. The key-value pairs will be used
+directly, and one object will be created and stored in the variable.
+
+When ``many`` is enabled, a list of dictionaries is expected. For each element,
+one corresponding call will be made to the ``type`` constructor, and all the
+objects produced will be stored (also as a list) in the variable.
+
+Optional variables
+^^^^^^^^^^^^^^^^^^
+
+In either case, when ``optional`` is enabled, the variable may have no value
+assigned, or be explicitly assigned a null value. When that happens the
+variable's final value will be ``None``.
 
 Example
 ^^^^^^^
 
-Below is an annotated example::
+Below is an annotated example:
 
-  from stacker.blueprints.base import Blueprint
-  from stacker.blueprints.variables.types import TroposphereType
-  from troposphere import s3
+.. code-block:: python
+
+    from stacker.blueprints.base import Blueprint
+    from stacker.blueprints.variables.types import TroposphereType
+    from troposphere import s3, sns
+
+    class Buckets(Blueprint):
+
+        VARIABLES = {
+            # Specify that Buckets will be a list of s3.Bucket types.
+            # This means the config should a dictionary of dictionaries
+            # which will be converted into troposphere buckets.
+            "Buckets": {
+                "type": TroposphereType(s3.Bucket, many=True),
+                "description": "S3 Buckets to create.",
+            },
+            # Specify that only a single bucket can be passed.
+            "SingleBucket": {
+                "type": TroposphereType(s3.Bucket),
+                "description": "A single S3 bucket",
+            },
+            # Specify that Subscriptions will be a list of sns.Subscription types.
+            # Note: sns.Subscription is the property type, not the standalone
+            # sns.SubscriptionResource.
+            "Subscriptions": {
+                "type": TroposphereType(sns.Subscription, many=True),
+                "description": "Multiple SNS subscription designations"
+            },
+            # Specify that only a single subscription can be passed, and that it
+            # is made optional.
+            "SingleOptionalSubscription": {
+                "type": TroposphereType(sns.Subscription, optional=True),
+                "description": "A single, optional SNS subscription designation"
+            }
+        }
+
+        def create_template(self):
+            t = self.template
+            variables = self.get_variables()
+
+            # The Troposphere s3 buckets have already been created when we
+            access variables["Buckets"], we just need to add them as
+            resources to the template.
+            [t.add_resource(bucket) for bucket in variables["Buckets"]]
+
+            # Add the single bucket to the template. You can use
+            `Ref(single_bucket)` to pass CloudFormation references to the
+            bucket just as you would with any other Troposphere type.
+            single_bucket = variables["SingleBucket"]
+            t.add_resource(single_bucket)
+
+            subscriptions = variables["Subscriptions"]
+            optional_subscription = variables["SingleOptionalSubscription"]
+            # Handle it in some special way...
+            if optional_subscription is not None:
+                subscriptions.append(optional_subscription)
+
+            t.add_resource(sns.Topic(
+                TopicName="one-test",
+                Subscriptions=))
+
+            t.add_resource(sns.Topic(
+                TopicName="another-test",
+                Subscriptions=subscriptions))
 
 
-  class Buckets(Blueprint):
 
-      VARIABLES = {
-          "Buckets": {
-              # Specify that Buckets will be a list of s3.Bucket types.
-              This means the config should take a list of dictionaries
-              which will be converted into troposphere buckets.
-              "type": TroposphereType(s3.Bucket, many=True),
-              "description": "S3 Buckets to create.",
-          },
-          "SingleBucket": {
-              # Specify that only a single bucket can be passed.
-              "type": TroposphereType(s3.Bucket),
-              "description": "A single S3 bucket",
-          },
-      }
+A sample config for the above:
 
-      def create_template(self):
-          t = self.template
-          variables = self.get_variables()
+..  code-block:: yaml
 
-          # The Troposphere s3 buckets have already been created when we
-          access variables["Buckets"], we just need to add them as
-          resources to the template.
-          [t.add_resource(bucket) for bucket in variables["Buckets"]]
+    stacks:
+      - name: buckets
+        class_path: path.to.above.Buckets
+        variables:
+          Buckets:
+            # resource name that will be added to CloudFormation
+            FirstBucket:
+              # name of the s3 bucket
+              BucketName: my-first-bucket
+            SecondBucket:
+              BucketName: my-second-bucket
+          SingleBucket:
+            BucketName: my-single-bucket
+          Subscriptions:
+            - Endpoint: one-lambda
+              Protocol: lambda
+            - Endpoint: another-lambda
+              Protocol: lambda
+          # The following could be ommited entirely
+          SingleOptionalSubscription:
+            Endpoint: a-third-lambda
+            Protocol: lambda
 
-          # Add the single bucket to the template. You can use
-          `Ref(single_bucket)` to pass CloudFormation references to the
-          bucket just as you would with any other Troposphere type.
-          single_bucket = variables["SingleBucket"]
-          t.add_resource(single_bucket)
-
-A sample config for the above::
-
-  stacks:
-    - name: buckets
-      class_path: path.to.above.Buckets
-      variables:
-        Buckets:
-          # resource name that will be added to CloudFormation
-          FirstBucket:
-            # name of the s3 bucket
-            BucketName: my-first-bucket
-          SecondBucket:
-            BucketName: my-second-bucket
-        SingleBucket:
-          BucketName: my-single-bucket
 
 CFNType
 -------
@@ -169,8 +250,9 @@ specific Parameter types like ``List<AWS::EC2::Image::Id>``. See
 Example
 ^^^^^^^
 
-Below is an annotated example::
+Below is an annotated example:
 
+.. code-block:: python
 
     from stacker.blueprints.base import Blueprint
     from stacker.blueprints.variables.types import (
@@ -247,3 +329,5 @@ stacker_blueprints repo. For example, see the tests used to test the
 .. _stacker_blueprints: https://github.com/remind101/stacker_blueprints
 .. _Route53 DNSRecords Blueprint: https://github.com/remind101/stacker_blueprints/blob/master/tests/test_route53.py
 .. _output results: https://github.com/remind101/stacker_blueprints/tree/master/tests/fixtures/blueprints
+.. _Resource Type: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html
+.. _Property Type: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-product-property-reference.html

--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -196,8 +196,8 @@ def resolve_variable(var_name, var_def, provided_variable, blueprint_name):
     if provided_variable:
         if not provided_variable.resolved:
             raise UnresolvedVariable(blueprint_name, provided_variable)
-        if provided_variable.value is not None:
-            value = provided_variable.value
+
+        value = provided_variable.value
     else:
         # Variable value not provided, try using the default, if it exists
         # in the definition

--- a/stacker/blueprints/variables/types.py
+++ b/stacker/blueprints/variables/types.py
@@ -8,10 +8,28 @@ class TroposphereType(object):
         :class:`Troposphere` will convert the value provided to the variable to
         the specified Troposphere type.
 
+        Both resource and parameter classes (which are just used to configure
+        other resources) are acceptable as configuration values.
+
+        Complete resource definitions must be dictionaries, with the keys
+        identifying the resource titles, and the values being used as the
+        constructor parameters.
+
+        Parameter classes can be defined as dictionariy or a list of
+        dictionaries. In either case, the keys and values will be used directly
+        as constructor parameters.
+
         Args:
             defined_type (type): Troposphere type
-            many (Optional[bool]): Boolean indicating whether or not the type
-                accepts a single object or a list of objects.
+            many (Optional[bool]): Boolean indicating whether or not multiple
+                resources can be constructed. If the defined type is a
+                resource, multiple resources can be passed as a dictionary of
+                dictionaries
+                If it is a parameter class, multiple resources are passed as
+                a list.
+            optional (Optional[bool]): Boolean indicating if an undefined/null
+                configured value is acceptable, and can be passed to the
+                template instead of triggering an error.
 
         """
 
@@ -36,8 +54,10 @@ class TroposphereType(object):
         """Create the troposphere type from the value.
 
         Args:
-            value (dict): a dictionary of the resource name to a dictionary of
-                the values you want to pass to `from_dict` for the troposphere
+            value (Union[dict, list]): A dictionary or list of dictionaries
+                (see class documentation for details) to use as parameters to
+                create the Troposphere type instance.
+                Each dictionary will be passed to the `from_dict` method of the
                 type.
 
         Returns:

--- a/stacker/blueprints/variables/types.py
+++ b/stacker/blueprints/variables/types.py
@@ -55,8 +55,8 @@ class TroposphereType(object):
                 raise ValueError("Resources must be specified as a dict of "
                                  "title to parameters")
             if not self._many and len(value) > 1:
-                raise ValueError("Only one resource can be provided for single "
-                                 "TroposphereType")
+                raise ValueError("Only one resource can be provided for this "
+                                 "TroposphereType variable")
 
             result = [self._type.from_dict(title, v) for title, v in
                       value.items()]

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -215,6 +215,8 @@ class TestVariables(unittest.TestCase):
 
     def test_resolve_variable_troposphere_type_props_single(self):
         sub_defs = {"Endpoint": "test", "Protocol": "lambda"}
+        # Note that sns.Subscription != sns.SubscriptionResource. The former
+        # is a property type, the latter is a complete resource.
         sub = self._resolve_troposphere_var(sns.Subscription, sub_defs)
 
         self.assertTrue(isinstance(sub, sns.Subscription))

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -222,7 +222,7 @@ class TestVariables(unittest.TestCase):
 
     def test_resolve_variable_troposphere_type_props_optional(self):
         sub = self._resolve_troposphere_var(sns.Subscription, None,
-                                              optional=True)
+                                            optional=True)
         self.assertEqual(sub, None)
 
     def test_resolve_variable_troposphere_type_props_many(self):


### PR DESCRIPTION
Previously TroposphereType only worked for complete resources, not
property objects meant to be used as parameters for other resources.

Change that by inspecting the type to determine if it represents a property
object, and interpreting the variable value differently. A dictionary is
used directly as parameters, instead as title/parameters pairs, and a list
can be provided to generate multiple objects (if the type definition
allows).

Also add an `optional` boolean parameter to the constructor (mutually
exclusive to `many`), indicating that a single object should be created,
but that a `None` (or ommited) value is acceptable, in which case it is
passed through to the template.