### PR TITLE
Make environment file optional

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -19,8 +19,7 @@ pushing them up into CloudFormation.
   usage: stacker build [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
                        [--replacements-only] [-o] [--force STACKNAME]
                        [--stacks STACKNAME] [-t] [-d DUMP]
-
-                       environment config
+                       [environment] config
 
   Launches or updates CloudFormation stacks based on the given config. Stacker
   is smart enough to figure out if anything (the template or parameters) have
@@ -66,7 +65,7 @@ pushing them up into CloudFormation.
     -t, --tail            Tail the CloudFormation logs while workingwith stacks
     -d DUMP, --dump DUMP  Dump the rendered Cloudformation templates to a
                           directory
-                          
+
 Destroy
 -------
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -13,6 +13,22 @@ duplicating config. (See `YAML anchors & references`_ for details)
 Top Level Keywords
 ==================
 
+Namespace
+---------
+
+You can provide a **namespace** to create all stacks within. The namespace will
+be used as a prefix for the name of any stack that stacker creates, and makes
+it unnecessary to specify the fully qualified name of the stack in output
+lookups.
+
+In addition, this value will be used to create an S3 bucket that stacker will
+use to upload and store all CloudFormation templates.
+
+In general, this is paired with the concept of `Environments
+<environments.html>`_ to create a namespace per environment::
+
+  namespace: ${namespace}
+
 Namespace Delimiter
 -------------------
 

--- a/docs/environments.rst
+++ b/docs/environments.rst
@@ -2,13 +2,11 @@
 Environments
 ============
 
-Every config stacker builds belongs to an Environment. An environment is, at
-its most basic, a name-space in which all the stacks will be created (by
-prepending the namespace to each stack name when creating the stack in
-CloudFormation). Every environment is a file that is provided on the command
-line when interacting with stacker. The format of the file is a single
-key/value per line, separated by a colon (**:**). At the minimum the
-environment must provide a namespace, like this::
+When running stacker, you can optionally provide an "environment" file. The
+stacker config file will be interpolated as a `string.Template
+<https://docs.python.org/2/library/string.html#template-strings>`_ using the
+key/value pairs from the environment file. The format of the file is a single
+key/value per line, separated by a colon (**:**), like this::
 
   namespace: stage-mycompany
 

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -136,7 +136,7 @@ class BaseCommand(object):
             "-v", "--verbose", action="count", default=0,
             help="Increase output verbosity. May be specified up to twice.")
         parser.add_argument(
-            "environment", type=environment_file, default={},
+            "environment", type=environment_file, nargs='?', default={},
             help="Path to a simple `key: value` pair environment file. The "
                  "values in the environment file can be used in the stack "
                  "config as if it were a string.Template type: "

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -3,12 +3,15 @@ import logging
 import sys
 
 from stacker.util import SourceProcessor
+from .exceptions import MissingConfig
 from .config import parse_config
-from .exceptions import MissingEnvironment
 from .stack import Stack
 from .lookups import register_lookup_handler
 
 logger = logging.getLogger(__name__)
+
+
+DEFAULT_NAMESPACE_DELIMITER = "-"
 
 
 def get_fqn(base_fqn, delimiter, name=None):
@@ -31,12 +34,10 @@ class Context(object):
     the command line and specified in the config to `Stack` objects.
 
     Args:
-        namespace (str): A unique namespace for the stacks being built.
         environment (dict): A dictionary used to pass in information about
             the environment. Useful for templating.
         stack_names (list): A list of stack_names to operate on. If not passed,
             usually all stacks defined in the config will be operated on.
-        mappings (dict): Used as Cloudformation mappings for the blueprint.
         config (dict): The configuration being operated on, containing the
             stack definitions.
         force_stacks (list): A list of stacks to force work on. Used to work
@@ -44,49 +45,69 @@ class Context(object):
 
     """
 
-    def __init__(self, environment,  # pylint: disable-msg=too-many-arguments
+    def __init__(self, environment=None,
                  stack_names=None,
-                 mappings=None,
                  config=None,
                  logger_type=None,
                  force_stacks=None):
-        try:
-            self.namespace = environment["namespace"]
-        except KeyError:
-            raise MissingEnvironment(["namespace"])
-
         self.environment = environment
         self.stack_names = stack_names or []
-        self.mappings = mappings or {}
         self.logger_type = logger_type
-        self.namespace_delimiter = "-"
         self.config = config or {}
         self.force_stacks = force_stacks or []
-        self._base_fqn = self.namespace.replace(".", "-").lower()
-        self.bucket_name = "stacker-%s" % (self.get_fqn(),)
-        self.tags = {
-            'stacker_namespace': self.namespace
-        }
-
         self.hook_data = {}
+
+    @property
+    def namespace(self):
+        namespace = self.config.get("namespace")
+        if namespace is not None:
+            return namespace
+
+        # For backwards compatibility, we fallback to attempting to
+        # fetch the namespace from the environment file, if provided.
+        namespace = self.environment.get("namespace")
+        if namespace:
+            logger.warn("specifying namespace in the environment is "
+                        "deprecated, and should be moved to the config")
+            return namespace
+
+        # Raise an error if no namespace was provided.
+        raise MissingConfig("namespace")
+
+    @property
+    def namespace_delimiter(self):
+        return self.config.get(
+                "namespace_delimiter",
+                DEFAULT_NAMESPACE_DELIMITER)
+
+    @property
+    def bucket_name(self):
+        return self.config.get("stacker_bucket") \
+                or "stacker-%s" % (self.get_fqn(),)
+
+    @property
+    def tags(self):
+        tags = self.config.get("tags", None)
+        if tags is not None:
+            return dict([(str(tag_key), str(tag_value)) for tag_key,
+                         tag_value in tags.items()])
+        else:
+            return {'stacker_namespace': self.namespace}
+
+    @property
+    def _base_fqn(self):
+        return self.namespace.replace(".", "-").lower()
+
+    @property
+    def mappings(self):
+        return self.config.get("mappings", {})
 
     def load_config(self, conf_string):
         self.config = parse_config(conf_string, environment=self.environment)
-        self.mappings = self.config.get("mappings", {})
-        namespace_delimiter = self.config.get("namespace_delimiter", None)
         if "sys_path" in self.config:
             logger.debug("Appending %s to sys.path.", self.config["sys_path"])
             sys.path.append(self.config["sys_path"])
             logger.debug("sys.path is now %s", sys.path)
-        if namespace_delimiter is not None:
-            self.namespace_delimiter = namespace_delimiter
-        bucket_name = self.config.get("stacker_bucket", None)
-        if bucket_name:
-            self.bucket_name = bucket_name
-        tags = self.config.get("tags", None)
-        if tags is not None:
-            self.tags = dict([(str(tag_key), str(tag_value)) for tag_key,
-                              tag_value in tags.items()])
         lookups = self.config.get("lookups", {})
         for key, handler in lookups.iteritems():
             register_lookup_handler(key, handler)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -110,6 +110,14 @@ class MissingEnvironment(Exception):
         super(MissingEnvironment, self).__init__(message, *args, **kwargs)
 
 
+class MissingConfig(Exception):
+
+    def __init__(self, key, *args, **kwargs):
+        self.key = key
+        message = "Config missing key %s." % (key,)
+        super(MissingConfig, self).__init__(message, *args, **kwargs)
+
+
 class ImproperlyConfigured(Exception):
 
     def __init__(self, cls, error, *args, **kwargs):

--- a/stacker/tests/hooks/test_aws_lambda.py
+++ b/stacker/tests/hooks/test_aws_lambda.py
@@ -76,8 +76,8 @@ class TestLambdaHooks(unittest.TestCase):
                     self.fail('s3: bucket {} does not exist'.format(bucket))
 
     def setUp(self):
-        self.context = Context(environment={'namespace': 'test'})
-        self.context.bucket_name = 'test'
+        self.context = Context(
+            config={'namespace': 'test', 'stacker_bucket': 'test'})
         self.provider = mock_provider(region="us-east-1")
 
     def run_hook(self, **kwargs):


### PR DESCRIPTION
This makes the `environment` argument optional, meaning you can invoke stacker `build/destroy` with only a stacker.yml file:

```console
$ echo "namespace: my-namespace" | stacker build -
```

Previously, you were required to pass both an "environment" file _and_ a stacker config file. The only reason the environment file was required was to determine the `namespace`. However, we already parse and interpolate the stacker config using the environment file, so the `namespace` might as well just be part of the stacker config.

In other words, instead of doing this:

```yaml
# dev.env
namespace: my-namespace
```

```yaml
# stacker.yaml
stacks:
- name: vpc
   ...
```

The recommended approach would be to do this:

```yaml
# dev.env
namespace: my-namespace
```

```yaml
# stacker.yaml
namespace: ${namespace}
stacks:
- name: vpc
   ...
```

Which I think is more consistent with the other keys that are already in the stack config (e.g. `namespace_delimiter`, `tags`, etc).

This change should be 100% backwards compatible. If the `namespace` key is not provided in the stack config, then it'll fallback to pulling it from the environment file, with a deprecation warning.

**TODO**

* [x] Update docs
* [x] Deprecation warning about moving `namespace` from environment to config.