### PR TITLE
Disable loop logger when --tail is provided

### DIFF
--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -99,7 +99,10 @@ class BaseCommand(object):
         pass
 
     def configure(self, options, **kwargs):
-        self.logger_type = setup_logging(options.verbose, options.interactive)
+        self.logger_type = setup_logging(
+            options.verbose,
+            interactive=options.interactive,
+            tail=options.tail)
 
     def get_context_kwargs(self, options, **kwargs):
         """Return a dictionary of kwargs that will be used with the Context.

--- a/stacker/logger/__init__.py
+++ b/stacker/logger/__init__.py
@@ -15,11 +15,11 @@ BASIC_LOGGER_TYPE = 0
 LOOP_LOGGER_TYPE = 1
 
 
-def setup_logging(verbosity, interactive):
+def setup_logging(verbosity, interactive=False, tail=False):
     enable_loop_logger = (
         verbosity == 0 and
         sys.stdout.isatty() and
-        not interactive
+        not (interactive or tail)
     )
     log_level = logging.INFO
     log_format = INFO_FORMAT

--- a/stacker/tests/test_logger.py
+++ b/stacker/tests/test_logger.py
@@ -38,6 +38,9 @@ class TestLogStreamLoopHandler(unittest.TestCase):
         self.assertEqual(logger, BASIC_LOGGER_TYPE)
         logger = setup_logging(verbosity=0, interactive=True)
         self.assertEqual(logger, BASIC_LOGGER_TYPE)
+        logger = setup_logging(verbosity=0, interactive=False, tail=True)
+        self.assertEqual(logger, BASIC_LOGGER_TYPE)
+
         patched_sys.stdout.isatty.return_value = False
         logger = setup_logging(verbosity=0, interactive=False)
         self.assertEqual(logger, BASIC_LOGGER_TYPE)


### PR DESCRIPTION
Fixes https://github.com/remind101/stacker/issues/386

When specifying `--tail`, this will now drop down to the basic logger so that the tail output doesn't get overwritten by the loop logger.