### PR TITLE
Allow `--tail` to be optional on a command

### DIFF
--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -102,7 +102,8 @@ class BaseCommand(object):
         self.logger_type = setup_logging(
             options.verbose,
             interactive=options.interactive,
-            tail=options.tail)
+            tail=getattr(options, "tail", False)
+        )
 
     def get_context_kwargs(self, options, **kwargs):
         """Return a dictionary of kwargs that will be used with the Context.


### PR DESCRIPTION
Fixes an issue introduced in #414.

Fixes #428 (also other issues)

Tests are going to be harder, but this is an easy fix.  I'm going to get
this out, I'll start thinking about deeper testing for commands (we have
none).