### PR TITLE
Support for profiles (cross region/account support)

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -2,7 +2,6 @@ import copy
 import logging
 
 import botocore.exceptions
-from stacker.session_cache import get_session
 
 logger = logging.getLogger(__name__)
 
@@ -62,8 +61,7 @@ class BaseAction(object):
     def s3_conn(self):
         """The boto s3 connection object used for communication with S3."""
         if not hasattr(self, "_s3_conn"):
-            session = get_session(self.provider.region)
-            self._s3_conn = session.client('s3')
+            self._s3_conn = self.provider.session.client('s3')
 
         return self._s3_conn
 

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -60,8 +60,12 @@ class Action(BaseAction):
         return plan
 
     def _destroy_stack(self, stack, **kwargs):
+        provider = self.provider
+        if stack.profile:
+            provider = self.provider.with_profile(stack.profile)
+
         try:
-            provider_stack = self.provider.get_stack(stack.fqn)
+            provider_stack = provider.get_stack(stack.fqn)
         except StackDoesNotExist:
             logger.debug("Stack %s does not exist.", stack.fqn)
             # Once the stack has been destroyed, it doesn't exist. If the
@@ -74,16 +78,16 @@ class Action(BaseAction):
 
         logger.debug(
             "Stack %s provider status: %s",
-            self.provider.get_stack_name(provider_stack),
-            self.provider.get_stack_status(provider_stack),
+            provider.get_stack_name(provider_stack),
+            provider.get_stack_status(provider_stack),
         )
-        if self.provider.is_stack_destroyed(provider_stack):
+        if provider.is_stack_destroyed(provider_stack):
             return DestroyedStatus
-        elif self.provider.is_stack_in_progress(provider_stack):
+        elif provider.is_stack_in_progress(provider_stack):
             return DestroyingStatus
         else:
             logger.debug("Destroying stack: %s", stack.fqn)
-            self.provider.destroy_stack(provider_stack)
+            provider.destroy_stack(provider_stack)
         return DestroyingStatus
 
     def pre_run(self, outline=False, *args, **kwargs):

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -113,6 +113,7 @@ class Context(object):
                 definition=stack_def,
                 context=self,
                 mappings=self.mappings,
+                profile=stack_def.get("profile"),
                 force=stack_def["name"] in self.force_stacks,
                 locked=stack_def.get("locked", False),
                 enabled=stack_def.get("enabled", True),

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -9,7 +9,6 @@ import botocore
 
 import formic
 from troposphere.awslambda import Code
-from stacker.session_cache import get_session
 
 from stacker.util import get_config_directory
 
@@ -447,8 +446,7 @@ def upload_lambda_functions(context, provider, **kwargs):
 
     prefix = kwargs.get('prefix', '')
 
-    session = get_session(provider.region)
-    s3_conn = session.client('s3')
+    s3_conn = provider.session.client('s3')
 
     _ensure_bucket(s3_conn, bucket)
 

--- a/stacker/hooks/ecs.py
+++ b/stacker/hooks/ecs.py
@@ -3,8 +3,6 @@
 #   https://github.com/boto/boto/pull/3143
 import logging
 
-from stacker.session_cache import get_session
-
 logger = logging.getLogger(__name__)
 
 
@@ -22,7 +20,7 @@ def create_clusters(provider, context, **kwargs):
     Returns: boolean for whether or not the hook succeeded.
 
     """
-    conn = get_session(provider.region).client('ecs')
+    conn = provider.session.client('ecs')
 
     try:
         clusters = kwargs["clusters"]

--- a/stacker/hooks/iam.py
+++ b/stacker/hooks/iam.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 
-from stacker.session_cache import get_session
 from botocore.exceptions import ClientError
 
 from awacs.aws import Statement, Allow, Policy
@@ -28,7 +27,7 @@ def create_ecs_service_role(provider, context, **kwargs):
 
     """
     role_name = kwargs.get("role_name", "ecsServiceRole")
