### PR TITLE
Include parameters in interactive provider diff

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -224,8 +224,9 @@ class Action(BaseAction):
                 return NotUpdatedStatus()
             try:
                 new_status = SubmittedStatus("updating existing stack")
-                self.provider.update_stack(stack.fqn, template_url, parameters,
-                                           tags)
+                existing_params = provider_stack.get('Parameters', [])
+                self.provider.update_stack(stack.fqn, template_url,
+                                           existing_params, parameters, tags)
                 logger.debug("Updating existing stack: %s", stack.fqn)
             except StackDidNotChange:
                 return DidNotChangeStatus()

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -220,7 +220,8 @@ class Provider(BaseProvider):
         )
         return True
 
-    def update_stack(self, fqn, template_url, parameters, tags, **kwargs):
+    def update_stack(self, fqn, template_url, old_parameters, parameters,
+                     tags, **kwargs):
         try:
             logger.debug("Attempting to update stack %s.", fqn)
             retry_on_throttling(
@@ -274,9 +275,13 @@ class Provider(BaseProvider):
             raise exceptions.StackDoesNotExist(stack_name)
 
         stack = stacks['Stacks'][0]
-        parameters = dict()
-        if 'Parameters' in stack:
-            for p in stack['Parameters']:
-                parameters[p['ParameterKey']] = p['ParameterValue']
+        parameters = self.params_as_dict(stack.get('Parameters', []))
 
         return [json.dumps(template), parameters]
+
+    @staticmethod
+    def params_as_dict(parameters_list):
+        parameters = dict()
+        for p in parameters_list:
+            parameters[p['ParameterKey']] = p['ParameterValue']
+        return parameters

--- a/stacker/tests/providers/aws/test_interactive.py
+++ b/stacker/tests/providers/aws/test_interactive.py
@@ -7,12 +7,15 @@ from mock import patch
 from botocore.stub import Stubber
 import boto3
 
+from ....actions.diff import DictValue
+
 from ....providers.aws.interactive import (
     Provider,
     requires_replacement,
     ask_for_approval,
     wait_till_change_set_complete,
     create_change_set,
+    summarize_params_diff
 )
 
 from .... import exceptions
@@ -128,22 +131,82 @@ class TestInteractiveProviderMethods(unittest.TestCase):
         for resource in replacement:
             self.assertEqual(resource["ResourceChange"]["Replacement"], "True")
 
-    def test_ask_for_approval(self):
+    def test_summarize_params_diff(self):
+        unmodified_param = DictValue("ParamA", "new-param-value",
+                                     "new-param-value")
+        modified_param = DictValue("ParamB", "param-b-old-value",
+                                   "param-b-new-value-delta")
+        added_param = DictValue("ParamC", None, "param-c-new-value")
+        removed_param = DictValue("ParamD", "param-d-old-value", None)
+
+        params_diff = [
+            unmodified_param,
+            modified_param,
+            added_param,
+            removed_param,
+        ]
+        self.assertEqual(summarize_params_diff([]), "")
+        self.assertEqual(summarize_params_diff(params_diff), '\n'.join([
+            "Parameters Added: ParamC",
+            "Parameters Removed: ParamD",
+            "Parameters Modified: ParamB\n",
+        ]))
+
+        only_modified_params_diff = [modified_param]
+        self.assertEqual(summarize_params_diff(only_modified_params_diff),
+                         "Parameters Modified: ParamB\n")
+
+        only_added_params_diff = [added_param]
+        self.assertEqual(summarize_params_diff(only_added_params_diff),
+                         "Parameters Added: ParamC\n")
+
+        only_removed_params_diff = [removed_param]
+        self.assertEqual(summarize_params_diff(only_removed_params_diff),
+                         "Parameters Removed: ParamD\n")
+
+    @patch("stacker.providers.aws.interactive.format_params_diff")
+    def test_ask_for_approval(self, patched_format):
         get_input_path = "stacker.providers.aws.interactive.get_raw_input"
         with patch(get_input_path, return_value="y"):
-            self.assertIsNone(ask_for_approval([]))
+            self.assertIsNone(ask_for_approval([], [], None))
 
         for v in ("n", "N", "x", "\n"):
             with patch(get_input_path, return_value=v):
                 with self.assertRaises(exceptions.CancelExecution):
-                    ask_for_approval([])
+                    ask_for_approval([], [])
 
         with patch(get_input_path, side_effect=["v", "n"]) as mock_get_input:
             with patch("yaml.safe_dump") as mock_safe_dump:
                 with self.assertRaises(exceptions.CancelExecution):
-                    ask_for_approval([], True)
+                    ask_for_approval([], [], True)
                 self.assertEqual(mock_safe_dump.call_count, 1)
             self.assertEqual(mock_get_input.call_count, 2)
+
+        self.assertEqual(patched_format.call_count, 0)
+
+    @patch("stacker.providers.aws.interactive.format_params_diff")
+    def test_ask_for_approval_with_params_diff(self, patched_format):
+        get_input_path = "stacker.providers.aws.interactive.get_raw_input"
+        params_diff = [
+            DictValue('ParamA', None, 'new-param-value'),
+            DictValue('ParamB', 'param-b-old-value', 'param-b-new-value-delta')
+        ]
+        with patch(get_input_path, return_value="y"):
+            self.assertIsNone(ask_for_approval([], params_diff, None))
+
+        for v in ("n", "N", "x", "\n"):
+            with patch(get_input_path, return_value=v):
+                with self.assertRaises(exceptions.CancelExecution):
+                    ask_for_approval([], params_diff)
+
+        with patch(get_input_path, side_effect=["v", "n"]) as mock_get_input:
+            with patch("yaml.safe_dump") as mock_safe_dump:
+                with self.assertRaises(exceptions.CancelExecution):
+                    ask_for_approval([], params_diff, True)
+                self.assertEqual(mock_safe_dump.call_count, 1)
+            self.assertEqual(mock_get_input.call_count, 2)
+
+        self.assertEqual(patched_format.call_count, 1)
 
     def test_wait_till_change_set_complete_success(self):
         self.stubber.add_response(
@@ -272,10 +335,12 @@ class TestInteractiveProvider(unittest.TestCase):
             self.provider.update_stack(
                 fqn="my-fake-stack",
                 template_url="http://fake.template.url.com/",
+                old_parameters=[],
                 parameters=[], tags=[]
             )
 
         patched_approval.assert_called_with(full_changeset=changes,
+                                            params_diff=[],
                                             include_verbose=True)
 
         self.assertEqual(patched_approval.call_count, 1)
@@ -303,6 +368,7 @@ class TestInteractiveProvider(unittest.TestCase):
             self.provider.update_stack(
                 fqn="my-fake-stack",
                 template_url="http://fake.template.url.com/",
+                old_parameters=[],
                 parameters=[], tags=[], diff=True
             )
 


### PR DESCRIPTION
We often use the interactive provider when we're dealing w/ more sensitive stacks, like dynamo tables, vpc, etc, but the current state of interactive only prompts for approval if there are structural or resource changes to that cloudformation detects, and the prompt omits any information about parameters that are changing. To me, parameters are a critical aspect of the changeset, so they deserve more direct attention in the interactive provider's prompt for approval.

This leans on some of the existing formatting of param changes that are used in the `diff` command, but it limits the parameters shown to ones that are actually changed, removed, or newly added. Any parameters that remain unchanged are not included in the prompt output.

Here's a snippet from an interactive build that adds a param `AdamTest` and changes the `VersionLabel` param value.

```
[2017-06-05T23:24:30] dptDwapi changes:
Parameters Added: AdamTest
Parameters Removed: ParamThatWasRemoved
Parameters Modified: VersionLabel, Foo
Replacements:
- Modify Task (AWS::ECS::TaskDefinition)
Changes:
- Modify CPUUtilizationHigh (AWS::CloudWatch::Alarm)
- Modify CPUUtilizationLow (AWS::CloudWatch::Alarm)
- Modify ScaleInPolicy (AWS::ApplicationAutoScaling::ScalingPolicy)
- Modify ScaleOutPolicy (AWS::ApplicationAutoScaling::ScalingPolicy)
- Modify ScalingTarget (AWS::ApplicationAutoScaling::ScalableTarget)
- Modify Service (AWS::ECS::Service)
- Modify ServiceRole (AWS::IAM::Role)
Execute the above changes? [y/n/v]
```

In verbose mode, the pull params are output exactly the same as the `diff` command does today.

Example:

```
[2017-06-22T18:40:01] Full changeset:

--- Old Parameters
+++ New Parameters
******************
 UnchangedParam = unchangedValue
+AdamTest = testValue
-ParamThatWasRemoved
-VersionLabel = 0.0.1
+VersionLabel = 0.0.2

- ResourceChange:
    Action: Modify
    Details:
    - CausingEntity: ScaleInPolicy
...
```
