### PR TITLE
new bucket region config

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -40,6 +40,10 @@ updating your stacks. By default it uses a bucket named
 If you want to change this, provide the **stacker_bucket** top level key word
 in the config.
 
+The bucket will be created in the same region that the stacks will be launched
+in.  If you want to change this, you can set the **stacker_bucket_region** to
+the region where you want to create the bucket.
+
 Module Paths
 ----------------
 When setting the ``classpath`` for blueprints/hooks, it is sometimes desirable to

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,14 @@ install_requires = [
 ]
 
 tests_require = [
-    "nose~=1.0",
     "mock~=2.0.0",
     "moto~=0.4.30",
     "testfixtures~=4.10.0",
     "coverage~=4.3.4"
+]
+
+setup_requires = [
+    "nose",
 ]
 
 
@@ -44,5 +47,6 @@ if __name__ == "__main__":
         scripts=glob.glob(os.path.join(src_dir, "scripts", "*")),
         install_requires=install_requires,
         tests_require=tests_require,
+        setup_requires=setup_requires,
         test_suite="nose.collector",
     )

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -69,7 +69,7 @@ class BaseAction(object):
         """The boto s3 connection object used for communication with S3."""
         if not hasattr(self, "_s3_conn"):
             # Always use the global client for s3
-            session = get_session("us-east-1")
+            session = get_session(self.bucket_region)
             self._s3_conn = session.client('s3')
 
         return self._s3_conn

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -5,7 +5,6 @@ import botocore.exceptions
 from stacker.session_cache import get_session
 
 from stacker.util import (
-    get_client_region,
     ensure_s3_bucket,
     get_s3_endpoint,
 )
@@ -69,7 +68,8 @@ class BaseAction(object):
     def s3_conn(self):
         """The boto s3 connection object used for communication with S3."""
         if not hasattr(self, "_s3_conn"):
-            session = get_session(self.provider.region)
+            # Always use the global client for s3
+            session = get_session("us-east-1")
             self._s3_conn = session.client('s3')
 
         return self._s3_conn
@@ -78,7 +78,7 @@ class BaseAction(object):
     def bucket_region(self):
         return self.context.config.get(
             "stacker_bucket_region",
-            get_client_region(self.s3_conn)
+            self.provider.region
         )
 
     def ensure_cfn_bucket(self):

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -464,7 +464,7 @@ def upload_lambda_functions(context, provider, **kwargs):
     )
 
     # Always use the global client for s3
-    session = get_session("us-east-1")
+    session = get_session(bucket_region)
     s3_client = session.client('s3')
 
     ensure_s3_bucket(s3_client, bucket_name, bucket_region)

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -463,7 +463,8 @@ def upload_lambda_functions(context, provider, **kwargs):
         provider.region
     )
 
-    session = get_session(bucket_region)
+    # Always use the global client for s3
+    session = get_session("us-east-1")
     s3_client = session.client('s3')
 
     ensure_s3_bucket(s3_client, bucket_name, bucket_region)

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -11,7 +11,10 @@ import formic
 from troposphere.awslambda import Code
 from stacker.session_cache import get_session
 
-from stacker.util import get_config_directory
+from stacker.util import (
+    get_config_directory,
+    ensure_s3_bucket,
+)
 
 
 """Mask to retrieve only UNIX file permissions from the external attributes
@@ -177,35 +180,6 @@ def _head_object(s3_conn, bucket, key):
             raise
 
 
-def _ensure_bucket(s3_conn, bucket):
-    """Create an S3 bucket if it does not already exist.
-
-    Args:
-        s3_conn (botocore.client.S3): S3 connection to use for operations.
-        bucket (str): name of the bucket to create.
-
-    Returns:
-        dict: S3 object information. See the AWS documentation for explanation
-        of the contents.
-
-    Raises:
-        botocore.exceptions.ClientError: any error from boto3 is passed
-            through.
-    """
-    try:
-        s3_conn.head_bucket(Bucket=bucket)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == '404':
-            logger.info('Creating bucket %s.', bucket)
-            s3_conn.create_bucket(Bucket=bucket)
-        elif e.response['Error']['Code'] in ('401', '403'):
-            logger.exception('Access denied for bucket %s.', bucket)
-            raise
-        else:
-            logger.exception('Error creating bucket %s. Error %s', bucket,
-                             e.response)
-
-
 def _upload_code(s3_conn, bucket, prefix, name, contents, content_hash):
     """Upload a ZIP file to S3 for use by Lambda.
 
