### PR TITLE
Functional test suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,8 @@ Ready to contribute? Here's how to set up `stacker` for local development.
 
 7. Submit a pull request through the GitHub website.
 
+For information about the functional testing suite, see [tests/README.md](./tests).
+
 ## Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,31 @@
-.PHONY: build
+.PHONY: build lint test-unit test-functional test ci
+
+# Only run the functional tests on the master branch, since they can be slow.
+ifeq ($(CIRCLE_BRANCH),master)
+CI_TESTS = test-unit test-functional
+else
+CI_TESTS = test-unit
+endif
 
 build:
 	docker build -t remind101/stacker .
 
-test:
+lint:
 	flake8 --exclude stacker/tests/ stacker
 	flake8 --ignore N802 stacker/tests # ignore setUp naming
+
+test-unit:
 	AWS_DEFAULT_REGION=us-east-1 python setup.py nosetests
+
+test-functional:
+	bats tests
+
+# General testing target for most development.
+test: lint test-unit
+
+# Target for CI tests. If building the master branch, this will also run the
+# functional tests, which can be slow.
+ci: $(CI_TESTS)
 
 apidocs:
 	sphinx-apidoc --force -o docs/api stacker

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,13 @@
 machine:
   timezone: America/Los_Angeles
+  pre:
+    - sudo add-apt-repository -y ppa:duggan/bats
+    - sudo apt-get update
+    - sudo apt-get install -y bats
+    - bats --version
+  environment:
+    AWS_DEFAULT_REGION: "us-east-1"
+    STACKER_NAMESPACE: "stacker-functional-tests-$CIRCLE_BUILD_NUM"
 
 dependencies:
   pre:
@@ -7,6 +15,6 @@ dependencies:
 
 test:
   override:
-    - make test
+    - make ci
   post:
     - codecov

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -1,4 +1,12 @@
-from troposphere import Output
+from troposphere import Output, Sub, Join, Ref
+from troposphere import iam
+
+from awacs.aws import Policy, Statement
+import awacs
+import awacs.s3
+import awacs.cloudformation
+import awacs.iam
+
 from troposphere.cloudformation import WaitConditionHandle
 
 from stacker.blueprints.base import Blueprint
@@ -11,6 +19,78 @@ from stacker.blueprints.variables.types import (
     EC2SubnetIdList,
     EC2VPCId,
 )
+
+
+class FunctionalTests(Blueprint):
+    """This creates a stack with an IAM user and access key for running the
+    functional tests for stacker.
+    """
+
+    VARIABLES = {
+        "StackerNamespace": {
+            "type": CFNString,
+            "description": "The stacker namespace that the tests will use. "
+                           "Access to cloudformation will be restricted to "
+                           "only allow access to stacks with this prefix."},
+        "StackerBucket": {
+            "type": CFNString,
+            "description": "The name of the bucket that the tests will use "
+                           "for uploading templates."}
+    }
+
+    def create_template(self):
+        t = self.template
+
+        bucket_arn = Sub("arn:aws:s3:::${StackerBucket}")
+        cloudformation_scope = Sub(
+            "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:"
+            "stack/${StackerNamespace}-*")
+        changeset_scope = "*"
+
+        # This represents the precise IAM permissions that stacker itself
+        # needs.
+        stacker_policy = iam.Policy(
+            PolicyName="Stacker",
+            PolicyDocument=Policy(
+                Statement=[
+                    Statement(
+                        Effect="Allow",
+                        Resource=[bucket_arn],
+                        Action=[
+                            awacs.s3.ListBucket,
+                            awacs.s3.GetBucketLocation,
+                            awacs.s3.CreateBucket]),
+                    Statement(
+                        Effect="Allow",
+                        Resource=[Join("", [bucket_arn, "/*"])],
+                        Action=[
+                            awacs.s3.GetObject,
+                            awacs.s3.GetObjectAcl,
+                            awacs.s3.PutObject,
+                            awacs.s3.PutObjectAcl]),
+                    Statement(
+                        Effect="Allow",
+                        Resource=[changeset_scope],
+                        Action=[
+                            awacs.cloudformation.DescribeChangeSet]),
+                    Statement(
+                        Effect="Allow",
+                        Resource=[cloudformation_scope],
+                        Action=[
+                            awacs.cloudformation.GetTemplate,
+                            awacs.cloudformation.CreateChangeSet,
+                            awacs.cloudformation.DeleteStack,
+                            awacs.cloudformation.CreateStack,
+                            awacs.cloudformation.UpdateStack,
+                            awacs.cloudformation.DescribeStacks])]))
+
+        user = t.add_resource(
+            iam.User(
+                "FunctionalTestUser",
+                Policies=[
+                    stacker_policy]))
+
+        t.add_output(Output("User", Value=Ref(user)))
 
 
 class Dummy(Blueprint):

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -1,3 +1,6 @@
+from troposphere import Output
+from troposphere.cloudformation import WaitConditionHandle
+
 from stacker.blueprints.base import Blueprint
 from stacker.blueprints.variables.types import (
     CFNCommaDelimitedList,
@@ -8,6 +11,18 @@ from stacker.blueprints.variables.types import (
     EC2SubnetIdList,
     EC2VPCId,
 )
+
+
+class Dummy(Blueprint):
+    VARIABLES = {
+        "StringVariable": {
+            "type": str,
+            "default": ""}
+    }
+
+    def create_template(self):
+        self.template.add_resource(WaitConditionHandle("Dummy"))
+        self.template.add_output(Output("DummyId", Value="dummy-1234"))
 
 
 class VPC(Blueprint):
@@ -30,8 +45,6 @@ class VPC(Blueprint):
             "type": CFNString,
             "description": "NAT EC2 instance type.",
             "default": "m3.medium"},
