### PR TITLE
DAG

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,1 @@
+benchmark.env

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,12 @@
+This is a stacker config for benchmarking stackers performance, you can run it with:
+
+```
+$ cp benchmark.env.example benchmark.env # change the namespace
+$ time stacker build benchmark.env benchmark.yaml
+```
+
+When you're done:
+
+```
+$ stacker destroy --force benchmark.env benchmark.yaml
+```

--- a/benchmark/benchmark.env.example
+++ b/benchmark/benchmark.env.example
@@ -1,0 +1,1 @@
+namespace: stacker-benchmark

--- a/benchmark/benchmark.yaml
+++ b/benchmark/benchmark.yaml
@@ -1,0 +1,67 @@
+# This config sets up a fairly large, and mostly fake, dependency graph, for
+# testing performance of Stacker.
+stacks:
+  - name: vpc
+    class_path: stacker.tests.blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db1
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db1Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db1::DummyOutput}
+  - name: db2
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db2Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db2::DummyOutput}
+  - name: db3
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db3Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db3::DummyOutput}
+  - name: db4
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: db4Replica
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output db4::DummyOutput}
+  - name: rabbitmqYellow
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: cluster
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      VpcId: ${output vpc::DummyOutput}
+  - name: app1
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+  - name: app2
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+      App1: ${output app1::DummyOutput}
+  - name: app3
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+  - name: app4
+    class_path: stacker.tests.blueprints.Dummy
+    variables:
+      Cluster: ${output cluster::DummyOutput}
+      RabbitMQ: ${output rabbitmqYellow::DummyOutput}

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,10 +1,98 @@
-import copy
+import threading
 import logging
+
+from colorama.ansi import Fore
+
+from ..plan import Step
+from ..status import (
+    SUBMITTED,
+    COMPLETE,
+)
 
 import botocore.exceptions
 from stacker.session_cache import get_session
 
 logger = logging.getLogger(__name__)
+
+
+def outline_plan(plan, level=logging.INFO, message=""):
+    """Print an outline of the actions the plan is going to take.
+    The outline will represent the rough ordering of the steps that will be
+    taken.
+    Args:
+        level (int, optional): a valid log level that should be used to log
+            the outline
+        message (str, optional): a message that will be logged to
+            the user after the outline has been logged.
+    """
+    steps = 1
+    logger.log(level, "Plan \"%s\":", plan.description)
+
+    nodes = plan.dag.topological_sort()
+    nodes.reverse()
+    for step_name in nodes:
+        step = plan.steps[step_name]
+        logger.log(
+            level,
+            "  - step: %s: target: \"%s\", action: \"%s\"",
+            steps,
+            step_name,
+            step.fn.__name__,
+        )
+        steps += 1
+
+    if message:
+        logger.log(level, message)
+
+
+def check_point_fn():
+    """Adds a check_point function to each of the given steps."""
+
+    lock = threading.Lock()
+
+    def _fn(plan):
+        lock.acquire()
+        _check_point(plan)
+        lock.release()
+
+    return _fn
+
+
+def _check_point(plan):
+    """Outputs the current status of all steps in the plan."""
+    status_to_color = {
+        SUBMITTED.code: Fore.YELLOW,
+        COMPLETE.code: Fore.GREEN,
+    }
+    logger.info("Plan Status:", extra={"reset": True, "loop": plan.id})
+
+    longest = 0
+    messages = []
+
+    nodes = plan.dag.topological_sort()
+    nodes.reverse()
+    for step_name in nodes:
+        step = plan.steps[step_name]
+
+        length = len(step.name)
+        if length > longest:
+            longest = length
+
+        msg = "%s: %s" % (step.name, step.status.name)
+        if step.status.reason:
+            msg += " (%s)" % (step.status.reason)
+
+        messages.append((msg, step))
+
+    for msg, step in messages:
+        parts = msg.split(' ', 1)
+        fmt = "\t{0: <%d}{1}" % (longest + 2,)
+        color = status_to_color.get(step.status.code, Fore.WHITE)
+        logger.info(fmt.format(*parts), extra={
+            'loop': plan.id,
+            'color': color,
+            'last_updated': step.last_updated,
+        })
 
 
 def stack_template_key_name(blueprint):
@@ -52,11 +140,23 @@ class BaseAction(object):
             the necessary actions.
     """
 
-    def __init__(self, context, provider=None):
+    def __init__(self, context, provider=None, cancel=None):
         self.context = context
         self.provider = provider
         self.bucket_name = context.bucket_name
         self._conn = None
+        self.cancel = cancel or threading.Event()
+
+    def _action(self):
+        raise NotImplementedError
+
+    @property
+    def steps(self):
+        if not hasattr(self, "_steps"):
+            self._steps = [
+                Step(stack, fn=self._action)
+                for stack in self.context.get_stacks()]
+        return self._steps
 
     @property
     def s3_conn(self):
@@ -132,60 +232,3 @@ class BaseAction(object):
 
     def post_run(self, *args, **kwargs):
         pass
-
-    def _get_all_stack_names(self, dependencies):
-        """Get all stack names specified in dependencies.
-
-        Args:
-            - dependencies (dict): a dictionary where each key should be the
-                fully qualified name of a stack whose value is an array of
-                fully qualified stack names that the stack depends on.
-
-        Returns:
-            set: set of all stack names
-
-        """
-        return set(
-            dependencies.keys() +
-            [item for items in dependencies.values() for item in items]
-        )
-
-    def get_stack_execution_order(self, dependencies):
-        """Return the order in which the stacks should be executed.
-
-        Args:
-            - dependencies (dict): a dictionary where each key should be the
-                fully qualified name of a stack whose value is an array of
-                fully qualified stack names that the stack depends on. This is
-                used to generate the order in which the stacks should be
-                executed.
-
-        Returns:
-            array: An array of stack names in the order which they should be
-                executed.
-
-        """
-        # copy the dependencies since we pop items out of it to get the
-        # execution order, we don't want to mutate the one passed in
-        dependencies = copy.deepcopy(dependencies)
-        pending_steps = []
-        executed_steps = []
-        stack_names = self._get_all_stack_names(dependencies)
-        for stack_name in stack_names:
-            requirements = dependencies.get(stack_name, None)
-            if not requirements:
-                dependencies.pop(stack_name, None)
-                pending_steps.append(stack_name)
-
-        while dependencies:
-            for step in pending_steps:
-                for stack_name, requirements in dependencies.items():
-                    if step in requirements:
-                        requirements.remove(step)
-
-                    if not requirements:
-                        dependencies.pop(stack_name)
-                        pending_steps.append(stack_name)
-                pending_steps.remove(step)
-                executed_steps.append(step)
-        return executed_steps + pending_steps

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -31,16 +31,12 @@ def outline_plan(plan, level=logging.INFO, message=""):
     steps = 1
     logger.log(level, "Plan \"%s\":", plan.description)
 
-    nodes = plan.dag.topological_sort()
-    nodes.reverse()
-    for step_name in nodes:
-        step = plan.steps[step_name]
+    for step in plan.steps:
         logger.log(
             level,
-            "  - step: %s: target: \"%s\", action: \"%s\"",
+            "  - step: %s: target: \"%s\"",
             steps,
-            step_name,
-            step.fn.__name__,
+            step.name
         )
         steps += 1
 
@@ -74,11 +70,7 @@ def _check_point(plan):
     longest = 0
     messages = []
 
-    nodes = plan.dag.topological_sort()
-    nodes.reverse()
-    for step_name in nodes:
-        step = plan.steps[step_name]
-
+    for step in plan.steps:
         length = len(step.name)
         if length > longest:
             longest = length

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -17,7 +17,7 @@ from ..status import (
     SubmittedStatus,
     CompleteStatus,
     CancelledStatus,
-    SUBMITTED
+    SUBMITTED,
 )
 
 
@@ -188,10 +188,6 @@ class Action(BaseAction):
 
         stack = step.stack
 
-        # Cancel execution if flag is set.
-        if self.cancel.wait(0):
-            return CancelledStatus(reason="cancelled")
-
         if not should_submit(stack):
             return NotSubmittedStatus()
 
@@ -238,8 +234,8 @@ class Action(BaseAction):
                 logger.debug("Updating existing stack: %s", stack.fqn)
             except StackDidNotChange:
                 return DidNotChangeStatus()
-            except CancelExecution:
-                return CancelledStatus(reason="cancelled")
+            except CancelExecution as e:
+                return CancelledStatus(reason=e.message)
 
         return new_status
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -1,8 +1,9 @@
 import logging
 
-from .base import BaseAction
+from .base import BaseAction, check_point_fn, outline_plan
 from .. import util
 from ..exceptions import (
+    CancelExecution,
     MissingParameterException,
     StackDidNotChange,
     StackDoesNotExist,
@@ -15,6 +16,7 @@ from ..status import (
     DidNotChangeStatus,
     SubmittedStatus,
     CompleteStatus,
+    CancelledStatus,
     SUBMITTED
 )
 
@@ -176,13 +178,20 @@ class Action(BaseAction):
         return [
             {'Key': t[0], 'Value': t[1]} for t in self.context.tags.items()]
 
-    def _launch_stack(self, stack, **kwargs):
+    def _launch_stack(self, step):
         """Handles the creating or updating of a stack in CloudFormation.
 
         Also makes sure that we don't try to create or update a stack while
         it is already updating or creating.
 
         """
+
+        stack = step.stack
+
+        # Cancel execution if flag is set.
+        if self.cancel.wait(0):
+            return CancelledStatus(reason="cancelled")
+
         if not should_submit(stack):
             return NotSubmittedStatus()
 
@@ -191,7 +200,7 @@ class Action(BaseAction):
         except StackDoesNotExist:
             provider_stack = None
 
-        old_status = kwargs.get("status")
+        old_status = step.status
         if provider_stack and old_status == SUBMITTED:
             logger.debug(
                 "Stack %s provider status: %s",
@@ -229,31 +238,19 @@ class Action(BaseAction):
                 logger.debug("Updating existing stack: %s", stack.fqn)
             except StackDidNotChange:
                 return DidNotChangeStatus()
+            except CancelExecution:
+                return CancelledStatus(reason="cancelled")
 
         return new_status
 
+    def _action(self, *args, **kwargs):
+        return self._launch_stack(*args, **kwargs)
+
     def _generate_plan(self, tail=False):
-        plan_kwargs = {}
-        if tail:
-            plan_kwargs["watch_func"] = self.provider.tail_stack
-
-        plan = Plan(description="Create/Update stacks",
-                    logger_type=self.context.logger_type, **plan_kwargs)
-        stacks = self.context.get_stacks_dict()
-        dependencies = self._get_dependencies()
-        for stack_name in self.get_stack_execution_order(dependencies):
-            plan.add(
-                stacks[stack_name],
-                run_func=self._launch_stack,
-                requires=dependencies.get(stack_name),
-            )
-        return plan
-
-    def _get_dependencies(self):
-        dependencies = {}
-        for stack in self.context.get_stacks():
-            dependencies[stack.fqn] = stack.requires
-        return dependencies
+        return Plan(
+            description="Create/Update stacks",
+            steps=self.steps,
+            check_point=check_point_fn())
 
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
@@ -270,7 +267,8 @@ class Action(BaseAction):
                 provider=self.provider,
                 context=self.context)
 
-    def run(self, outline=False, tail=False, dump=False, *args, **kwargs):
+    def run(self, outline=False, tail=False,
+            dump=False, semaphore=None, *args, **kwargs):
         """Kicks off the build/update of the stacks in the stack_definitions.
 
         This is the main entry point for the Builder.
