### PR TITLE
Attempting to catch undefined variable value - Issue #387

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -211,6 +211,10 @@ def resolve_variable(var_name, var_def, provided_variable, blueprint_name):
     try:
         value = validator(value)
     except Exception as exc:
+        try:
+            value
+        except UnboundLocalError:
+            value = "mising or undefined"
         raise ValidatorError(var_name, validator.__name__, value, exc)
 
     # Ensure that the resulting value is the correct type

--- a/stacker/tests/blueprints/test_base.py
+++ b/stacker/tests/blueprints/test_base.py
@@ -535,6 +535,20 @@ class TestVariables(unittest.TestCase):
         with self.assertRaises(AttributeError):
             TestBlueprint(name="test", context=MagicMock())
 
+    def test_variable_exists_but_value_is_none(self):
+        var_name = "testVar"
+        var_def = {"type": str}
+        var_value = None
+        provided_variable = Variable(var_name, var_value)
+        blueprint_name = "testBlueprint"
+
+        with self.assertRaises(ValidatorError) as cm:
+            resolve_variable(var_name, var_def, provided_variable,
+                             blueprint_name)
+
+        exc = cm.exception.exception  # The wrapped exception
+        self.assertIsInstance(exc, UnboundLocalError)
+
 
 class TestCFNParameter(unittest.TestCase):
     def test_cfnparameter_convert_boolean(self):


### PR DESCRIPTION
and passing that to the ValidatorError function.

This resolves the specific scenario where a user defines the key, but not the value of a variable. This was causing an "UnboundLocalError" when attempting to pass in the "value" to the ValidatorError function.  

This resolves issue #387 