### PR TITLE
Use region-agnostic virtual-hosted–style URLs

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -33,7 +33,7 @@ def stack_template_url(bucket_name, blueprint):
         string: S3 URL.
     """
     key_name = stack_template_key_name(blueprint)
-    return "https://s3.amazonaws.com/%s/%s" % (bucket_name, key_name)
+    return "https://%s.s3.amazonaws.com/%s" % (bucket_name, key_name)
 
 
 class BaseAction(object):


### PR DESCRIPTION
~~The current path-style URLs are causing issues with deployments to cn-north-1 (and likely other China regions).~~

~~In our tests changing the URL to the virtual-hosted-style noted at https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro resolved the issue.~~

EDIT: this didn't correct the cn-north-1 issue as I thought. I'll open a separate PR to account for that