@@ -338,6 +312,32 @@ def _upload_function(s3_conn, bucket, prefix, name, options):
                         content_hash)
 
 
+def select_bucket_region(custom_bucket, hook_region, stacker_bucket_region,
+                         provider_region):
+    """Returns the appropriate region to use when uploading functions.
+
+    Select the appropriate region for the bucket where lambdas are uploaded in.
+
+    Args:
+        custom_bucket (str, None): The custom bucket name provided by the
+            `bucket` kwarg of the aws_lambda hook, if provided.
+        hook_region (str): The contents of the `bucket_region` argument to
+            the hook.
+        stacker_bucket_region (str): The contents of the
+            `stacker_bucket_region` global setting.
+        provider_region (str): The region being used by the provider.
+
+    Returns:
+        str: The appropriate region string.
+    """
+    region = None
+    if custom_bucket:
+        region = hook_region
+    else:
+        region = stacker_bucket_region
+    return region or provider_region
+
+
 def upload_lambda_functions(context, provider, **kwargs):
     """Builds Lambda payloads from user configuration and uploads them to S3.
 
@@ -360,6 +360,10 @@ def upload_lambda_functions(context, provider, **kwargs):
     Keyword Arguments:
         bucket (str, optional): Custom bucket to upload functions to.
             Omitting it will cause the default stacker bucket to be used.
+        bucket_region (str, optional): The region in which the bucket should
+            exist. If not given, the region will be either be that of the
+            global `stacker_bucket_region` setting, or else the region in
+            use by the provider.
         prefix (str, optional): S3 key prefix to prepend to the uploaded
             zip name.
         functions (dict):
@@ -438,23 +442,37 @@ def upload_lambda_functions(context, provider, **kwargs):
                         )
                     )
     """
-    bucket = kwargs.get('bucket')
-    if not bucket:
-        bucket = context.bucket_name
-        logger.info('lambda: using default bucket from stacker: %s', bucket)
+    custom_bucket = kwargs.get('bucket')
+    if not custom_bucket:
+        bucket_name = context.bucket_name
+        logger.info("lambda: using default bucket from stacker: %s",
+                    bucket_name)
     else:
-        logger.info('lambda: using custom bucket: %s', bucket)
+        bucket_name = custom_bucket
+        logger.info("lambda: using custom bucket: %s", bucket_name)
+
+    custom_bucket_region = kwargs.get("bucket_region")
+    if not custom_bucket and custom_bucket_region:
+        raise ValueError("Cannot specify `bucket_region` without specifying "
+                         "`bucket`.")
+
+    bucket_region = select_bucket_region(
+        custom_bucket,
+        custom_bucket_region,
+        context.config.get("stacker_bucket_region"),
+        provider.region
+    )
+
+    session = get_session(bucket_region)
+    s3_client = session.client('s3')
+
+    ensure_s3_bucket(s3_client, bucket_name, bucket_region)
 
     prefix = kwargs.get('prefix', '')
 
-    session = get_session(provider.region)
-    s3_conn = session.client('s3')
-
-    _ensure_bucket(s3_conn, bucket)
-
     results = {}
     for name, options in kwargs['functions'].items():
