### PR TITLE
Fixes AMI lookup (and adds optional region specification)

### DIFF
--- a/docs/lookups.rst
+++ b/docs/lookups.rst
@@ -327,6 +327,9 @@ matches the given filters.
 
 Valid arguments::
 
+  region OPTIONAL ONCE:
+      e.g. us-east-1@
+
   owners (comma delimited) REQUIRED ONCE:
       aws_account_id | amazon | self
 
@@ -343,8 +346,10 @@ Example::
 
   # Grabs the most recently created AMI that is owned by either this account,
   # amazon, or the account id 888888888888 that has a name that matches
-  # the regex "server[0-9]+" and has "i386" as it's architecture.
-  ImageId: ${ami owners:self,888888888888,amazon name_regex:server[0-9]+ architecture:i386}
+  # the regex "server[0-9]+" and has "i386" as its architecture.
+
+  # Note: The region is optional, and defaults to the current stacker region
+  ImageId: ${ami [<region>@]owners:self,888888888888,amazon name_regex:server[0-9]+ architecture:i386}
 
 .. _`custom lookup`:
 

--- a/stacker/lookups/handlers/ami.py
+++ b/stacker/lookups/handlers/ami.py
@@ -16,16 +16,18 @@ class ImageNotFound(Exception):
         super(ImageNotFound, self).__init__(message)
 
 
-def handler(value, **kwargs):
+def handler(value, provider, **kwargs):
     """Fetch the most recent AMI Id using a filter
 
     For example:
 
-        ${ami owners:self,account,amazon name_regex:serverX-[0-9]+ architecture:x64,i386}
+        ${ami [<region>@]owners:self,account,amazon name_regex:serverX-[0-9]+ architecture:x64,i386}
 
         The above fetches the most recent AMI where owner is self
         account or amazon and the ami name matches the regex described,
         the architecture will be either x64 or i386
+
+        You can also optionally specify the region in which to perform the AMI lookup.
 
         Valid arguments:
 
@@ -43,7 +45,12 @@ def handler(value, **kwargs):
     """  # noqa
     value = read_value_from_path(value)
 
-    ec2 = get_session().client('ec2')
+    if "@" in value:
+        region, value = value.split("@", 1)
+    else:
+        region = provider.region
+
+    ec2 = get_session(region).client('ec2')
 
     values = {}
     describe_args = {}

--- a/stacker/tests/lookups/handlers/test_ami.py
+++ b/stacker/tests/lookups/handlers/test_ami.py
@@ -3,14 +3,16 @@ import mock
 from botocore.stub import Stubber
 from stacker.lookups.handlers.ami import handler, ImageNotFound
 import boto3
-from stacker.tests.factories import SessionStub
+from stacker.tests.factories import SessionStub, mock_provider
 
+REGION="us-east-1"
 
 class TestAMILookup(unittest.TestCase):
-    client = boto3.client("ec2", region_name="us-east-1")
+    client = boto3.client("ec2", region_name=REGION)
 
     def setUp(self):
         self.stubber = Stubber(self.client)
+        self.provider = mock_provider(region=REGION)
 
     @mock.patch("stacker.lookups.handlers.ami.get_session",
                 return_value=SessionStub(client))
@@ -34,7 +36,38 @@ class TestAMILookup(unittest.TestCase):
         )
 
         with self.stubber:
-            value = handler("owners:self name_regex:Fake\sImage\s\d")
+            value = handler(
+                value="owners:self name_regex:Fake\sImage\s\d",
+                provider=self.provider
+            )
+            self.assertEqual(value, image_id)
+
+    @mock.patch("stacker.lookups.handlers.ami.get_session",
+                return_value=SessionStub(client))
+    def test_basic_lookup_with_region(self, mock_client):
+        image_id = "ami-fffccc111"
+        self.stubber.add_response(
+            "describe_images",
+            {
+                "Images": [
+                    {
+                        "OwnerId": "897883143566",
+                        "Architecture": "x86_64",
+                        "CreationDate": "2011-02-13T01:17:44.000Z",
+                        "State": "available",
+                        "ImageId": image_id,
+                        "Name": "Fake Image 1",
+                        "VirtualizationType": "hvm",
+                    }
+                ]
+            }
+        )
+
+        with self.stubber:
+            value = handler(
+                value="us-west-1@owners:self name_regex:Fake\sImage\s\d",
+                provider=self.provider
+            )
             self.assertEqual(value, image_id)
 
     @mock.patch("stacker.lookups.handlers.ami.get_session",
@@ -68,7 +101,10 @@ class TestAMILookup(unittest.TestCase):
         )
 
         with self.stubber:
-            value = handler("owners:self name_regex:Fake\sImage\s\d")
+            value = handler(
+                value="owners:self name_regex:Fake\sImage\s\d",
+                provider=self.provider
+            )
             self.assertEqual(value, image_id)
 
     @mock.patch("stacker.lookups.handlers.ami.get_session",
@@ -102,7 +138,10 @@ class TestAMILookup(unittest.TestCase):
         )
 
         with self.stubber:
-            value = handler("owners:self name_regex:Fake\sImage\s\d")
+            value = handler(
+                value="owners:self name_regex:Fake\sImage\s\d",
+                provider=self.provider
+            )
             self.assertEqual(value, image_id)
 
     @mock.patch("stacker.lookups.handlers.ami.get_session",
@@ -117,7 +156,10 @@ class TestAMILookup(unittest.TestCase):
 
         with self.stubber:
             with self.assertRaises(ImageNotFound):
-                handler("owners:self name_regex:Fake\sImage\s\d")
+                handler(
+                    value="owners:self name_regex:Fake\sImage\s\d",
+                    provider=self.provider
+                )
 
     @mock.patch("stacker.lookups.handlers.ami.get_session",
                 return_value=SessionStub(client))
@@ -142,4 +184,7 @@ class TestAMILookup(unittest.TestCase):
 
         with self.stubber:
             with self.assertRaises(ImageNotFound):
-                handler("owners:self name_regex:MyImage\s\d")
+                handler(
+                    value="owners:self name_regex:MyImage\s\d",
+                    provider=self.provider
+                )

--- a/stacker/tests/lookups/handlers/test_ami.py
+++ b/stacker/tests/lookups/handlers/test_ami.py
@@ -5,7 +5,8 @@ from stacker.lookups.handlers.ami import handler, ImageNotFound
 import boto3
 from stacker.tests.factories import SessionStub, mock_provider
 
-REGION="us-east-1"
+REGION = "us-east-1"
+
 
 class TestAMILookup(unittest.TestCase):
     client = boto3.client("ec2", region_name=REGION)


### PR DESCRIPTION
The AMI lookup is currently broken as it attempts to call `get_session()` without passing any arguments, leading to the following error: `get_session() takes exactly 1 argument (0 given)`

This PR modifies the AMI lookup to accept an optional region (similar to some of the other lookups) and falls back to the provider to get the region if it's not explicitly set.