-        "SshKeyName": {
-            "type": EC2KeyPairKeyName},
         "BaseDomain": {
             "type": CFNString,
             "default": "",
@@ -58,7 +71,7 @@ class VPC(Blueprint):
     }
 
     def create_template(self):
-        return
+        self.template.add_resource(WaitConditionHandle("VPC"))
 
 
 class Bastion(Blueprint):

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -41,7 +41,7 @@ class FunctionalTests(Blueprint):
     def create_template(self):
         t = self.template
 
-        bucket_arn = Sub("arn:aws:s3:::${StackerBucket}")
+        bucket_arn = Sub("arn:aws:s3:::${StackerBucket}*")
         cloudformation_scope = Sub(
             "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:"
             "stack/${StackerNamespace}-*")
@@ -62,7 +62,7 @@ class FunctionalTests(Blueprint):
                             awacs.s3.CreateBucket]),
                     Statement(
                         Effect="Allow",
-                        Resource=[Join("", [bucket_arn, "/*"])],
+                        Resource=[bucket_arn],
                         Action=[
                             awacs.s3.GetObject,
                             awacs.s3.GetObjectAcl,
@@ -73,6 +73,11 @@ class FunctionalTests(Blueprint):
                         Resource=[changeset_scope],
                         Action=[
                             awacs.cloudformation.DescribeChangeSet]),
+                    Statement(
+                        Effect="Deny",
+                        Resource=[Ref("AWS::StackId")],
+                        Action=[
+                            awacs.cloudformation.Action("*")]),
                     Statement(
                         Effect="Allow",
                         Resource=[cloudformation_scope],

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,31 @@
+This directory contains the functional testing suite for stacker. It exercises all of stacker against a real AWS account.
+
+## Setup
+
+1. First, ensure that you're inside a virtualenv:
+
+  ```console
+  $ source venv/bin/activate
+  ```
+2. Set a stacker namespace for the test suite to use:
+
+  ```console
+  $ export STACKER_NAMESPACE=my-stacker-test-namespace
+  ```
+3. Generate an IAM user for the test suite to use:
+
+  ```console
+  $ ./stacker.yaml.sh | stacker build -
+  ```
+4. In the AWS console, generate a new IAM access key pair for the user and set it in your shell:
+
+  ```console
+  $ export AWS_ACCESS_KEY_ID=access-key
+  $ export AWS_SECRET_ACCESS_KEY=secret-access-key
+  ```
+5. Run the test suite:
+
+  ```console
+  $ brew install bats
+  $ bats .
+  ```

--- a/tests/stacker.yaml.sh
+++ b/tests/stacker.yaml.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cat - <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: stackerFunctionalTests
+    class_path: stacker.tests.fixtures.mock_blueprints.FunctionalTests
+    variables:
+      StackerBucket: stacker-${STACKER_NAMESPACE}
+      StackerNamespace: ${STACKER_NAMESPACE}
+EOF

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -1,0 +1,272 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "stacker build - no config" {
+  stacker build
+  assert ! "$status" -eq 0
+  assert_has_line "stacker build: error: too few arguments"
+}
+
+@test "stacker build - empty config" {
+  stacker build <(echo "")
+  assert ! "$status" -eq 0
+
+  # FIXME(ejholmes): This is thrown because yaml.load doesn't know it should be
+  # a dict. This is a pretty bad first experience if someone provides an empty
+  # config to stacker.
+  assert_has_line "TypeError: argument of type 'NoneType' is not iterable"
+}
+
+@test "stacker build - config with no stacks" {
+  stacker build - <<EOF
+namespace: ${STACKER_NAMESPACE}
+EOF
+  assert ! "$status" -eq 0
+
+  # FIXME(ejholmes): This is thrown because the config doesn't specify any
+  # stacks. Again, not a great first user experience.
+  assert_has_line "KeyError: 'stacks'"
+}
+
+@test "stacker build - config with no namespace" {
+  stacker build - <<EOF
+stacker_bucket: stacker-${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.VPC
+EOF
+  assert ! "$status" -eq 0
+  assert_has_line "stacker.exceptions.MissingConfig: Config missing key namespace"
+}
+
+@test "stacker build - missing environment key" {
+  environment() {
+    cat <<EOF
+vpc_private_subnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22
+EOF
+  }
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.VPC
+    variables:
+      PublicSubnets: \${vpc_public_subnets}
+      PrivateSubnets: \${vpc_private_subnets
+EOF
+  }
+
+  # Create the new stacks.
+  stacker build <(environment) <(config)
+  assert ! "$status" -eq 0
+  assert_has_line "stacker.exceptions.MissingEnvironment: Environment missing key vpc_public_subnets."
+}
+
+@test "stacker build - missing variable" {
+  needs_aws
+
+  stacker build - <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.VPC
+EOF
+  assert ! "$status" -eq 0
+  assert_has_line "stacker.exceptions.MissingVariable: Variable \"PublicSubnets\" in blueprint \"vpc\" is missing"
+}
+
+@test "stacker build - simple build" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.VPC
+    variables:
+      PublicSubnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
+      PrivateSubnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using Default AWS Provider"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: pending"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: complete (creating new stack)"
+
+  # Perform a noop update to the stacks, in interactive mode.
+  stacker build -i <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using Interactive AWS Provider"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: pending"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: skipped (nochange)"
+
+  # Cleanup
+  stacker destroy --force <(config)
+  assert "$status" -eq 0
+  assert_has_line "${STACKER_NAMESPACE}-vpc: pending"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (submitted for destruction)"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: complete (stack destroyed)"
+}
+
+@test "stacker build - simple build with output lookups" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    variables:
+      StringVariable: \${output vpc::DummyId}
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using Default AWS Provider"
+
+  for stack in vpc bastion; do
+    assert_has_line -E "${STACKER_NAMESPACE}-${stack}:\s.*pending"
+    assert_has_line -E "${STACKER_NAMESPACE}-${stack}:\s.*submitted \(creating new stack\)"
+    assert_has_line -E "${STACKER_NAMESPACE}-${stack}:\s.*complete \(creating new stack\)"
+  done
+}
+
+@test "stacker build - simple build with environment" {
+  needs_aws
+
+  environment() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+vpc_public_subnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
+vpc_private_subnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22
+EOF
+  }
+
+  config() {
+    cat <<EOF
+namespace: \${namespace}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.VPC
+    variables:
+      PublicSubnets: \${vpc_public_subnets}
+      PrivateSubnets: \${vpc_private_subnets
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(environment) <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(environment) <(config)
+  assert "$status" -eq 0
+}
+
+@test "stacker build - overriden environment key with -e" {
+  needs_aws
+
+  environment() {
+    cat <<EOF
+namespace: stacker
+EOF
+  }
+
+  config() {
+    cat <<EOF
+namespace: \${namespace}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.VPC
+    variables:
+      PublicSubnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
+      PrivateSubnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22
+EOF
+  }
+
+  teardown() {
+    stacker destroy -e namespace=$STACKER_NAMESPACE --force <(environment) <(config)
+  }
+
+  # Create the new stacks.
+  stacker build -e namespace=$STACKER_NAMESPACE <(environment) <(config)
+  assert "$status" -eq 0
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (creating new stack)"
+}
+
+@test "stacker build - dump" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    variables:
+      StringVariable: \${output vpc::DummyId}
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+
+  stacker build -d "$TMP" <(config)
+  assert "$status" -eq 0
+}
+
+@test "stacker diff - simple diff with output lookups" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    variables:
+      StringVariable: \${output vpc::DummyId}
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+
+  stacker diff <(config)
+  assert "$status" -eq 0
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if [ -z "$STACKER_NAMESPACE" ]; then
+  >&2 echo "To run these tests, you must set a STACKER_NAMESPACE environment variable"
+  exit 1
+fi
+
+# Simple wrapper around the builtin bash `test` command.
+assert() {
+  builtin test "$@"
+}
+
+# Checks that the given line is in $output.
+assert_has_line() {
+  echo "$output" | grep "$@" 1>/dev/null
+}
+
+# This helper wraps "stacker" with bats' "run" and also outputs debug
+# information. If you need to execute the stacker binary _without_ calling
+# "run", you can use "command stacker".
+stacker() {
+  echo "$ stacker $@"
+  run command stacker "$@"
+  echo "$output"
+  echo
+}
+
+# A helper to tag a test as requiring access to AWS. If no credentials are set,
+# then the tests will be skipped.
+needs_aws() {
+  if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+    skip "aws credentials not set"
+  fi
+}


### PR DESCRIPTION
This is a quick spike into https://github.com/remind101/stacker/issues/437.

This adds some _really_ basic end-to-end sanity tests that exercise a `stacker build/destroy` using [bats](https://github.com/sstephenson/bats).

Assuming you have bats installed, and some AWS access keys set, you can run this with:

```console
$ brew install bats
$ source venv/bin/activate
$ STACKER_NAMESPACE=<my-stacker-tests-namespace> bats tests
 ✓ stacker build - no config
 ✓ stacker build - empty config
 ✓ stacker build - config with no stacks
 ✓ stacker build - config with no namespace
 ✓ stacker build - missing environment key
 ✓ stacker build - missing variable
 ✓ stacker build - simple build destroy
 ✓ stacker build - simple build with environment
 ✓ stacker build - overriden environment key with -e

9 tests, 0 failures
```

We'd likely want to run this in CI using an isolated AWS account with access keys that are super tight (only allows cloudformation actions, and the ability to create a WaitCondtionHandle).