@@ -278,9 +276,9 @@ class Action(BaseAction):
         """
         plan = self._generate_plan(tail=tail)
         if not outline and not dump:
-            plan.outline(logging.DEBUG)
+            outline_plan(plan, logging.DEBUG)
             logger.debug("Launching stacks: %s", ", ".join(plan.keys()))
-            plan.execute()
+            plan.execute(semaphore=semaphore)
         else:
             if outline:
                 plan.outline()

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -1,11 +1,12 @@
 import logging
 
-from .base import BaseAction
+from .base import BaseAction, check_point_fn, outline_plan
 from ..exceptions import StackDoesNotExist
 from .. import util
 from ..status import (
     CompleteStatus,
     SubmittedStatus,
+    CancelledStatus,
     SUBMITTED,
 )
 from ..plan import Plan
@@ -31,35 +32,23 @@ class Action(BaseAction):
 
     """
 
-    def _get_dependencies(self, stacks_dict):
-        dependencies = {}
-        for stack_name, stack in stacks_dict.iteritems():
-            required_stacks = stack.requires
-            if not required_stacks:
-                if stack_name not in dependencies:
-                    dependencies[stack_name] = required_stacks
-                continue
-
-            for requirement in required_stacks:
-                dependencies.setdefault(requirement, set()).add(stack_name)
-        return dependencies
+    def _action(self, *args, **kwargs):
+        return self._destroy_stack(*args, **kwargs)
 
     def _generate_plan(self, tail=False):
-        plan_kwargs = {}
-        if tail:
-            plan_kwargs["watch_func"] = self.provider.tail_stack
-        plan = Plan(description="Destroy stacks", **plan_kwargs)
-        stacks_dict = self.context.get_stacks_dict()
-        dependencies = self._get_dependencies(stacks_dict)
-        for stack_name in self.get_stack_execution_order(dependencies):
-            plan.add(
-                stacks_dict[stack_name],
-                run_func=self._destroy_stack,
-                requires=dependencies.get(stack_name),
-            )
-        return plan
+        return Plan(
+            description="Destroy stacks",
+            steps=self.steps,
+            check_point=check_point_fn(),
+            reverse=True)
 
-    def _destroy_stack(self, stack, **kwargs):
+    def _destroy_stack(self, step):
+        stack = step.stack
+
+        # Cancel execution if flag is set.
+        if self.cancel.wait(0):
+            return CancelledStatus(reason="cancelled")
+
         try:
             provider_stack = self.provider.get_stack(stack.fqn)
         except StackDoesNotExist:
@@ -67,7 +56,7 @@ class Action(BaseAction):
             # Once the stack has been destroyed, it doesn't exist. If the
             # status of the step was SUBMITTED, we know we just deleted it,
             # otherwise it should be skipped
-            if kwargs.get("status", None) == SUBMITTED:
+            if step.status == SUBMITTED:
                 return DestroyedStatus
             else:
                 return StackDoesNotExistStatus()
@@ -96,17 +85,15 @@ class Action(BaseAction):
                 provider=self.provider,
                 context=self.context)
 
-    def run(self, force, tail=False, *args, **kwargs):
+    def run(self, force, tail=False, semaphore=None, *args, **kwargs):
         plan = self._generate_plan(tail=tail)
         if force:
-            # need to generate a new plan to log since the outline sets the
-            # steps to COMPLETE in order to log them
-            debug_plan = self._generate_plan()
-            debug_plan.outline(logging.DEBUG)
-            plan.execute()
+            outline_plan(plan, logging.DEBUG)
+            plan.execute(semaphore=semaphore)
         else:
