### PR TITLE
add stacker_bucket_endpoint config option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -42,9 +42,9 @@ in the config.
 
 S3 Bucket Endpoint
 ------------------
-Isolated AWS regions don't permit access to S3 buckets via the default
-'s3.amazonaws.com' endpoint. This endpoint can be overriden via the
-**stacker_bucket_endpoint** top level keyword in the config, e.g.::
+The correct S3 endpoint should be automatically chosen, but it can also be
+overriden via the **stacker_bucket_endpoint** top level keyword in the config,
+e.g.::
 
   stacker_bucket_endpoint: s3.cn-north-1.amazonaws.com.cn
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -40,6 +40,14 @@ updating your stacks. By default it uses a bucket named
 If you want to change this, provide the **stacker_bucket** top level key word
 in the config.
 
+S3 Bucket Endpoint
+------------------
+Isolated AWS regions don't permit access to S3 buckets via the default
+'s3.amazonaws.com' endpoint. This endpoint can be overriden via the
+**stacker_bucket_endpoint** top level keyword in the config, e.g.::
+
+  stacker_bucket_endpoint: s3.cn-north-1.amazonaws.com.cn
+
 Module Paths
 ----------------
 When setting the ``classpath`` for blueprints/hooks, it is sometimes desirable to

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -87,13 +87,16 @@ class BaseAction(object):
                 raise
 
     def stack_template_url(self, blueprint):
-        if 'stacker_bucket_endpoint' in self.context.config:
-            return stack_template_url(
-                self.bucket_name,
-                blueprint,
-                self.context.config['stacker_bucket_endpoint'])
-        else:
-            return stack_template_url(self.bucket_name, blueprint)
+        # Assume default S3 endpoint
+        endpoint = "s3.amazonaws.com"
+        # Allow the endpoint to be overriden manually
+        if "stacker_bucket_endpoint" in self.context.config:
+            endpoint = self.context.config['stacker_bucket_endpoint']
+        # Or fallback to automatically overriding it for isolated regions
+        # http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region
+        elif self.provider.region == "cn-north-1":
+            endpoint = "s3.cn-north-1.amazonaws.com.cn"
+        return stack_template_url(self.bucket_name, blueprint, endpoint)
 
     def s3_stack_push(self, blueprint, force=False):
         """Pushes the rendered blueprint's template to S3.


### PR DESCRIPTION
Allows for use with S3 buckets in isolated regions like cn-north-1

Example endpoint retrieved from
http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region