-    client = get_session(provider.region).client('iam')
+    client = provider.session.client('iam')
 
     try:
         client.create_role(
@@ -121,7 +120,7 @@ def get_cert_contents(kwargs):
 
 
 def ensure_server_cert_exists(provider, context, **kwargs):
-    client = get_session(provider.region).client('iam')
+    client = provider.session.client('iam')
     cert_name = kwargs["cert_name"]
     status = "unknown"
     try:

--- a/stacker/hooks/keypair.py
+++ b/stacker/hooks/keypair.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-from stacker.session_cache import get_session
-
 from . import utils
 
 logger = logging.getLogger(__name__)
@@ -28,8 +26,7 @@ def ensure_keypair_exists(provider, context, **kwargs):
     Returns: boolean for whether or not the hook succeeded.
 
     """
-    session = get_session(provider.region)
-    client = session.client("ec2")
+    client = provider.session.client("ec2")
     keypair_name = kwargs.get("keypair")
     resp = client.describe_key_pairs()
     keypair = find(resp["KeyPairs"], "KeyName", keypair_name)

--- a/stacker/hooks/route53.py
+++ b/stacker/hooks/route53.py
@@ -1,7 +1,5 @@
 import logging
 
-from stacker.session_cache import get_session
-
 from stacker.util import create_route53_zone
 
 logger = logging.getLogger(__name__)
@@ -18,8 +16,7 @@ def create_domain(provider, context, **kwargs):
     Returns: boolean for whether or not the hook succeeded.
 
     """
-    session = get_session(provider.region)
-    client = session.client("route53")
+    client = provider.session.client("route53")
     domain = kwargs.get("domain")
     if not domain:
         logger.error("domain argument or BaseDomain variable not provided.")

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -43,7 +43,14 @@ def handler(value, provider=None, context=None, fqn=False, rfqn=False,
 
     stack_fqn = d.stack_name
     if not fqn:
-        stack_fqn = context.get_fqn(d.stack_name)
+        stacks = context.get_stacks_dict()
+        stack = stacks.get(d.stack_name)
+        if stack:
+            if stack.profile:
+                provider = provider.with_profile(stack.profile)
+            stack_fqn = stack.fqn
+        else:
+            stack_fqn = context.get_fqn(d.stack_name)
 
     output = provider.get_output(stack_fqn, d.output_name)
     return output

--- a/stacker/providers/base.py
+++ b/stacker/providers/base.py
@@ -4,6 +4,10 @@ def not_implemented(method):
 
 
 class BaseProvider(object):
+    def with_profile(profile):
+        # pylint: disable=unused-argument
+        not_implemented("with_profile")
+
     def get_stack(self, stack_name, *args, **kwargs):
         # pylint: disable=unused-argument
         not_implemented("get_stack")

--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -1,11 +1,10 @@
 import json
 import os
-import botocore
 import boto3
 import logging
 
 
-def get_session(region):
+def get_session(region=None, profile=None):
     """Creates a boto3 session with a cache
 
     Args:
@@ -15,13 +14,11 @@ def get_session(region):
         :class:`boto3.session.Session`: A boto3 session with
             credential caching
     """
-    session = botocore.session.get_session()
-    if region is not None:
-        session.set_config_variable('region',  region)
-    c = session.get_component('credential_provider')
+    session = boto3.Session(profile_name=profile, region_name=region)
+    c = session._session.get_component('credential_provider')
     provider = c.get_provider('assume-role')
     provider.cache = CredentialCache()
-    return boto3.session.Session(botocore_session=session)
+    return session
 
 
 logger = logging.getLogger(__name__)

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -64,7 +64,7 @@ class Stack(object):
     """
 
     def __init__(self, definition, context, variables=None, mappings=None,
-                 locked=False, force=False, enabled=True):
+                 locked=False, force=False, enabled=True, profile=None):
         self.name = definition["name"]
         self.fqn = context.get_fqn(self.name)
         self.definition = definition
@@ -73,6 +73,7 @@ class Stack(object):
         self.locked = locked
         self.force = force
         self.enabled = enabled
+        self.profile = profile
         self.context = copy.deepcopy(context)
 
     def __repr__(self):

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -155,6 +155,7 @@ class TestBuildAction(unittest.TestCase):
         _, step = plan.list_pending()[0]
         step.stack = mock.MagicMock()
         step.stack.locked = False
+        step.stack.profile = None
 
         # mock provider shouldn't return a stack at first since it hasn't been
         # launched

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -19,6 +19,7 @@ class MockStack(object):
     def __init__(self, name, tags=None, **kwargs):
         self.name = name
         self.fqn = name
+        self.profile = None
         self.requires = []
 
 

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -1,11 +1,20 @@
-from mock import MagicMock
+import boto3
 
 from stacker.context import Context
 from stacker.lookups import Lookup
 
 
+class MockProvider(object):
+    def __init__(self, region, **kwargs):
+        self.region = region
+
+    @property
+    def session(self):
+        return boto3.Session()
+
+
 def mock_provider(**kwargs):
-    return MagicMock(**kwargs)
+    return MockProvider(**kwargs)
 
 
 def mock_context(namespace=None, **kwargs):

--- a/stacker/tests/lookups/handlers/test_output.py
+++ b/stacker/tests/lookups/handlers/test_output.py
@@ -12,6 +12,7 @@ class TestOutputHandler(unittest.TestCase):
 
     def test_output_handler(self):
         self.provider.get_output.return_value = "Test Output"
+        self.context.get_stacks_dict.return_value = {}
         self.context.get_fqn.return_value = "fully-qualified-stack-name"
         value = handler("stack-name::SomeOutput",
                         provider=self.provider, context=self.context)

--- a/stacker/tests/lookups/handlers/test_rxref.py
+++ b/stacker/tests/lookups/handlers/test_rxref.py
@@ -10,7 +10,8 @@ class TestRxrefHandler(unittest.TestCase):
     def setUp(self):
         self.provider = MagicMock()
         self.context = Context(
-            environment={"namespace": "ns"}
+            environment={"namespace": "ns"},
+            config={"stacks": []}
         )
 
     def test_rxref_handler(self):

--- a/stacker/tests/test_variables.py
+++ b/stacker/tests/test_variables.py
@@ -43,6 +43,20 @@ class TestVariables(unittest.TestCase):
         self.assertEqual(var.value, "resolved")
 
     def test_variable_resolve_simple_lookup(self):
+        self.context.get_stacks_dict.return_value = {}
+        var = Variable("Param1", "${output fakeStack::FakeOutput}")
+        self.assertEqual(len(var.lookups), 1)
+        self.provider.get_output.return_value = "resolved"
+        var.resolve(self.context, self.provider)
+        self.assertTrue(var.resolved)
+        self.assertEqual(var.value, "resolved")
+
+    def test_variable_resolve_simple_lookup_stack_in_config(self):
+        stack = MagicMock()
+        stack.fqn = "fakeStack"
+        stack.profile = None
+        self.context.get_stacks_dict.return_value = {
+            'fakeStack': stack}
         var = Variable("Param1", "${output fakeStack::FakeOutput}")
         self.assertEqual(len(var.lookups), 1)
         self.provider.get_output.return_value = "resolved"
@@ -65,6 +79,8 @@ class TestVariables(unittest.TestCase):
         self.assertEqual(var.value, "url://resolved@resolved2")
 
     def test_variable_resolve_multiple_lookups_string(self):
+        self.context.get_stacks_dict.return_value = {}
+
         var = Variable(
             "Param1",
             "url://${output fakeStack::FakeOutput}@"
@@ -160,6 +176,7 @@ class TestVariables(unittest.TestCase):
             var.resolve(self.context, self.provider)
 
     def test_variable_resolve_nested_lookup(self):
+        self.context.get_stacks_dict.return_value = {}
 
         def mock_handler(value, context, provider, **kwargs):
             return "looked up: {}".format(value)

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -306,6 +306,9 @@ def handle_hooks(stage, hooks, provider, context):
         data_key = hook.get("data_key")
         required = hook.get("required", True)
         kwargs = hook.get("args", {})
+        profile = hook.get("profile")
+        if profile:
+            provider = provider.with_profile(profile)
         try:
             method = load_object_from_string(hook["path"])
         except (AttributeError, ImportError):


### PR DESCRIPTION
This is based on the RFC in https://github.com/remind101/stacker/wiki/RFC:-Profiles

Closes https://github.com/remind101/stacker/issues/263
Fixes https://github.com/remind101/stacker/issues/277

With this change, you can specify a boto3 profile to use for a given stack. This can be used for cross account/region provisioning and linking of stacks. For example, say you wanted to provision a hot and cold version of an application in multiple regions, you could do something like this:

```yaml
stacks:
- name: vpc-hot
  profile: hot
- name: vpc-cold
  profile: cold
- name: app
  profile: hot
  variables:
    VpcId: ${vpc-hot::VpcId}
- name: app-cold
  profile: cold
  variables:
    VpcId: ${vpc-cold::VpcId}
```

```console
$ echo <<EOF > .aws/config.prod
[profile hot]
region = us-east-1

[profile prod/cold]
region = us-west-1
EOF
```

```console
$ AWS_CONFIG_FILE=.aws/config.prod stacker build prod.env stacker.yaml
```

## TODO

* [ ] Docs around using boto3 profiles with stacker.
* [x] Hooks. Add support for specifying profile?