-            plan.outline(message="To execute this plan, run with \"--force\" "
-                                 "flag.")
+            outline_plan(
+                plan,
+                message="To execute this plan, run with \"--force\" flag.")
 
     def post_run(self, outline=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -8,7 +8,7 @@ from ..status import (
     SubmittedStatus,
     SUBMITTED,
 )
-from ..plan import Plan
+from ..plan import build_plan
 
 from ..status import StackDoesNotExist as StackDoesNotExistStatus
 
@@ -34,10 +34,11 @@ class Action(BaseAction):
     def _action(self, *args, **kwargs):
         return self._destroy_stack(*args, **kwargs)
 
-    def _generate_plan(self, tail=False):
-        return Plan(
+    def _generate_plan(self, tail=False, stack_names=None):
+        return build_plan(
             description="Destroy stacks",
             steps=self.steps,
+            step_names=stack_names,
             check_point=check_point_fn(),
             reverse=True)
 
@@ -80,8 +81,10 @@ class Action(BaseAction):
                 provider=self.provider,
                 context=self.context)
 
-    def run(self, force, tail=False, semaphore=None, *args, **kwargs):
-        plan = self._generate_plan(tail=tail)
+    def run(self, force, tail=False, semaphore=None,
+            stack_names=None,
+            *args, **kwargs):
+        plan = self._generate_plan(tail=tail, stack_names=stack_names)
         if force:
             outline_plan(plan, logging.DEBUG)
             plan.execute(semaphore=semaphore)

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -6,7 +6,6 @@ from .. import util
 from ..status import (
     CompleteStatus,
     SubmittedStatus,
-    CancelledStatus,
     SUBMITTED,
 )
 from ..plan import Plan
@@ -44,10 +43,6 @@ class Action(BaseAction):
 
     def _destroy_stack(self, step):
         stack = step.stack
-
-        # Cancel execution if flag is set.
-        if self.cancel.wait(0):
-            return CancelledStatus(reason="cancelled")
 
         try:
             provider_stack = self.provider.get_stack(stack.fqn)

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -4,7 +4,7 @@ import threading
 from .base import outline_plan
 from .. import exceptions
 from ..plan import COMPLETE, Plan
-from ..status import NotSubmittedStatus, NotUpdatedStatus, CancelledStatus
+from ..status import NotSubmittedStatus, NotUpdatedStatus
 from . import build
 import difflib
 import json
@@ -153,10 +153,6 @@ class Action(build.Action):
         """Handles the diffing a stack in CloudFormation vs our config"""
 
         stack = step.stack
-
-        # Cancel execution if flag is set.
-        if self.cancel.wait(0):
-            return CancelledStatus(reason="cancelled")
 
         if not build.should_submit(stack):
             return NotSubmittedStatus()

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -199,7 +199,7 @@ class Action(build.Action):
     def run(self, *args, **kwargs):
         plan = self._generate_plan()
         outline_plan(plan, logging.DEBUG)
-        logger.info("Diffing stacks: %s", ", ".join(plan.keys()))
+        logger.info("Diffing stacks: %s", ", ".join(plan.step_names))
         plan.execute(semaphore=threading.Semaphore(1))
 
     """Don't ever do anything for pre_run or post_run"""

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -6,7 +6,7 @@ skip executing anything against the stack.
 
 """
 
-from .base import BaseCommand
+from .base import BaseCommand, cancel
 from ...actions import build
 
 
@@ -46,10 +46,15 @@ class Build(BaseCommand):
 
     def run(self, options, **kwargs):
         super(Build, self).run(options, **kwargs)
-        action = build.Action(options.context, provider=options.provider)
+        action = build.Action(
+            options.context,
+            provider=options.provider,
+            cancel=cancel())
+
         action.execute(outline=options.outline,
                        tail=options.tail,
-                       dump=options.dump)
+                       dump=options.dump,
+                       semaphore=self.semaphore(options))
 
     def get_context_kwargs(self, options, **kwargs):
         return {"stack_names": options.stacks, "force_stacks": options.force}

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -33,10 +33,10 @@ class Build(BaseCommand):
                                  "the config.")
         parser.add_argument("--stacks", action="append",
                             metavar="STACKNAME", type=str,
-                            help="Only work on the stacks given. Can be "
-                                 "specified more than once. If not specified "
-                                 "then stacker will work on all stacks in the "
-                                 "config file.")
+                            help="Only work on the stacks given, and their "
+                                 "dependencies. Can be specified more than "
+                                 "once. If not specified then stacker will "
+                                 "work on all stacks in the config file.")
         parser.add_argument("-t", "--tail", action="store_true",
                             help="Tail the CloudFormation logs while working"
                                  "with stacks")
@@ -54,7 +54,8 @@ class Build(BaseCommand):
         action.execute(outline=options.outline,
                        tail=options.tail,
                        dump=options.dump,
+                       stack_names=options.stacks,
                        semaphore=self.semaphore(options))
 
     def get_context_kwargs(self, options, **kwargs):
-        return {"stack_names": options.stacks, "force_stacks": options.force}
+        return {"force_stacks": options.force}

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -5,7 +5,7 @@ any manual requirements they specify or output values they rely on from other
 stacks.
 
 """
-from .base import BaseCommand
+from .base import BaseCommand, cancel
 from ...actions import destroy
 
 
@@ -31,8 +31,14 @@ class Destroy(BaseCommand):
 
     def run(self, options, **kwargs):
         super(Destroy, self).run(options, **kwargs)
-        action = destroy.Action(options.context, provider=options.provider)
-        action.execute(force=options.force, tail=options.tail)
+        action = destroy.Action(
+            options.context,
+            provider=options.provider,
+            cancel=cancel())
+        action.execute(
+            force=options.force,
+            tail=options.tail,
+            semaphore=self.semaphore(options))
 
     def get_context_kwargs(self, options, **kwargs):
         return {"stack_names": options.stacks}

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -21,10 +21,10 @@ class Destroy(BaseCommand):
                                  " with destroying the stacks")
         parser.add_argument("--stacks", action="append",
                             metavar="STACKNAME", type=str,
-                            help="Only work on the stacks given. Can be "
-                                 "specified more than once. If not specified "
-                                 "then stacker will work on all stacks in the "
-                                 "config file.")
+                            help="Only work on the stacks given, and their "
+                                 "dependencies. Can be specified more than "
+                                 "once. If not specified then stacker will "
+                                 "work on all stacks in the config file.")
         parser.add_argument("-t", "--tail", action="store_true",
                             help="Tail the CloudFormation logs while working"
                                  "with stacks")
@@ -38,7 +38,8 @@ class Destroy(BaseCommand):
         action.execute(
             force=options.force,
             tail=options.tail,
+            stack_names=options.stacks,
             semaphore=self.semaphore(options))
 
     def get_context_kwargs(self, options, **kwargs):
-        return {"stack_names": options.stacks}
+        return {}

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -33,8 +33,6 @@ class Context(object):
         namespace (str): A unique namespace for the stacks being built.
         environment (dict): A dictionary used to pass in information about
             the environment. Useful for templating.
-        stack_names (list): A list of stack_names to operate on. If not passed,
-            usually all stacks defined in the config will be operated on.
         mappings (dict): Used as Cloudformation mappings for the blueprint.
         config (dict): The configuration being operated on, containing the
             stack definitions.
@@ -44,7 +42,6 @@ class Context(object):
     """
 
     def __init__(self, environment,  # pylint: disable-msg=too-many-arguments
-                 stack_names=None,
                  mappings=None,
                  config=None,
                  logger_type=None,
@@ -55,7 +52,6 @@ class Context(object):
             raise MissingEnvironment(["namespace"])
 
         self.environment = environment
-        self.stack_names = stack_names or []
         self.mappings = mappings or {}
         self.logger_type = logger_type
         self.namespace_delimiter = "-"
@@ -91,10 +87,7 @@ class Context(object):
             register_lookup_handler(key, handler)
 
     def _get_stack_definitions(self):
-        if not self.stack_names:
-            return self.config["stacks"]
-        return [s for s in self.config["stacks"] if s["name"] in
-                self.stack_names]
+        return self.config["stacks"]
 
     def get_stacks(self):
         """Get the stacks for the current action.

