### PR TITLE
Cleanup docs

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -16,8 +16,8 @@ pushing them up into CloudFormation.
 ::
 
   # stacker build -h
-  usage: stacker build [-h] [-p PARAMETER=VALUE] [-e ENV=VALUE] [-r REGION] [-v]
-                       [-i] [--replacements-only] [-m MAX_ZONES] [-o]
+  usage: stacker build [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
+                       [--replacements-only] [-m MAX_ZONES] [-o]
                        [--force STACKNAME] [--stacks STACKNAME] [-t] [-d DUMP]
                        environment config
 
@@ -33,26 +33,23 @@ pushing them up into CloudFormation.
                           https://docs.python.org/2/library/string.html
                           #template-strings. Must define at least a "namespace".
     config                The config file where stack configuration is located.
-                          Must be in yaml format.
+                          Must be in yaml format. If `-` is provided, then the
+                          config will be read from stdin.
 
   optional arguments:
     -h, --help            show this help message and exit
-    -p PARAMETER=VALUE, --parameter PARAMETER=VALUE
-                          Adds parameters from the command line that can be used
-                          inside any of the stacks being built. Can be specified
-                          more than once.
     -e ENV=VALUE, --env ENV=VALUE
                           Adds environment key/value pairs from the command
                           line. Overrides your environment file settings. Can be
                           specified more than once.
     -r REGION, --region REGION
-                          The AWS region to launch in. Default: us-east-1
+                          The AWS region to launch in.
     -v, --verbose         Increase output verbosity. May be specified up to
                           twice.
     -i, --interactive     Enable interactive mode. If specified, this will use
                           the AWS interactive provider, which leverages
-                          CloudFormation Change Sets to display changes before
-                          running CloudFormation templates. You'll be asked if
+                          Cloudformation Change Sets to display changes before
+                          running cloudformation templates. You'll be asked if
                           you want to execute each change set. If you only want
                           to authorize replacements, run with "--replacements-
                           only" as well.
@@ -71,7 +68,8 @@ pushing them up into CloudFormation.
                           than once. If not specified then stacker will work on
                           all stacks in the config file.
     -t, --tail            Tail the CloudFormation logs while workingwith stacks
-    -d DUMP, --dump DUMP  Dump the rendered CloudFormation templates to a
+    -d DUMP, --dump DUMP  Dump the rendered Cloudformation templates to a
+                          directory
 
 
 Destroy
@@ -85,28 +83,49 @@ already been destroyed).
 ::
 
   # stacker destroy -h
