### PR TITLE
Add provider to the dump method for lookups that require it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,13 @@ Thumbs.db
 
 # Vagrant
 .vagrant
+Vagrantfile
 
 # Editor crap
 *.sw*
 *~
+.idea
+*.iml
 
 # Byte-compiled python
 *.pyc
@@ -56,7 +59,7 @@ dist/
 # nosetest --with-coverage dumps these in CWD
 .coverage
 
-Vagrantfile
+
 
 vm_setup.sh
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -285,7 +285,7 @@ class Action(BaseAction):
             if outline:
                 plan.outline()
             if dump:
-                plan.dump(directory=dump, context=self.context)
+                plan.dump(directory=dump, context=self.context, provider=self.provider)
 
     def post_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -136,6 +136,29 @@ def _handle_missing_parameters(params, required_params, existing_stack=None):
     return params.items()
 
 
+def handle_hooks(stage, hooks, provider, context, dump, outline):
+    """Handle pre/post hooks.
+
+    Args:
+        stage (str): The name of the hook stage - pre_build/post_build.
+        hooks (list): A list of dictionaries containing the hooks to execute.
+        provider (:class:`stacker.provider.base.BaseProvider`): The provider
+            the current stack is using.
+        context (:class:`stacker.context.Context`): The current stacker
+            context.
+        dump (bool): Whether running with dump set or not.
+        outline (bool): Whether running with outline set or not.
+
+    """
+    if not outline and not dump and hooks:
+        util.handle_hooks(
+            stage=stage,
+            hooks=hooks,
+            provider=provider,
+            context=context
+        )
+
+
 class Action(BaseAction):
     """Responsible for building & coordinating CloudFormation stacks.
 
@@ -257,18 +280,15 @@ class Action(BaseAction):
 
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
-        pre_build = self.context.config.get("pre_build")
-        should_run_hooks = (
-            not outline and
-            not dump and
-            pre_build
+        hooks = self.context.config.get("pre_build")
+        handle_hooks(
+            "post_build",
+            hooks,
+            self.provider,
+            self.context,
+            dump,
+            outline
         )
-        if should_run_hooks:
-            util.handle_hooks(
-                stage="pre_build",
-                hooks=pre_build,
-                provider=self.provider,
-                context=self.context)
 
     def run(self, outline=False, tail=False, dump=False, *args, **kwargs):
         """Kicks off the build/update of the stacks in the stack_definitions.
@@ -290,10 +310,12 @@ class Action(BaseAction):
 
     def post_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""
-        post_build = self.context.config.get("post_build")
-        if not outline and not dump and post_build:
-            util.handle_hooks(
-                stage="post_build",
-                hooks=post_build,
-                provider=self.provider,
-                context=self.context)
+        hooks = self.context.config.get("post_build")
+        handle_hooks(
+            "post_build",
+            hooks,
+            self.provider,
+            self.context,
+            dump,
+            outline
+        )

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -285,7 +285,8 @@ class Action(BaseAction):
             if outline:
                 plan.outline()
             if dump:
-                plan.dump(directory=dump, context=self.context, provider=self.provider)
+                plan.dump(directory=dump, context=self.context,
+                          provider=self.provider)
 
     def post_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -309,7 +309,7 @@ class Plan(OrderedDict):
         for _, step in self.iteritems():
             step.status = PENDING
 
-    def dump(self, directory, context):
+    def dump(self, directory, context, provider=None):
         steps = 1
         logger.info("Dumping \"%s\"...", self.description)
         directory = os.path.expanduser(directory)
@@ -320,7 +320,7 @@ class Plan(OrderedDict):
             step_name, step = self.list_pending()[0]
             step.stack.resolve(
                 context=context,
-                provider=None,
+                provider=provider,
             )
             blueprint = step.stack.blueprint
             filename = stack_template_key_name(blueprint)

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -275,7 +275,6 @@ def cf_safe_name(name):
     return "".join([uppercase_first_letter(part) for part in parts])
 
 
-# TODO: perhaps make this a part of the builder?
 def handle_hooks(stage, hooks, provider, context):
     """ Used to handle pre/post_build hooks.
 


### PR DESCRIPTION
Currently attempting to dump (`stacker build -d <dir>`) a template that contains lookups like `${output}` fail when attempting to resolve those variables, as they now have a hard requirement on provider. This passes the provider from the `build` command so they can successfully resolve template variables.