--- a/stacker/dag/__init__.py
+++ b/stacker/dag/__init__.py
@@ -1,0 +1,313 @@
+import threading
+import logging
+from copy import copy, deepcopy
+from collections import deque
+
+logger = logging.getLogger(__name__)
+
+try:
+    from collections import OrderedDict
+except:
+    from ordereddict import OrderedDict
+
+
+class DAGValidationError(Exception):
+    pass
+
+
+class DAG(object):
+    """ Directed acyclic graph implementation. """
+
+    def __init__(self):
+        """ Construct a new DAG with no nodes or edges. """
+        self.reset_graph()
+
+    def add_node(self, node_name, graph=None):
+        """ Add a node if it does not exist yet, or error out. """
+        if not graph:
+            graph = self.graph
+        if node_name in graph:
+            raise KeyError('node %s already exists' % node_name)
+        graph[node_name] = set()
+
+    def add_node_if_not_exists(self, node_name, graph=None):
+        try:
+            self.add_node(node_name, graph=graph)
+        except KeyError:
+            pass
+
+    def delete_node(self, node_name, graph=None):
+        """ Deletes this node and all edges referencing it. """
+        if not graph:
+            graph = self.graph
+        if node_name not in graph:
+            raise KeyError('node %s does not exist' % node_name)
+        graph.pop(node_name)
+
+        for node, edges in graph.iteritems():
+            if node_name in edges:
+                edges.remove(node_name)
+
+    def delete_node_if_exists(self, node_name, graph=None):
+        try:
+            self.delete_node(node_name, graph=graph)
+        except KeyError:
+            pass
+
+    def add_edge(self, ind_node, dep_node, graph=None):
+        """ Add an edge (dependency) between the specified nodes. """
+        if not graph:
+            graph = self.graph
+        if ind_node not in graph:
+            raise KeyError('node %s does not exist' % ind_node)
+        if dep_node not in graph:
+            raise KeyError('node %s does not exist' % dep_node)
+        test_graph = deepcopy(graph)
+        test_graph[ind_node].add(dep_node)
+        is_valid, message = self.validate(test_graph)
+        if is_valid:
+            graph[ind_node].add(dep_node)
+        else:
+            raise DAGValidationError(message)
+
+    def delete_edge(self, ind_node, dep_node, graph=None):
+        """ Delete an edge from the graph. """
+        if not graph:
+            graph = self.graph
+        if dep_node not in graph.get(ind_node, []):
+            raise KeyError('this edge does not exist in graph')
+        graph[ind_node].remove(dep_node)
+
+    def transpose(self, graph=None):
+        """ Builds a new graph with the edges reversed. """
+        if not graph:
+            graph = self.graph
+        transposed = DAG()
+        for node, edges in graph.items():
+            transposed.add_node(node)
+        for node, edges in graph.items():
+            # for each edge A -> B, transpose it so that B -> A
+            for edge in edges:
+                transposed.add_edge(edge, node)
+        return transposed
+
+    def walk(self, walk_func, graph=None):
+        """ Walks each node of the graph, in parallel if it can.
+
+        The walk_func is only called when the nodes dependencies have been
+        satisfied
+        """
+        if not graph:
+            graph = self.graph
+
+        # First, we'll topologically sort all of the nodes, with nodes that
+        # have no dependencies first. We do this to ensure that we don't call
+        # .join on a thread that hasn't yet been started.
+        #
+        # TODO(ejholmes): An alternative would be to ensure that Thread.join
+        # blocks if the thread has not yet been started.
+        nodes = self.topological_sort(graph=graph)
+        nodes.reverse()
+
+        # This maps a node name to a thread of execution.
+        threads = {}
+
+        # Blocks until all of the given nodes have completed execution (whether
+        # successfully, or errored). Returns True if all nodes returned True.
+        def wait_for(nodes):
+            return all(threads[node].join() for node in nodes)
+
+        # For each node in the graph, we're going to allocate a thread to
+        # execute. The thread will block executing walk_func, until all of the
+        # nodes dependencies have executed successfully.
+        #
+        # If any node fails for some reason (e.g. raising an exception), any
+        # downstream nodes will be cancelled.
+        for node in nodes:
+            def fn(n, deps):
+                if deps:
+                    logger.debug(
+                        "%s waiting for %s to complete",
+                        n,
+                        ", ".join(deps))
+
+                # Wait for all dependencies to complete sucessfully.
+                if not wait_for(deps):
+                    logger.debug("cancelling %s. "
+                                 "Some dependencies "
+                                 "were not satisfied", n)
+                    return False
+
+                logger.debug("%s starting", n)
+
+                ret = walk_func(n)
+
+                if ret:
+                    logger.debug("%s completed", n)
+                else:
+                    logger.debug("%s failed", n)
+
+                return ret
+
+            deps = self.all_downstreams(node, graph=graph)
+            threads[node] = Thread(target=fn, args=(node, deps), name=node)
+
+        # Start up all of the threads.
+        for node in nodes:
+            threads[node].start()
+
+        # Wait for all threads to complete executing.
+        return wait_for(nodes)
+
+    def rename_edges(self, old_task_name, new_task_name, graph=None):
+        """ Change references to a task in existing edges. """
+        if not graph:
+            graph = self.graph
+        for node, edges in graph.items():
+            if node == old_task_name:
+                graph[new_task_name] = copy(edges)
+                del graph[old_task_name]
+
+            else:
+                if old_task_name in edges:
+                    edges.remove(old_task_name)
+                    edges.add(new_task_name)
+
+    def predecessors(self, node, graph=None):
+        """ Returns a list of all predecessors of the given node """
+        if graph is None:
+            graph = self.graph
+        return [key for key in graph if node in graph[key]]
+
+    def downstream(self, node, graph=None):
+        """ Returns a list of all nodes this node has edges towards. """
+        if graph is None:
+            graph = self.graph
+        if node not in graph:
+            raise KeyError('node %s is not in graph' % node)
+        return list(graph[node])
+
+    def all_downstreams(self, node, graph=None):
+        """Returns a list of all nodes ultimately downstream
+        of the given node in the dependency graph, in
+        topological order."""
+        if graph is None:
+            graph = self.graph
+        nodes = [node]
+        nodes_seen = set()
+        i = 0
+        while i < len(nodes):
+            downstreams = self.downstream(nodes[i], graph)
+            for downstream_node in downstreams:
+                if downstream_node not in nodes_seen:
+                    nodes_seen.add(downstream_node)
+                    nodes.append(downstream_node)
+            i += 1
+        return filter(
+                lambda node: node
+                in nodes_seen, self.topological_sort(graph=graph))
+
+    def all_leaves(self, graph=None):
+        """ Return a list of all leaves (nodes with no downstreams) """
+        if graph is None:
+            graph = self.graph
+        return [key for key in graph if not graph[key]]
+
+    def from_dict(self, graph_dict):
+        """ Reset the graph and build it from the passed dictionary.
+
+        The dictionary takes the form of {node_name: [directed edges]}
+        """
+
+        self.reset_graph()
+        for new_node in graph_dict.iterkeys():
+            self.add_node(new_node)
+        for ind_node, dep_nodes in graph_dict.iteritems():
+            if not isinstance(dep_nodes, list):
+                raise TypeError('dict values must be lists')
+            for dep_node in dep_nodes:
+                self.add_edge(ind_node, dep_node)
+
+    def reset_graph(self):
+        """ Restore the graph to an empty state. """
+        self.graph = OrderedDict()
+
+    def ind_nodes(self, graph=None):
+        """ Returns a list of all nodes in the graph with no dependencies. """
+        if graph is None:
+            graph = self.graph
+
+        dependent_nodes = set(
+            node for dependents
+            in graph.itervalues() for node in dependents)
+        return [node for node in graph.keys() if node not in dependent_nodes]
+
+    def validate(self, graph=None):
+        """ Returns (Boolean, message) of whether DAG is valid. """
+        if graph is None:
+            graph = self.graph
+
+        if len(self.ind_nodes(graph)) == 0:
+            return (False, 'no independent nodes detected')
+        try:
+            self.topological_sort(graph)
+        except ValueError as e:
+            return (False, e.message)
+        return (True, 'valid')
+
+    def topological_sort(self, graph=None):
+        """ Returns a topological ordering of the DAG.
+
+        Raises an error if this is not possible (graph is not valid).
+        """
+        if graph is None:
+            graph = self.graph
+
+        in_degree = {}
+        for u in graph:
+            in_degree[u] = 0
+
+        for u in graph:
+            for v in graph[u]:
+                in_degree[v] += 1
+
+        queue = deque()
+        for u in in_degree:
+            if in_degree[u] == 0:
+                queue.appendleft(u)
+
+        l = []
+        while queue:
+            u = queue.pop()
+            l.append(u)
+            for v in graph[u]:
+                in_degree[v] -= 1
+                if in_degree[v] == 0:
+                    queue.appendleft(v)
+
+        if len(l) == len(graph):
+            return l
+        else:
+            raise ValueError('graph is not acyclic')
+
+    def size(self):
+        return len(self.graph)
+
+
+class Thread(threading.Thread):
+    """Used when executing walk_func's in parallel, to provide access to the
+    return value.
+    """
+    def __init__(self, *args, **kwargs):
+        super(Thread, self).__init__(*args, **kwargs)
+        self._return = None
+
+    def run(self):
+        if self._Thread__target is not None:
+            self._return = self._Thread__target(
+                    *self._Thread__args,
+                    **self._Thread__kwargs)
+
+    def join(self, *args, **kwargs):
+        super(Thread, self).join(*args, **kwargs)
+        return self._return

--- a/stacker/dag/__init__.py
+++ b/stacker/dag/__init__.py
@@ -207,6 +207,28 @@ class DAG(object):
                 lambda node: node
                 in nodes_seen, self.topological_sort(graph=graph))
 
+    def filter(self, nodes, graph=None):
+        """ Returns a new DAG with only the given nodes and their
+        dependencies.
+        """
+
+        if graph is None:
+            graph = self.graph
+        dag = DAG()
+
+        # Add only the nodes we need.
+        for node in nodes:
+            dag.add_node_if_not_exists(node)
+            for edge in self.all_downstreams(node, graph=graph):
+                dag.add_node_if_not_exists(edge)
+
+        # Now, rebuild the graph for each node that's present.
+        for node, edges in graph.items():
+            if node in dag.graph:
+                dag.graph[node] = edges
+
+        return dag
+
     def all_leaves(self, graph=None):
         """ Return a list of all leaves (nodes with no downstreams) """
         if graph is None:

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -188,3 +188,17 @@ class UnableToExecuteChangeSet(Exception):
                    "%s" % (change_set_id, stack_name, execution_status))
 
         super(UnableToExecuteChangeSet, self).__init__(message)