-  usage: stacker destroy [-h] [-p PARAMETER=VALUE] [-e ENV=VALUE] [-r REGION] [-v] [-f] [-t] environment config
+  usage: stacker destroy [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
+                         [--replacements-only] [-f] [--stacks STACKNAME] [-t]
+                         environment config
 
-  Destroys CloudFormation stacks based on the given config. Stacker will determine the order in which stacks should be destroyed based on any manual requirements they
-  specify or output values they rely on from other stacks.
+  Destroys CloudFormation stacks based on the given config. Stacker will
+  determine the order in which stacks should be destroyed based on any manual
+  requirements they specify or output values they rely on from other stacks.
 
   positional arguments:
-    environment           Path to a simple `key: value` pair environment file. The values in the environment file can be used in the stack config as if it were a
-                          string.Template type: https://docs.python.org/2/library/string.html#template-strings. Must define at least a 'namespace'.
-    config                The config file where stack configuration is located. Must be in yaml format.
+    environment           Path to a simple `key: value` pair environment file.
+                          The values in the environment file can be used in the
+                          stack config as if it were a string.Template type:
+                          https://docs.python.org/2/library/string.html
+                          #template-strings. Must define at least a "namespace".
+    config                The config file where stack configuration is located.
+                          Must be in yaml format. If `-` is provided, then the
+                          config will be read from stdin.
 
   optional arguments:
     -h, --help            show this help message and exit
-    -p PARAMETER=VALUE, --parameter PARAMETER=VALUE
-                          Adds parameters from the command line that can be used inside any of the stacks being built. Can be specified more than once.
     -e ENV=VALUE, --env ENV=VALUE
-                          Adds environment key/value pairs from the command line. Overrides your environment file settings. Can be specified more than once.
+                          Adds environment key/value pairs from the command
+                          line. Overrides your environment file settings. Can be
+                          specified more than once.
     -r REGION, --region REGION
-                          The AWS region to launch in. Default: us-east-1
-    -v, --verbose         Increase output verbosity. May be specified up to twice.
-    -f, --force           Whether or not you want to go through with destroying the stacks
+                          The AWS region to launch in.
+    -v, --verbose         Increase output verbosity. May be specified up to
+                          twice.
+    -i, --interactive     Enable interactive mode. If specified, this will use
+                          the AWS interactive provider, which leverages
+                          Cloudformation Change Sets to display changes before
+                          running cloudformation templates. You'll be asked if
+                          you want to execute each change set. If you only want
+                          to authorize replacements, run with "--replacements-
+                          only" as well.
+    --replacements-only   If interactive mode is enabled, stacker will only
+                          prompt to authorize replacements.
+    -f, --force           Whether or not you want to go through with destroying
+                          the stacks
+    --stacks STACKNAME    Only work on the stacks given. Can be specified more
+                          than once. If not specified then stacker will work on
+                          all stacks in the config file.
     -t, --tail            Tail the CloudFormation logs while workingwith stacks
-
 
 Info
 ----
@@ -118,25 +137,44 @@ config.
 ::
 
   # stacker info -h
-  usage: stacker info [-h] [-p PARAMETER=VALUE] [-e ENV=VALUE] [-r REGION] [-v] [--stacks STACKNAME] environment config
+  usage: stacker info [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
+                      [--replacements-only] [--stacks STACKNAME]
+                      environment config
 
   Gets information on the CloudFormation stacks based on the given config.
 
   positional arguments:
-    environment           Path to a simple `key: value` pair environment file. The values in the environment file can be used in the stack config as if it were a
-                          string.Template type: https://docs.python.org/2/library/string.html#template-strings. Must define at least a 'namespace'.
-    config                The config file where stack configuration is located. Must be in yaml format.
+    environment           Path to a simple `key: value` pair environment file.
+                          The values in the environment file can be used in the
+                          stack config as if it were a string.Template type:
+                          https://docs.python.org/2/library/string.html
+                          #template-strings. Must define at least a "namespace".
+    config                The config file where stack configuration is located.
+                          Must be in yaml format. If `-` is provided, then the
+                          config will be read from stdin.
 
   optional arguments:
     -h, --help            show this help message and exit
-    -p PARAMETER=VALUE, --parameter PARAMETER=VALUE
-                          Adds parameters from the command line that can be used inside any of the stacks being built. Can be specified more than once.
     -e ENV=VALUE, --env ENV=VALUE
-                          Adds environment key/value pairs from the command line. Overrides your environment file settings. Can be specified more than once.
+                          Adds environment key/value pairs from the command
+                          line. Overrides your environment file settings. Can be
+                          specified more than once.
     -r REGION, --region REGION
-                          The AWS region to launch in. Default: us-east-1
-    -v, --verbose         Increase output verbosity. May be specified up to twice.
-    --stacks STACKNAME    Only work on the stacks given. Can be specified more than once. If not specified then stacker will work on all stacks in the config file.
+                          The AWS region to launch in.
+    -v, --verbose         Increase output verbosity. May be specified up to
+                          twice.
+    -i, --interactive     Enable interactive mode. If specified, this will use
+                          the AWS interactive provider, which leverages
+                          Cloudformation Change Sets to display changes before
+                          running cloudformation templates. You'll be asked if
+                          you want to execute each change set. If you only want
+                          to authorize replacements, run with "--replacements-
+                          only" as well.
+    --replacements-only   If interactive mode is enabled, stacker will only
+                          prompt to authorize replacements.
+    --stacks STACKNAME    Only work on the stacks given. Can be specified more
+                          than once. If not specified then stacker will work on
+                          all stacks in the config file.
 
 Diff
 ----
@@ -149,24 +187,46 @@ possible, but it should give a good idea if anything has changed.
 ::
 
   # stacker diff -h
-  usage: stacker diff [-h] [-p PARAMETER=VALUE] [-e ENV=VALUE] [-r REGION] [-v] [--force STACKNAME] [--stacks STACKNAME] environment config
+  usage: stacker diff [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
+                      [--replacements-only] [--force STACKNAME]
+                      [--stacks STACKNAME]
+                      environment config
 
-  Diffs the config against the currently running CloudFormation stacks Sometimes small changes can have big impacts. Run 'stacker diff' before 'stacker build' to
-  detect bad things(tm) from happening in advance!
+  Diffs the config against the currently running CloudFormation stacks Sometimes
+  small changes can have big impacts. Run "stacker diff" before "stacker build"
+  to detect bad things(tm) from happening in advance!
 
   positional arguments:
-    environment           Path to a simple `key: value` pair environment file. The values in the environment file can be used in the stack config as if it were a
-                          string.Template type: https://docs.python.org/2/library/string.html#template-strings. Must define at least a 'namespace'.
-    config                The config file where stack configuration is located. Must be in yaml format.
+    environment           Path to a simple `key: value` pair environment file.
+                          The values in the environment file can be used in the
+                          stack config as if it were a string.Template type:
+                          https://docs.python.org/2/library/string.html
+                          #template-strings. Must define at least a "namespace".
+    config                The config file where stack configuration is located.
+                          Must be in yaml format. If `-` is provided, then the
+                          config will be read from stdin.
 
   optional arguments:
     -h, --help            show this help message and exit
-    -p PARAMETER=VALUE, --parameter PARAMETER=VALUE
-                          Adds parameters from the command line that can be used inside any of the stacks being built. Can be specified more than once.
     -e ENV=VALUE, --env ENV=VALUE
-                          Adds environment key/value pairs from the command line. Overrides your environment file settings. Can be specified more than once.
+                          Adds environment key/value pairs from the command
+                          line. Overrides your environment file settings. Can be
+                          specified more than once.
     -r REGION, --region REGION
-                          The AWS region to launch in. Default: us-east-1
-    -v, --verbose         Increase output verbosity. May be specified up to twice.
-    --force STACKNAME     If a stackname is provided to --force, it will be diffed, even if it is locked in the config.
-    --stacks STACKNAME    Only work on the stacks given. Can be specified more than once. If not specified then stacker will work on all stacks in the config file.
+                          The AWS region to launch in.
+    -v, --verbose         Increase output verbosity. May be specified up to
+                          twice.
+    -i, --interactive     Enable interactive mode. If specified, this will use
+                          the AWS interactive provider, which leverages
+                          Cloudformation Change Sets to display changes before
+                          running cloudformation templates. You'll be asked if
+                          you want to execute each change set. If you only want
+                          to authorize replacements, run with "--replacements-
+                          only" as well.
+    --replacements-only   If interactive mode is enabled, stacker will only
+                          prompt to authorize replacements.
+    --force STACKNAME     If a stackname is provided to --force, it will be
+                          diffed, even if it is locked in the config.
+    --stacks STACKNAME    Only work on the stacks given. Can be specified more
+                          than once. If not specified then stacker will work on
+                          all stacks in the config file.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -170,10 +170,6 @@ A stack has the following keys:
   will be prepended to this)
 **class_path:**
   The python class path to the Blueprint to be used.
-**parameters:**
-  A dictionary of Parameters_ to pass into CloudFormation when the
-  stack is submitted. (note: parameters will be deprecated in the future
-  in favor of variables)
 **variables:**
   A dictionary of Variables_ to pass into the Blueprint when rendering the
   CloudFormation template. Variables_ can be any valid YAML data
@@ -218,64 +214,6 @@ Here's an example from stacker_blueprints_, used to create a VPC::
         CidrBlock: 10.128.0.0/16
 
 
-Parameters
-==========
-
-.. note::
-  Parameters have been deprecated in favor of Variables_ and will be
-  removed in a future release.
-
-Parameters are a CloudFormation concept that allow you to re-use an existing
-CloudFormation template, but modify its behavior by passing in different
-values.
-
-stacker tries to make working with Parameters a little easier in a few ways:
-
-Parameter YAML anchors & references
------------------------------------
-
-If you have a common set of parameters that you need to pass around in many
-places, it can be annoying to have to copy and paste them in multiple places.
-Instead, using a feature of YAML known as `anchors & references`_, you can
-define common values in a single place and then refer to them with a simple
-syntax.
-
-For example, say you pass a common domain name to each of your stacks, each of
-them taking it as a Parameter. Rather than having to enter the domain into
-each stack (and hopefully not typo'ing any of them) you could do the
-following::
-
-  domain_name: mydomain.com &domain
-
-Now you have an anchor called **domain** that you can use in place of any value
-in the config to provide the value **mydomain.com**. You use the anchor with
-a reference::
-
-  stacks:
-    - name: vpc
-      class_path: stacker_blueprints.vpc.VPC
-      parameters:
-        DomainName: *domain
-
-Even more powerful is the ability to anchor entire dictionaries, and then
-reference them in another dictionary, effectively providing it with default
-values. For example::
-
-  common_variables: &common_parameters
-    DomainName: mydomain.com
-    InstanceType: m3.medium
-    AMI: ami-12345abc
-
-Now, rather than having to provide each of those Parameters to every stack that
-could use them, you can just do this instead::
-
-  stacks:
-    - name: vpc
-      class_path: stacker_blueprints.vpc.VPC
-      parameters:
-        << : *common_variables
-        InstanceType: c4.xlarge # override the InstanceType in this stack
-
 Variables
 ==========
 
@@ -317,7 +255,7 @@ Even more powerful is the ability to anchor entire dictionaries, and then
 reference them in another dictionary, effectively providing it with default
 values. For example::
 
-  common_variables: &common_parameters
+  common_variables: &common_variables
     DomainName: mydomain.com
     InstanceType: m3.medium
     AMI: ami-12345abc


### PR DESCRIPTION
Some minor docs cleanup. Refreshes the `-h` output to what it currently outputs, and removes references to parameters, since they no longer work in 1.0.