### PR TITLE
Fix issues with "none" as variable values

### DIFF
--- a/stacker/blueprints/base.py
+++ b/stacker/blueprints/base.py
@@ -211,10 +211,6 @@ def resolve_variable(var_name, var_def, provided_variable, blueprint_name):
     try:
         value = validator(value)
     except Exception as exc:
-        try:
-            value
-        except UnboundLocalError:
-            value = "mising or undefined"
         raise ValidatorError(var_name, validator.__name__, value, exc)
 
     # Ensure that the resulting value is the correct type


### PR DESCRIPTION
This was introduced by the merging of two different PRs (#379, #388),
each with their own ideas about "None" as a value.  This should give
us the best of both worlds (hopefully).