+
+
+class GraphError(Exception):
+    """Raised when the graph is invalid (e.g. acyclic dependencies)
+    """
+
+    def __init__(self, exception, stack=None, dependency=None):
+        self.stack = stack
+        self.dependency = dependency
+        self.exception = exception
+        message = ("Error detected when adding '%s' "
+                   "as a dependency of '%s': %s") % (
+                           dependency, stack, exception.message)
+        super(GraphError, self).__init__(message)

--- a/stacker/logger/__init__.py
+++ b/stacker/logger/__init__.py
@@ -35,6 +35,12 @@ def setup_logging(verbosity, interactive):
         fmt = ColorFormatter(COLOR_FORMAT, ISO_8601)
         hdlr = LogLoopStreamHandler()
         hdlr.setFormatter(fmt)
+
+        # When in the loop logger, stack traces will get overwritten by the
+        # ANSI escape sequences. To see raw exceptions, don't use the loop
+        # logger.
+        hdlr.addFilter(NoExceptions())
+
         logging.root.addHandler(hdlr)
         logging.root.setLevel(log_level)
     else:
@@ -44,3 +50,10 @@ def setup_logging(verbosity, interactive):
             level=log_level,
         )
     return log_type
+
+
+class NoExceptions(object):
+    def filter(self, record):
+        if record.levelno == logging.ERROR:
+            return 0
+        return 1

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -12,7 +12,8 @@ from .status import (
     COMPLETE,
     SKIPPED,
     CANCELLED,
-    CancelledStatus
+    ERRORED,
+    ErroredStatus
 )
 
 logger = logging.getLogger(__name__)
@@ -47,8 +48,7 @@ class Step(object):
                 status = self.fn(self)
                 self.set_status(status)
             except Exception as e:
-                self.set_status(CancelledStatus(e.message))
-                raise
+                self.set_status(ErroredStatus(e.message))
         return self.ok
 
     @property
@@ -75,11 +75,16 @@ class Step(object):
         return self.status == CANCELLED
 
     @property
+    def errored(self):
+        """Returns True if the step is in a ERRORED state."""
+        return self.status == ERRORED
+
+    @property
     def done(self):
         """Returns True if the step is finished (either COMPLETE, SKIPPED or
         CANCELLED)
         """
-        return self.completed or self.skipped or self.cancelled
+        return self.completed or self.skipped or self.cancelled or self.errored
 
     @property
     def ok(self):

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -49,6 +49,7 @@ class Step(object):
                 self.set_status(status)
             except Exception as e:
                 self.set_status(ErroredStatus(e.message))
+                logger.exception(e)
         return self.ok
 
     @property

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -11,7 +11,8 @@ from .status import (
     SUBMITTED,
     COMPLETE,
     SKIPPED,
-    CANCELLED
+    CANCELLED,
+    CancelledStatus
 )
 
 logger = logging.getLogger(__name__)