-        results[name] = _upload_function(s3_conn, bucket, prefix, name,
+        results[name] = _upload_function(s3_client, bucket_name, prefix, name,
                                          options)
 
     return results

--- a/stacker/tests/actions/test_base.py
+++ b/stacker/tests/actions/test_base.py
@@ -51,13 +51,15 @@ class TestBaseActionFunctions(unittest.TestCase):
             self.assertEqual(get_s3_endpoint(client), endpoint_map[region])
 
     def test_s3_create_bucket_location_constraint(self):
-        client = boto3.client("s3", region_name="us-east-1")
-        self.assertEqual(s3_create_bucket_location_constraint(client), "")
-        client = boto3.client("s3", region_name="us-west-1")
-        self.assertEqual(
-            s3_create_bucket_location_constraint(client),
-            "us-west-1"
+        tests = (
+            ("us-east-1", ""),
+            ("us-west-1", "us-west-1")
         )
+        for region, result in tests:
+            self.assertEqual(
+                s3_create_bucket_location_constraint(region),
+                result
+            )
 
 
 class TestBaseAction(unittest.TestCase):

--- a/stacker/tests/actions/test_base.py
+++ b/stacker/tests/actions/test_base.py
@@ -1,13 +1,9 @@
 import unittest
 
-import boto3
 from botocore.stub import Stubber, ANY
 import botocore.exceptions
 
 from stacker.actions.base import (
-    get_client_region,
-    get_s3_endpoint,
-    s3_create_bucket_location_constraint,
     BaseAction
 )
 
@@ -29,37 +25,6 @@ class TestBlueprint(Blueprint):
     VARIABLES = {
         "Param1": {"default": "default", "type": str},
     }
-
-
-class TestBaseActionFunctions(unittest.TestCase):
-    def test_get_client_region(self):
-        regions = ["us-east-1", "us-west-1", "eu-west-1", "sa-east-1"]
-        for region in regions:
-            client = boto3.client("s3", region_name=region)
-            self.assertEqual(get_client_region(client), region)
-
-    def test_get_s3_endpoint(self):
-        endpoint_map = {
-            "us-east-1": "https://s3.amazonaws.com",
-            "us-west-1": "https://s3-us-west-1.amazonaws.com",
-            "eu-west-1": "https://s3-eu-west-1.amazonaws.com",
-            "sa-east-1": "https://s3-sa-east-1.amazonaws.com",
-        }
-
-        for region in endpoint_map:
-            client = boto3.client("s3", region_name=region)
-            self.assertEqual(get_s3_endpoint(client), endpoint_map[region])
-
-    def test_s3_create_bucket_location_constraint(self):
-        tests = (
-            ("us-east-1", ""),
-            ("us-west-1", "us-west-1")
-        )
-        for region, result in tests:
-            self.assertEqual(
-                s3_create_bucket_location_constraint(region),
-                result
-            )
 
 
 class TestBaseAction(unittest.TestCase):

--- a/stacker/tests/hooks/test_aws_lambda.py
+++ b/stacker/tests/hooks/test_aws_lambda.py
@@ -16,7 +16,8 @@ from stacker.context import Context
 from stacker.hooks.aws_lambda import (
     upload_lambda_functions,
     ZIP_PERMS_MASK,
-    _calculate_hash
+    _calculate_hash,
+    select_bucket_region,
 )
 from ..factories import mock_provider
 
@@ -375,3 +376,15 @@ class TestLambdaHooks(unittest.TestCase):
                 hash1 = _calculate_hash(files1, root1)
                 hash2 = _calculate_hash(files2, root2)
                 self.assertEqual(hash1, hash2)
+
+    def test_select_bucket_region(self):
+        tests = (
+            (("myBucket", "us-east-1", "us-west-1", "eu-west-1"), "us-east-1"),
+            (("myBucket", None, "us-west-1", "eu-west-1"), "eu-west-1"),
+            ((None, "us-east-1", "us-west-1", "eu-west-1"), "us-west-1"),
+            ((None, "us-east-1", None, "eu-west-1"), "eu-west-1"),
+
+        )
+
+        for args, result in tests:
+            self.assertEqual(select_bucket_region(*args), result)

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -8,6 +8,8 @@ import re
 import sys
 import time
 
+import botocore.exceptions
+
 logger = logging.getLogger(__name__)
 
 
@@ -366,3 +368,85 @@ def read_value_from_path(value):
         with open(relative_path) as read_file:
             value = read_file.read()
     return value
+
+
+def get_client_region(client):
+    """Gets the region from a :class:`boto3.client.Client` object.
+
+    Args:
+        client (:class:`boto3.client.Client`): The client to get the region
+            from.
+
+    Returns:
+        string: AWS region string.
+    """
+
+    return client._client_config.region_name
+
+
+def get_s3_endpoint(client):
+    """Gets the s3 endpoint for the given :class:`boto3.client.Client` object.
+
+    Args:
+        client (:class:`boto3.client.Client`): The client to get the endpoint
+            from.
+
+    Returns:
+        string: The AWS endpoint for the client.
+    """
+
+    return client._endpoint.host
+
+
+def s3_bucket_location_constraint(region):
+    """Returns the appropriate LocationConstraint info for a new S3 bucket.
+
+    When creating a bucket in a region OTHER than us-east-1, you need to
+    specify a LocationConstraint inside the CreateBucketConfiguration argument.
+    This function helps you determine the right value given a given client.
+
+    Args:
+        region (str): The region where the bucket will be created in.
+
+    Returns:
+        string: The string to use with the given client for creating a bucket.
+    """
+    if region == "us-east-1":
+        return ""
+    return region
+
+
+def ensure_s3_bucket(s3_client, bucket_name, bucket_region=None):
+    """Ensure an s3 bucket exists, if it does not then create it.
+
+    Args:
+        s3_client (:class:`botocore.client.Client`): An s3 client used to
+            verify and create the bucket.
+        bucket_name (str): The bucket being checked/created.
+        bucket_region (str, optional): The region to create the bucket in. If
+            not provided, will be determined by s3_client's region.
+    """
+    try:
+        s3_client.head_bucket(Bucket=bucket_name)
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Message'] == "Not Found":
+            logger.debug("Creating bucket %s.", bucket_name)
+            create_args = {"Bucket": bucket_name}
+            bucket_region = bucket_region or get_client_region(s3_client)
+            location_constraint = s3_bucket_location_constraint(
+                bucket_region
+            )
+            if location_constraint:
+                create_args["CreateBucketConfiguration"] = {
+                    "LocationConstraint": location_constraint
+                }
+            s3_client.create_bucket(**create_args)
+        elif e.response['Error']['Message'] == "Forbidden":
+            logger.exception("Access denied for bucket %s.  Did " +
+                             "you remember to use a globally unique name?",
+                             bucket_name)
+            raise
+        else:
+            logger.exception("Error creating bucket %s. Error %s",
+                             bucket_name, e.response)
+            raise

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -416,7 +416,7 @@ def s3_bucket_location_constraint(region):
     return region
 
 
-def ensure_s3_bucket(s3_client, bucket_name, bucket_region=None):
+def ensure_s3_bucket(s3_client, bucket_name, bucket_region):
     """Ensure an s3 bucket exists, if it does not then create it.
 
     Args:
@@ -432,7 +432,6 @@ def ensure_s3_bucket(s3_client, bucket_name, bucket_region=None):
         if e.response['Error']['Message'] == "Not Found":
             logger.debug("Creating bucket %s.", bucket_name)
             create_args = {"Bucket": bucket_name}
-            bucket_region = bucket_region or get_client_region(s3_client)
             location_constraint = s3_bucket_location_constraint(
                 bucket_region
             )


### PR DESCRIPTION
Fixes #413. Adds a new config setting, `stacker_bucket_region`. If set
the stacker bucket where templates are stored is created in that region.
If not, it defaults to using the region provided by `--region` or
`AWS_REGION`.

This is a semi-breaking change, unfortunately - simply because we
weren't consistent about this before.