### PR TITLE
Get region from provider to the environment for interpolation

### DIFF
--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -31,6 +31,11 @@ class Stacker(BaseCommand):
         else:
             logger.info('Using Default AWS Provider')
             options.provider = default.Provider(region=options.region)
+
+        # Copy the region from the provider, if set, to the environment
+        if options.provider.region:
+            options.environment.update({'region': options.provider.region})
+
         options.context = Context(
             environment=options.environment,
             logger_type=self.logger_type,

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -30,7 +30,6 @@ class Context(object):
     the command line and specified in the config to `Stack` objects.
 
     Args:
-        namespace (str): A unique namespace for the stacks being built.
         environment (dict): A dictionary used to pass in information about
             the environment. Useful for templating.
         stack_names (list): A list of stack_names to operate on. If not passed,

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -94,6 +94,9 @@ class Provider(BaseProvider):
         # Necessary to deal w/ multiprocessing issues w/ sharing ssl conns
         # see: https://github.com/remind101/stacker/issues/196
         self._pid = os.getpid()
+        # If region is not set explicitly, fetch it from the boto session
+        if not self.region:
+            self.region = get_session().region_name
 
     @property
     def cloudformation(self):

--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -5,7 +5,7 @@ import boto3
 import logging
 
 
-def get_session(region):
+def get_session(region=None):
     """Creates a boto3 session with a cache
 
     Args:


### PR DESCRIPTION
When working with stacker in multiple regions I've found it essential to be able to use variable interpolation for the region. For example, the stacker template bucket needs to be region specific because CloudFormation does not allow manipulating objects in other regions.

This change is meant to read the region back from the provider into the context, if it's set in the provider. This way we get a variable ${region} available to configuration templates, and it is set correctly whether passed in or using the default boto credentials chain.