@@ -42,8 +43,12 @@ class Step(object):
         """
 
         while not self.done:
-            status = self.fn(self)
-            self.set_status(status)
+            try:
+                status = self.fn(self)
+                self.set_status(status)
+            except Exception as e:
+                self.set_status(CancelledStatus(e.message))
+                raise
         return self.ok
 
     @property

--- a/stacker/status.py
+++ b/stacker/status.py
@@ -30,6 +30,11 @@ class SkippedStatus(Status):
         super(SkippedStatus, self).__init__("skipped", 3, reason)
 
 
+class CancelledStatus(Status):
+    def __init__(self, reason=None):
+        super(CancelledStatus, self).__init__("cancelled", 4, reason)
+
+
 class NotSubmittedStatus(SkippedStatus):
     reason = "disabled"
 
@@ -50,3 +55,4 @@ PENDING = PendingStatus()
 SUBMITTED = SubmittedStatus()
 COMPLETE = CompleteStatus()
 SKIPPED = SkippedStatus()
+CANCELLED = CancelledStatus()

--- a/stacker/status.py
+++ b/stacker/status.py
@@ -35,6 +35,11 @@ class CancelledStatus(Status):
         super(CancelledStatus, self).__init__("cancelled", 4, reason)
 
 
+class ErroredStatus(Status):
+    def __init__(self, reason=None):
+        super(ErroredStatus, self).__init__("errored", 5, reason)
+
+
 class NotSubmittedStatus(SkippedStatus):
     reason = "disabled"
 
@@ -56,3 +61,5 @@ SUBMITTED = SubmittedStatus()
 COMPLETE = CompleteStatus()
 SKIPPED = SkippedStatus()
 CANCELLED = CancelledStatus()
+INTERRUPTED = CancelledStatus(reason="interrupted")
+ERRORED = ErroredStatus()

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -107,7 +107,7 @@ class TestBuildAction(unittest.TestCase):
                 'namespace-bastion': set(['namespace-vpc']),
                 'namespace-other': set([]),
                 'namespace-vpc': set([])},
-            plan.dag.graph
+            plan.graph.dag.graph
         )
 
     def test_dont_execute_plan_when_outline_specified(self):

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -13,15 +13,6 @@ from stacker.status import (
 )
 
 
-class MockStack(object):
-    """Mock our local Stacker stack and an AWS provider stack"""
-
-    def __init__(self, name, tags=None, **kwargs):
-        self.name = name
-        self.fqn = name
-        self.requires = []
-
-
 class TestDestroyAction(unittest.TestCase):
 
     def setUp(self):
@@ -39,10 +30,25 @@ class TestDestroyAction(unittest.TestCase):
 
     def test_generate_plan(self):
         plan = self.action._generate_plan()
-        stacks = ["other", "db", "instance", "bastion", "vpc"]
         self.assertEqual(
-            [self.context.get_fqn(s) for s in stacks],
-            plan.keys(),
+            {
+                'namespace-vpc': set(
+                    [
+                        'namespace-db',
+                        'namespace-instance',
+                        'namespace-bastion']),
+                'namespace-other': set([]),
+                'namespace-bastion': set(
+                    [
+                        'namespace-instance',
+                        'namespace-db']),
+                'namespace-instance': set(
+                    [
+                        'namespace-db']),
+                'namespace-db': set(
+                    [
+                        'namespace-other'])},
+            plan.dag.graph,
         )
 
     def test_only_execute_plan_when_forced(self):
@@ -58,106 +64,20 @@ class TestDestroyAction(unittest.TestCase):
             self.assertEqual(mock_generate_plan().execute.call_count, 1)
 
     def test_destroy_stack_complete_if_state_submitted(self):
+        step = mock.MagicMock()
+        step.name = "vpc"
+
         # Simulate the provider not being able to find the stack (a result of
         # it being successfully deleted)
         self.action.provider = mock.MagicMock()
         self.action.provider.get_stack.side_effect = StackDoesNotExist("mock")
-        status = self.action._destroy_stack(MockStack("vpc"), status=PENDING)
+        step.status = PENDING
+        status = self.action._destroy_stack(step)
         # if we haven't processed the step (ie. has never been SUBMITTED,
         # should be skipped)
         self.assertEqual(status, SKIPPED)
-        status = self.action._destroy_stack(MockStack("vpc"), status=SUBMITTED)
+        step.status = SUBMITTED
+        status = self.action._destroy_stack(step)
         # if we have processed the step and then can't find the stack, it means
         # we successfully deleted it
-        self.assertEqual(status, COMPLETE)
-
-    def test_destroy_stack_in_parallel(self):
-        count = {"_count": 0}
-        mock_provider = mock.MagicMock()
-        self.context.config = {
-            "stacks": [
-                {"name": "vpc"},
-                {"name": "bastion", "requires": ["vpc"]},
-                {"name": "instance", "requires": ["vpc"]},
-                {"name": "db", "requies": ["vpc"]},
-            ],
-        }
-        stacks_dict = self.context.get_stacks_dict()
-
-        def get_stack(stack_name):
-            return stacks_dict.get(stack_name)
-
-        def get_stack_staggered(stack_name):
-            count["_count"] += 1
-            if not count["_count"] % 2:
-                raise StackDoesNotExist(stack_name)
-            return stacks_dict.get(stack_name)
-
-        def wait_func(*args):
-            # we want "get_stack" above to return staggered results for the
-            # stack being "deleted" to simulate waiting on stacks to complete
-            mock_provider.get_stack.side_effect = get_stack_staggered
-
-        plan = self.action._generate_plan()
-        plan._wait_func = wait_func
-
-        # swap for mock provider
-        plan.provider = mock_provider
-        self.action.provider = mock_provider
-
-        # we want "get_stack" to return the mock stacks above on the first
-        # pass. "wait_func" will simulate the stack being deleted every second
-        # pass
-        mock_provider.get_stack.side_effect = get_stack
-        mock_provider.is_stack_destroyed.return_value = False
-        mock_provider.is_stack_in_progress.return_value = True
-
-        independent_stacks = filter(lambda x: x.name != "vpc",
-                                    self.context.get_stacks())
-        while not plan._single_run():
-            # vpc should be the last stack that is deleted
-            if plan["namespace-vpc"].completed:
-                self.assertFalse(plan.list_pending())
-
-            # all of the independent stacks should be submitted at the same
-            # time
-            submitted_stacks = [
-                plan[stack.fqn].submitted for stack in independent_stacks
-            ]
-            if any(submitted_stacks):
-                self.assertTrue(all(submitted_stacks))
-            wait_func()
-
-    def test_destroy_stack_step_statuses(self):
-        mock_provider = mock.MagicMock()
-        stacks_dict = self.context.get_stacks_dict()
-
-        def get_stack(stack_name):
-            return stacks_dict.get(stack_name)
-
-        plan = self.action._generate_plan()
-        _, step = plan.list_pending()[0]
-        # we need the AWS provider to generate the plan, but swap it for
-        # the mock one to make the test easier
-        self.action.provider = mock_provider
-
-        # simulate stack doesn't exist and we haven't submitted anything for
-        # deletion
-        mock_provider.get_stack.side_effect = StackDoesNotExist("mock")
-        status = step.run()
-        self.assertEqual(status, SKIPPED)
-
-        # simulate stack getting successfully deleted
-        mock_provider.get_stack.side_effect = get_stack
-        mock_provider.is_stack_destroyed.return_value = False
-        mock_provider.is_stack_in_progress.return_value = False
-        status = step.run()
-        self.assertEqual(status, SUBMITTED)
-        mock_provider.is_stack_destroyed.return_value = False
-        mock_provider.is_stack_in_progress.return_value = True
-        status = step.run()
-        self.assertEqual(status, SUBMITTED)
-        mock_provider.is_stack_destroyed.return_value = True
-        mock_provider.is_stack_in_progress.return_value = False
-        status = step.run()
         self.assertEqual(status, COMPLETE)

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -48,7 +48,7 @@ class TestDestroyAction(unittest.TestCase):
                 'namespace-db': set(
                     [
                         'namespace-other'])},
-            plan.dag.graph,
+            plan.graph.dag.graph,
         )
 
     def test_only_execute_plan_when_forced(self):

--- a/stacker/tests/blueprints/__init__.py
+++ b/stacker/tests/blueprints/__init__.py
@@ -1,0 +1,10 @@
+from troposphere import Output, Ref
+from stacker.blueprints.base import Blueprint
+from troposphere.cloudformation import WaitConditionHandle
+
+
+class Dummy(Blueprint):
+    def create_template(self):
+        handle = self.template.add_resource(
+            WaitConditionHandle("DummyResource"))
+        self.template.add_output(Output("DummyOutput", Value=Ref(handle)))

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -27,21 +27,11 @@ class TestContext(unittest.TestCase):
     def test_context_optional_keys_set(self):
         context = Context(
             environment=self.environment,
-            stack_names=["stack"],
             mappings={},
             config={},
         )
         for key in ["mappings", "config"]:
             self.assertEqual(getattr(context, key), {})
-        self.assertEqual(context.stack_names, ["stack"])
-
-    def test_context_get_stacks_specific_stacks(self):
-        context = Context(
-            environment=self.environment,
-            config=self.config,
-            stack_names=["stack2"],
-        )
-        self.assertEqual(len(context.get_stacks()), 1)
 
     def test_context_get_stacks(self):
         context = Context(self.environment, config=self.config)

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -1,0 +1,214 @@
+""" Tests on the DAG implementation """
+
+from nose import with_setup
+from nose.tools import nottest, raises
+from stacker.dag import DAG, DAGValidationError
+import threading
+
+dag = None
+
+
+@nottest
+def blank_setup():
+    global dag
+    dag = DAG()
+
+
+@nottest
+def start_with_graph():
+    global dag
+    dag = DAG()
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+
+@with_setup(blank_setup)
+def test_add_node():
+    dag.add_node('a')
+    assert dag.graph == {'a': set()}
+
+
+@with_setup(start_with_graph)
+def test_transpose():
+    transposed = dag.transpose()
+    assert transposed.graph == {'d': set(['c', 'b']),
+                                'c': set(['a']),
+                                'b': set(['a']),
+                                'a': set([])}
+
+
+@with_setup(blank_setup)
+def test_add_edge():
+    dag.add_node('a')
+    dag.add_node('b')
+    dag.add_edge('a', 'b')
+    assert dag.graph == {'a': set('b'), 'b': set()}
+
+
+@with_setup(blank_setup)
+def test_from_dict():
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+    assert dag.graph == {'a': set(['b', 'c']),
+                         'b': set('d'),
+                         'c': set('d'),
+                         'd': set()}
+
+
+@with_setup(blank_setup)
+def test_reset_graph():
+    dag.add_node('a')
+    assert dag.graph == {'a': set()}
+    dag.reset_graph()
+    assert dag.graph == {}
+
+
+@with_setup(blank_setup)
+def test_walk():
+    dag = DAG()
+
+    # b and c should be executed at the same time.
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+    lock = threading.Lock()  # Protects nodes from concurrent access
+    nodes = []
+
+    def walk_func(n):
+        lock.acquire()
+        nodes.append(n)
+        lock.release()
+        return True
+
+    ok = dag.walk(walk_func)
+    assert ok == True  # noqa: E712
+    assert nodes == ['d', 'c', 'b', 'a'] or nodes == ['d', 'b', 'c', 'a']
+
+
+@with_setup(blank_setup)
+def test_walk_failed():
+    dag = DAG()
+
+    # b and c should be executed at the same time.
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+    lock = threading.Lock()  # Protects nodes from concurrent access
+    nodes = []
+
+    def walk_func(n):
+        lock.acquire()
+        nodes.append(n)
+        lock.release()
+        return False
+
+    ok = dag.walk(walk_func)
+
+    # Only 2 should have been hit. The rest are canceled because they depend on
+    # the success of d.
+    assert ok == False  # noqa: E712
+    assert nodes == ['d']
+
+
+@with_setup(blank_setup)
+def test_walk_exception():
+    dag = DAG()
+
+    # b and c should be executed at the same time.
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+    lock = threading.Lock()  # Protects nodes from concurrent access
+    nodes = []
+
+    def walk_func(n):
+        lock.acquire()
+        nodes.append(n)
+        lock.release()
+        raise Exception('well shit')
+
+    ok = dag.walk(walk_func)
+
+    # Only 2 should have been hit. The rest are canceled because they depend on
+    # the success of d.
+    assert ok == False  # noqa: E712
+    assert nodes == ['d']
+
+
+@with_setup(start_with_graph)
+def test_ind_nodes():
+    assert dag.ind_nodes(dag.graph) == ['a']
+
+
+@with_setup(blank_setup)
+def test_topological_sort():
+    dag.from_dict({'a': [],
+                   'b': ['a'],
+                   'c': ['b']})
+    assert dag.topological_sort() == ['c', 'b', 'a']
+
+
+@with_setup(start_with_graph)
+def test_successful_validation():
+    assert dag.validate()[0] == True  # noqa: E712
+
+
+@raises(DAGValidationError)
+@with_setup(blank_setup)
+def test_failed_validation():
+    dag.from_dict({'a': ['b'],
+                   'b': ['a']})
+
+
+@with_setup(start_with_graph)
+def test_downstream():
+    assert set(dag.downstream('a', dag.graph)) == set(['b', 'c'])
+
+
+@with_setup(start_with_graph)
+def test_all_downstreams():
+    assert dag.all_downstreams('a') == ['c', 'b', 'd']
+    assert dag.all_downstreams('b') == ['d']
+    assert dag.all_downstreams('d') == []
+
+
+@with_setup(start_with_graph)
+def test_all_downstreams_pass_graph():
+    dag2 = DAG()
+    dag2.from_dict({'a': ['c'],
+                    'b': ['d'],
+                    'c': ['d'],
+                    'd': []})
+    assert dag.all_downstreams('a', dag2.graph) == ['c', 'd']
+    assert dag.all_downstreams('b', dag2.graph) == ['d']
+    assert dag.all_downstreams('d', dag2.graph) == []
+
+
+@with_setup(start_with_graph)
+def test_predecessors():
+    assert set(dag.predecessors('a')) == set([])
+    assert set(dag.predecessors('b')) == set(['a'])
+    assert set(dag.predecessors('c')) == set(['a'])
+    assert set(dag.predecessors('d')) == set(['b', 'c'])
+
+
+@with_setup(start_with_graph)
+def test_all_leaves():
+    assert dag.all_leaves() == ['d']
+
+
+@with_setup(start_with_graph)
+def test_size():
+    assert dag.size() == 4
+    dag.delete_node('a')
+    assert dag.size() == 3

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -203,6 +203,14 @@ def test_predecessors():
 
 
 @with_setup(start_with_graph)
+def test_filter():
+    dag2 = dag.filter(['b', 'c'])
+    assert dag2.graph == {'b': set('d'),
+                          'c': set('d'),
+                          'd': set()}
+
+
+@with_setup(start_with_graph)
 def test_all_leaves():
     assert dag.all_leaves() == ['d']
 

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -3,14 +3,10 @@ import unittest
 import mock
 
 from stacker.context import Context
-from stacker.exceptions import ImproperlyConfigured, FailedVariableLookup
+from stacker.exceptions import GraphError
 from stacker.lookups.registry import (
     register_lookup_handler,
     unregister_lookup_handler,
-)
-from stacker.logger import (
-    BASIC_LOGGER_TYPE,
-    LOOP_LOGGER_TYPE,
 )
 from stacker.plan import (
     Step,
@@ -19,7 +15,7 @@ from stacker.plan import (
 from stacker.status import (
     COMPLETE,
     SKIPPED,
-    SUBMITTED,
+    CANCELLED,
 )
 from stacker.stack import Stack
 
@@ -31,15 +27,8 @@ count = 0
 class TestStep(unittest.TestCase):
 
     def setUp(self):
-        self.context = Context({"namespace": "namespace"})
-        stack = Stack(
-            definition=generate_definition("vpc", 1),
-            context=self.context,
-        )
-        self.step = Step(
-            stack=stack,
-            run_func=lambda x, y: (x, y),
-        )
+        stack = mock.MagicMock()
+        self.step = Step(stack=stack)
 
     def test_status(self):
         self.assertFalse(self.step.submitted)
@@ -63,268 +52,120 @@ class TestPlan(unittest.TestCase):
     def tearDown(self):
         unregister_lookup_handler("noop")
 
-    def _run_func(self, stack, **kwargs):
-        self.count += 1
-        if not self.count % 2:
-            return COMPLETE
-        elif self.count == 9:
-            return SKIPPED
-        return SUBMITTED
+    def test_pan(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        plan = Plan(description="Test", steps=[Step(vpc), Step(bastion)])
+
+        self.assertEqual(plan.dag.graph, {
+            'namespace-bastion.1': set(['namespace-vpc.1']),
+            'namespace-vpc.1': set([])})
 
     def test_execute_plan(self):
-        plan = Plan(description="Test", sleep_time=0)
-        previous_stack = None
-        for i in range(5):
-            overrides = {}
-            if previous_stack:
-                overrides["requires"] = [previous_stack.fqn]
-            stack = Stack(
-                definition=generate_definition("vpc", i, **overrides),
-                context=self.context,
-            )
-            previous_stack = stack
-            plan.add(
-                stack=stack,
-                run_func=self._run_func,
-                requires=stack.requires,
-            )
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
 
-        pre_md5 = plan.md5
-        plan.execute()
-        self.assertNotEqual(pre_md5, plan.md5)
-        self.assertEqual(self.count, 9)
-        self.assertEqual(len(plan.list_skipped()), 1)
+        calls = []
 
-    @mock.patch("stacker.plan.multiprocessing")
-    def test_execute_plan_with_watchers(self, patched_multiprocessing):
-        watch_func = mock.MagicMock()
-        plan = Plan(description="Test", sleep_time=0, watch_func=watch_func)
-        previous_stack = None
-        for i in range(5):
-            overrides = {}
-            if previous_stack:
-                overrides["requires"] = [previous_stack.fqn]
-            stack = Stack(
-                definition=generate_definition("vpc", i, **overrides),
-                context=self.context,
-            )
-            previous_stack = stack
-            plan.add(
-                stack=stack,
-                run_func=self._run_func,
-                requires=stack.requires,
-            )
-
-        plan.execute()
-        self.assertEqual(self.count, 9)
-        self.assertEqual(len(plan.list_skipped()), 1)
-        self.assertEqual(patched_multiprocessing.Process().start.call_count, 5)
-        # verify we terminate the process when the stack is finished and also
-        # redundantly terminate the process after execution
-        self.assertEqual(
-            patched_multiprocessing.Process().terminate.call_count, 10)
-
-    def test_step_must_return_status(self):
-        plan = Plan(description="Test", sleep_time=0)
-        stack = Stack(definition=generate_definition("vpc", 1),
-                      context=mock.MagicMock())
-        plan.add(
-            stack=stack,
-            run_func=lambda x, **kwargs: (x),
-        )
-        with self.assertRaises(ValueError):
-            plan.execute()
-
-    def test_execute_plan_ensure_parallel_builds(self):
-        # key: stack_name, value: current iteration
-        work_states = {}
-        submitted_state = 0
-        # It takes 4 iterations for each task to finish
-        finished_state = 3
-
-        def _run_func(stack, *args, **kwargs):
-            if stack.name not in work_states:
-                work_states[stack.name] = submitted_state
-                return SUBMITTED
-
-            if work_states[stack.name] == finished_state:
-                return COMPLETE
-
-            work_states[stack.name] += 1
-            return SUBMITTED
-
-        vpc_stack = Stack(definition=generate_definition("vpc", 1),
-                          context=self.context)
-        web_stack = Stack(
-            definition=generate_definition("web", 2, requires=[vpc_stack.fqn]),
-            context=self.context,
-        )
-        db_stack = Stack(
-            definition=generate_definition("db", 3, requires=[vpc_stack.fqn]),
-            context=self.context,
-        )
-
-        plan = Plan(description="Test", sleep_time=0)
-        for stack in [vpc_stack, web_stack, db_stack]:
-            plan.add(
-                stack=stack,
-                run_func=_run_func,
-                requires=stack.requires,
-            )
-
-        parallel_success = False
-        while not plan._single_run():
-            vpc_step = plan[vpc_stack.fqn]
-            web_step = plan[web_stack.fqn]
-            db_step = plan[db_stack.fqn]
-            if not vpc_step.completed:
-                self.assertFalse(web_step.submitted)
-                self.assertFalse(db_step.submitted)
-            else:
-                # If the vpc step is complete, and we see both the web & db
-                # steps submitted during the same run, then parallel running
-                # works
-                if web_step.status == SUBMITTED and \
-                        db_step.status == SUBMITTED:
-                    parallel_success = True
-        self.assertTrue(parallel_success)
-
-    def test_plan_wait_func_must_be_function(self):
-        with self.assertRaises(ImproperlyConfigured):
-            Plan(description="Test", wait_func="invalid")
-
-    def test_plan_steps_listed_with_fqn(self):
-        plan = Plan(description="Test", sleep_time=0)
-        stack = Stack(definition=generate_definition("vpc", 1),
-                      context=self.context)
-        plan.add(stack=stack, run_func=lambda x, y: (x, y))
-        steps = plan.list_pending()
-        self.assertEqual(steps[0][0], stack.fqn)
-
-    def test_execute_plan_wait_func_not_called_if_complete(self):
-        wait_func = mock.MagicMock()
-        plan = Plan(description="Test", wait_func=wait_func)
-
-        def run_func(*args, **kwargs):
+        def fn(step):
+            calls.append(step.name)
             return COMPLETE
 
-        for i in range(2):
-            stack = Stack(definition=generate_definition("vpc", i),
-                          context=self.context)
-            plan.add(
-                stack=stack,
-                run_func=run_func,
-                requires=stack.requires,
-            )
+        plan = Plan(
+            description="Test", steps=[Step(vpc, fn), Step(bastion, fn)])
+        plan.execute()
+
+        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+
+    def test_execute_plan_cancelled(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        calls = []
+
+        def fn(step):
+            calls.append(step.name)
+            if step == vpc_step:
+                return CANCELLED
+            return COMPLETE
+
+        vpc_step = Step(vpc, fn)
+        bastion_step = Step(bastion, fn)
+        plan = Plan(description="Test", steps=[vpc_step, bastion_step])
 
         plan.execute()
-        self.assertEqual(wait_func.call_count, 0)
 
-    def test_reset_plan(self):
-        plan = Plan(description="Test", sleep_time=0)
-        previous_stack = None
-        for i in range(5):
-            overrides = {}
-            if previous_stack:
-                overrides["requires"] = [previous_stack.fqn]
-            stack = Stack(
-                definition=generate_definition("vpc", i, **overrides),
-                context=self.context,
-            )
-            previous_stack = stack
-            plan.add(
-                stack=stack,
-                run_func=self._run_func,
-                requires=stack.requires,
-            )
+        self.assertEquals(calls, ['namespace-vpc.1'])
 
+    def test_execute_plan_skipped(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        calls = []
+
+        def fn(step):
+            calls.append(step.name)
+            if step == vpc_step:
+                return SKIPPED
+            return COMPLETE
+
+        vpc_step = Step(vpc, fn)
+        bastion_step = Step(bastion, fn)
+
+        plan = Plan(description="Test", steps=[vpc_step, bastion_step])
         plan.execute()
-        self.assertEqual(self.count, 9)
-        self.assertEqual(len(plan.list_skipped()), 1)
-        plan.reset()
-        self.assertEqual(len(plan.list_pending()), len(plan))
 
-    def test_reset_after_outline(self):
-        plan = Plan(description="Test", sleep_time=0)
-        previous_stack = None
-        for i in range(5):
-            overrides = {}
-            if previous_stack:
-                overrides["requires"] = [previous_stack.fqn]
-            stack = Stack(
-                definition=generate_definition("vpc", i, **overrides),
-                context=self.context,
-            )
-            previous_stack = stack
-            plan.add(
-                stack=stack,
-                run_func=self._run_func,
-                requires=stack.requires,
-            )
+        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
 
-        plan.outline()
-        self.assertEqual(len(plan.list_pending()), len(plan))
+    def test_build_plan_missing_dependency(self):
+        bastion = Stack(
+            definition=generate_definition(
+                'bastion', 1, requires=['namespace-vpc.1']),
+            context=self.context)
 
-    @mock.patch("stacker.plan.os")
-    @mock.patch("stacker.plan.open", mock.mock_open(), create=True)
-    def test_reset_after_dump(self, *args):
-        plan = Plan(description="Test", sleep_time=0)
-        previous_stack = None
-        for i in range(5):
-            overrides = {
-                "variables": {
-                    "PublicSubnets": "1",
-                    "SshKeyName": "1",
-                    "PrivateSubnets": "1",
-                    "Random": "${noop something}",
-                },
-            }
-            if previous_stack:
-                overrides["requires"] = [previous_stack.fqn]
-            stack = Stack(
-                definition=generate_definition("vpc", i, **overrides),
-                context=self.context,
-            )
-            previous_stack = stack
-            plan.add(
-                stack=stack,
-                run_func=self._run_func,
-                requires=stack.requires,
-            )
+        with self.assertRaises(GraphError) as expected:
+            Plan(description="Test", steps=[Step(bastion, None)])
+        message = ("Error detected when adding 'namespace-vpc.1' "
+                   "as a dependency of 'namespace-bastion.1': node "
+                   "namespace-vpc.1 does not exist")
+        self.assertEqual(expected.exception.message, message)
 
-        plan.dump("test", context=self.context)
-        self.assertEqual(len(plan.list_pending()), len(plan))
+    def test_build_plan_cyclic_dependencies(self):
+        vpc = Stack(
+            definition=generate_definition(
+                'vpc', 1),
+            context=self.context)
+        db = Stack(
+            definition=generate_definition(
+                'db', 1, requires=['namespace-app.1']),
+            context=self.context)
+        app = Stack(
+            definition=generate_definition(
+                'app', 1, requires=['namespace-db.1']),
+            context=self.context)
 
-    @mock.patch("stacker.plan.os")
-    @mock.patch("stacker.plan.open", mock.mock_open(), create=True)
-    def test_dump_no_provider_lookups(self, *args):
-        plan = Plan(description="Test", sleep_time=0)
-        previous_stack = None
-        for i in range(5):
-            overrides = {
-                "variables": {
-                    "Var1": "${output fakeStack::FakeOutput}",
-                    "Var2": "${xref fakeStack::FakeOutput2}",
-                },
-            }
-            if previous_stack:
-                overrides["requires"] = [previous_stack.fqn]
-            stack = Stack(
-                definition=generate_definition("vpc", i, **overrides),
-                context=self.context,
-            )
-            previous_stack = stack
-            plan.add(
-                stack=stack,
-                run_func=self._run_func,
-                requires=stack.requires,
-            )
-
-        with self.assertRaises(FailedVariableLookup):
-            plan.dump("test", context=self.context)
-
-    def test_plan_checkpoint_interval(self):
-        plan = Plan(description="Test", logger_type=BASIC_LOGGER_TYPE)
-        self.assertEqual(plan.check_point_interval, 10)
-        plan = Plan(description="Test", logger_type=LOOP_LOGGER_TYPE)
-        self.assertEqual(plan.check_point_interval, 1)
+        with self.assertRaises(GraphError) as expected:
+            Plan(
+                description="Test",
+                steps=[Step(vpc, None), Step(db, None), Step(app, None)])
+        message = ("Error detected when adding 'namespace-db.1' "
+                   "as a dependency of 'namespace-app.1': graph is "
+                   "not acyclic")
+        self.assertEqual(expected.exception.message, message)


### PR DESCRIPTION
This PR is an internal refactor to make stacker build a Directed Acyclic Graph when planning execution.

Fixes https://github.com/remind101/stacker/issues/300
Fixes https://github.com/remind101/stacker/issues/186
Fixes https://github.com/remind101/stacker/issues/279
Fixes https://github.com/remind101/stacker/issues/384

## Why use a DAG?


### Performance

The DAG simplifies [parallel scheduling](https://ocw.mit.edu/courses/electrical-engineering-and-computer-science/6-042j-mathematics-for-computer-science-spring-2015/readings/MIT6_042JS15_Session17.pdf), so that we can execute mutually exclusive stacks at the same time.

In this PR, each stack is executed in it's own thread. The thread blocks until all of the stacks dependencies have been executed, and then immediately starts. This means that stacks at the same depth, won't block each other unnecessarily.

The worst case `stacker build` time, is now the total time it takes for the longest critical chain (the longest chain of dependencies). Previously, the worst case `stacker build` time was a combination of the longest critical chain, in addition to the widest point in the graph.

For a concrete example, using the `benchmark.yaml` config, this PR dropped NOOP execution time from ~1min+ to ~15 seconds.

In our internal infrastructure repo, it drops NOOP execution time from ~7 minutes down to ~2.5 minutes (with my shitty RTT in Thailand).

### Automatic dependency resolution for `--stacks`

`stacker build` supports a `--stacks` flag, however, in practice, it's difficult to use, because it won't automatically resolve dependencies. The DAG makes this easy, so when you provide a `--stacks` flag now, any dependencies are automatically visited.

### Simplified destroy

`stacker destroy` is just a `stacker build` with a transposed graph.

### Graceful SIGINT/SIGTERM

SIGINT and SIGTERM are handled more gracefully now. When received, stacker will wait until all _current_ stack operations complete before shutting down.

### Cyclic Dependency Checks

If there are any circular dependencies, it's detected and an error is shown. Previously, stacker would just hang forever.

### Duplicate Node Detection

Previously, if you accidentally added a node with the same name, you wouldn't know about it, until it overwrote your existing stack with the new template (I've done this before with an RDS stack...). With the DAG, duplicate nodes are automatically detected.

### Logging Improvements

The log output is updated whenever a step changes status, which fixes a number of issues where it would previously look like stacker wasn't doing anything (e.g. a noop run would never update the statuses).

Currently, logging is pretty jiterry because of this. I'll try to fix these issues before this gets merged.

https://asciinema.org/a/ilOwudPADDXQBnmfqa57JaC4Y

## What can go wrong

### Thread Safety

stacker is now multi-threaded, so we need to be careful to ensure that everything is thread safe. Not sure if there are any static analysis tools in the Python world for this.

### Rate limiting

Because we're executing more API calls in parallel, it's possible for stacker to hit rate limits more easily, although, I've yet to hit any rate limits in all of my tests.

---

### Tested

* [x] Interactive mode
* [ ] Tailing
* [x] Assuming role with MFA
* [x] Diff

### TODO

* [ ] Add a `--j/jobs` flag for specifying concurrency
* [x] Figure out how to show stack traces without getting overwritten by checkpointing
* [ ] Fix jitter in checkpointing
* [ ] Fix SIGINT catch breaking CTL-C from MFA prompt.
* [ ] Better handling of retrieving stack status updates to avoid throttling on DescribeStacks.