### PR TITLE
Structured Config object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ install_requires = [
     "awacs~=0.6.0",
     "colorama~=0.3.7",
     "formic~=0.9b",
-    "gitpython~=2.0"
+    "gitpython~=2.0",
+    "schematics~=2.0.1"
 ]
 
 tests_require = [

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -76,10 +76,8 @@ class BaseAction(object):
 
     @property
     def bucket_region(self):
-        return self.context.config.get(
-            "stacker_bucket_region",
-            self.provider.region
-        )
+        return self.context.config.stacker_bucket_region \
+                or self.provider.region
 
     def ensure_cfn_bucket(self):
         """The CloudFormation bucket where templates will be stored."""

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -281,7 +281,7 @@ class Action(BaseAction):
 
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
-        hooks = self.context.config.get("pre_build")
+        hooks = self.context.config.pre_build
         handle_hooks(
             "post_build",
             hooks,
@@ -311,7 +311,7 @@ class Action(BaseAction):
 
     def post_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""
-        hooks = self.context.config.get("post_build")
+        hooks = self.context.config.post_build
         handle_hooks(
             "post_build",
             hooks,

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -88,7 +88,7 @@ class Action(BaseAction):
 
     def pre_run(self, outline=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
-        pre_destroy = self.context.config.get("pre_destroy")
+        pre_destroy = self.context.config.pre_destroy
         if not outline and pre_destroy:
             util.handle_hooks(
                 stage="pre_destroy",
@@ -110,7 +110,7 @@ class Action(BaseAction):
 
     def post_run(self, outline=False, *args, **kwargs):
         """Any steps that need to be taken after running the action."""
-        post_destroy = self.context.config.get("post_destroy")
+        post_destroy = self.context.config.post_destroy
         if not outline and post_destroy:
             util.handle_hooks(
                 stage="post_destroy",

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -5,6 +5,7 @@ from .destroy import Destroy
 from .info import Info
 from .diff import Diff
 from .base import BaseCommand
+from ...config import render_parse_load as load_config
 from ...context import Context
 from ...providers.aws import (
     default,
@@ -31,14 +32,20 @@ class Stacker(BaseCommand):
         else:
             logger.info('Using Default AWS Provider')
             options.provider = default.Provider(region=options.region)
+
+        config = load_config(
+            options.config.read(),
+            environment=options.environment,
+            validate=True)
+
         options.context = Context(
             environment=options.environment,
+            config=config,
             logger_type=self.logger_type,
             # Allow subcommands to provide any specific kwargs to the Context
             # that it wants.
             **options.get_context_kwargs(options)
         )
-        options.context.load_config(options.config.read())
 
     def add_arguments(self, parser):
         parser.add_argument("--version", action="version",

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -1,16 +1,69 @@
+import sys
+import logging
+
 from string import Template
 from StringIO import StringIO
 
+from schematics import Model
+from schematics.exceptions import ValidationError
+from schematics.exceptions import BaseError as SchematicsError
+from schematics.types import (
+    ModelType,
+    ListType,
+    StringType,
+    BooleanType,
+    DictType,
+    BaseType
+)
+
 import yaml
 
+from ..lookups import register_lookup_handler
+from ..util import SourceProcessor
 from .. import exceptions
 
 # register translators (yaml constructors)
 from .translators import *  # NOQA
 
+logger = logging.getLogger(__name__)
 
-def parse_config(raw_config, environment=None):
-    """Parse a config, using it as a template with the environment.
+
+def render_parse_load(raw_config, environment=None, validate=True):
+    """Encapsulates the render -> parse -> validate -> load process.
+
+    Args:
+        raw_config (str): the raw stacker configuration string.
+        environment (dict, optional): any environment values that should be
+            passed to the config
+        validate (bool): if provided, the config is validated before being
+            loaded.
+
+    Returns:
+        :class:`Config`: the parsed stacker config.
+
+    """
+
+    rendered = render(raw_config, environment)
+
+    config = parse(rendered)
+
+    # For backwards compatibility, if the config doesn't specify a namespace,
+    # we fall back to fetching it from the environment, if provided.
+    if config.namespace is None:
+        namespace = environment.get("namespace")
+        if namespace:
+            logger.warn("specifying namespace in the environment is "
+                        "deprecated, and should be moved to the config")
+            config.namespace = namespace
+
+    if validate:
+        config.validate()
+
+    return load(config)
+
+
+def render(raw_config, environment=None):
+    """Renders a config, using it as a template with the environment.
 
     Args:
         raw_config (str): the raw stacker configuration string.
@@ -18,10 +71,11 @@ def parse_config(raw_config, environment=None):
             passed to the config
 
     Returns:
-        dict: the stacker configuration populated with any values passed from
+        str: the stacker configuration populated with any values passed from
             the environment
 
     """
+
     t = Template(raw_config)
     buff = StringIO()
     if not environment:
@@ -35,5 +89,210 @@ def parse_config(raw_config, environment=None):
         buff.write(t.safe_substitute(environment))
 
     buff.seek(0)
-    config = yaml.load(buff)
+    return buff.read()
+
+
+def parse(raw_config):
+    """Parse a raw yaml formatted stacker config.
+
+    Args:
+        raw_config (str): the raw stacker configuration string in yaml format.
+
+    Returns:
+        :class:`Config`: the parsed stacker config.
+
+    """
+
+    # We have to enable non-strict mode, because people may be including top
+    # level keys for re-use with stacks (e.g. including something like
+    # `common_variables: &common_variables`).
+    #
+    # The unfortunate side effect of this is that it propagates down to every
+    # schematics model, and there doesn't seem to be a good way to only disable
+    # strict mode on a single model.
+    #
+    # If we enabled strict mode, it would break backwards compatibility, so we
+    # should consider enabling this in the future.
+    strict = False
+
+    return Config(yaml.safe_load(raw_config), strict=strict)
+
+
+def load(config):
+    """Loads a stacker configuration by modifying sys paths, loading lookups,
+    etc.
+
+    Args:
+        config (:class:`Config`): the stacker config to load.
+
+    Returns:
+        :class:`Config`: the stacker config provided above.
+
+    """
+
+    if config.sys_path:
+        logger.debug("Appending %s to sys.path.", config.sys_path)
+        sys.path.append(config.sys_path)
+        logger.debug("sys.path is now %s", sys.path)
+    if config.lookups:
+        for key, handler in config.lookups.iteritems():
+            register_lookup_handler(key, handler)
+    sources = config.package_sources
+    if sources is not None:
+        processor = SourceProcessor(
+            stacker_cache_dir=config.stacker_cache_dir
+        )
+        processor.get_package_sources(sources=sources)
+
     return config
+
+
+def dump(config):
+    """Dumps a stacker Config object as yaml.
+
+    Args:
+        config (:class:`Config`): the stacker Config object.
+        stream (stream): an optional stream object to write to.
+
+    Returns:
+        str: the yaml formatted stacker Config.
+
+    """
+
+    return yaml.safe_dump(
+        config.to_primitive(),
+        default_flow_style=False,
+        encoding='utf-8',
+        allow_unicode=True)
+
+
+def not_empty_list(value):
+    if not value or len(value) < 1:
+        raise ValidationError("Should have more than one element.")
+    return value
+
+
+class AnyType(BaseType):
+    pass
+
+
+class GitPackageSource(Model):
+    uri = StringType(required=True)
+
+    tag = StringType(serialize_when_none=False)
+
+    branch = StringType(serialize_when_none=False)
+
+    commit = StringType(serialize_when_none=False)
+
+    paths = ListType(StringType, serialize_when_none=False)
+
+
+class PackageSources(Model):
+    git = ListType(ModelType(GitPackageSource))
+
+
+class Hook(Model):
+    path = StringType(required=True)
+
+    required = BooleanType(default=True)
+
+    data_key = StringType(serialize_when_none=False)
+
+    args = DictType(AnyType)
+
+
+class Stack(Model):
+    name = StringType(required=True)
+
+    class_path = StringType(required=True)
+
+    requires = ListType(StringType, serialize_when_none=False)
+
+    locked = BooleanType(default=False)
+
+    enabled = BooleanType(default=True)
+
+    variables = DictType(AnyType, serialize_when_none=False)
+
+    parameters = DictType(AnyType, serialize_when_none=False)
+
+    def validate_parameters(self, data, value):
+        if value:
+            stack_name = data['name']
+            raise ValidationError(
+                    "Stack definition %s contains deprecated "
+                    "'parameters', rather than 'variables'. Please "
+                    "update your config." % stack_name)
+        return value
+
+
+class Config(Model):
+    """This is the Python representation of a stacker config file.
+
+    This is used internally by stacker to parse and validate a yaml formatted
+    stacker configuration file, but can also be used in scripts to generate a
+    stacker config file before handing it off to stacker to build/destroy.
+
+    Example::
+
+        from stacker.config import dump, Config, Stack
+
+        vpc = Stack({
+            "name": "vpc",
+            "class_path": "blueprints.VPC"})
+
+        config = Config()
+        config.namespace = "prod"
+        config.stacks = [vpc]
+
+        print dump(config)
+
+    """
+
+    namespace = StringType(required=True)
+
+    namespace_delimiter = StringType(serialize_when_none=False)
+
+    stacker_bucket = StringType(serialize_when_none=False)
+
+    stacker_bucket_region = StringType(serialize_when_none=False)
+
+    stacker_cache_dir = StringType(serialize_when_none=False)
+
+    sys_path = StringType(serialize_when_none=False)
+
+    package_sources = ModelType(PackageSources, serialize_when_none=False)
+
+    pre_build = ListType(ModelType(Hook), serialize_when_none=False)
+
+    post_build = ListType(ModelType(Hook), serialize_when_none=False)
+
+    pre_destroy = ListType(ModelType(Hook), serialize_when_none=False)
+
+    post_destroy = ListType(ModelType(Hook), serialize_when_none=False)
+
+    tags = DictType(StringType, serialize_when_none=False)
+
+    mappings = DictType(
+        DictType(DictType(StringType)), serialize_when_none=False)
+
+    lookups = DictType(StringType, serialize_when_none=False)
+
+    stacks = ListType(ModelType(Stack), default=[], validators=[not_empty_list])
+
+    def validate(self):
+        try:
+            super(Config, self).validate()
+        except SchematicsError as e:
+            raise exceptions.InvalidConfig(e.errors)
+
+    def validate_stacks(self, data, value):
+        if value:
+            names = set()
+            for i, stack in enumerate(value):
+                if stack.name in names:
+                    raise ValidationError(
+                        "Duplicate stack %s found at index %d."
+                        % (stack.name, i))
+                names.add(stack.name)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -1,3 +1,9 @@
+class InvalidConfig(Exception):
+    def __init__(self, errors):
+        super(InvalidConfig, self).__init__(errors)
+        self.errors = errors
+
+
 class InvalidLookupCombination(Exception):
 
     def __init__(self, lookup, lookups, value, *args, **kwargs):
@@ -108,14 +114,6 @@ class MissingEnvironment(Exception):
         self.key = key
         message = "Environment missing key %s." % (key,)
         super(MissingEnvironment, self).__init__(message, *args, **kwargs)
-
-
-class MissingConfig(Exception):
-
-    def __init__(self, key, *args, **kwargs):
-        self.key = key
-        message = "Config missing key %s." % (key,)
-        super(MissingConfig, self).__init__(message, *args, **kwargs)
 
 
 class ImproperlyConfigured(Exception):

--- a/stacker/hooks/aws_lambda.py
+++ b/stacker/hooks/aws_lambda.py
@@ -459,7 +459,7 @@ def upload_lambda_functions(context, provider, **kwargs):
     bucket_region = select_bucket_region(
         custom_bucket,
         custom_bucket_region,
-        context.config.get("stacker_bucket_region"),
+        context.config.stacker_bucket_region,
         provider.region
     )
 

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -29,8 +29,8 @@ def handler(value, provider=None, context=None, fqn=False, rfqn=False,
 
     if rfqn:
             value = "%s%s%s" % (
-                    context.environment['namespace'],
-                    context.environment.get('namespace_delimiter', '-'),
+                    context.namespace,
+                    context.namespace_delimiter,
                     value
             )
 

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -11,6 +11,7 @@ from stacker.actions.build import (
 )
 from stacker.blueprints.variables.types import CFNString
 from stacker.context import Context
+from stacker.config import Config
 from stacker.exceptions import StackDidNotChange
 from stacker.providers.base import BaseProvider
 from stacker.status import (
@@ -49,20 +50,23 @@ class TestProvider(BaseProvider):
 
 class TestBuildAction(unittest.TestCase):
     def setUp(self):
-        self.context = Context({"namespace": "namespace"})
+        self.context = Context(config=Config({"namespace": "namespace"}))
         self.build_action = build.Action(self.context, provider=TestProvider())
 
     def _get_context(self, **kwargs):
-        config = {"stacks": [
-            {"name": "vpc"},
-            {"name": "bastion",
-             "variables": {"test": "${output vpc::something}"}},
-            {"name": "db",
-             "variables": {"test": "${output vpc::something}",
-                           "else": "${output bastion::something}"}},
-            {"name": "other", "variables": {}}
-        ]}
-        return Context({"namespace": "namespace"}, config=config, **kwargs)
+        config = Config({
+            "namespace": "namespace",
+            "stacks": [
+                {"name": "vpc"},
+                {"name": "bastion",
+                 "variables": {"test": "${output vpc::something}"}},
+                {"name": "db",
+                 "variables": {"test": "${output vpc::something}",
+                               "else": "${output bastion::something}"}},
+                {"name": "other", "variables": {}}
+            ]
+        })
+        return Context(config=config, **kwargs)
 
     def test_handle_missing_params(self):
         stack = {'StackName': 'teststack'}

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -4,6 +4,7 @@ import mock
 
 from stacker.actions import destroy
 from stacker.context import Context
+from stacker.config import Config
 from stacker.exceptions import StackDoesNotExist
 from stacker.status import (
     COMPLETE,
@@ -25,8 +26,8 @@ class MockStack(object):
 class TestDestroyAction(unittest.TestCase):
 
     def setUp(self):
-        self.context = Context({"namespace": "namespace"})
-        self.context.config = {
+        config = Config({
+            "namespace": "namespace",
             "stacks": [
                 {"name": "vpc"},
                 {"name": "bastion", "requires": ["vpc"]},
@@ -34,7 +35,8 @@ class TestDestroyAction(unittest.TestCase):
                 {"name": "db", "requires": ["instance", "vpc", "bastion"]},
                 {"name": "other", "requires": ["db"]},
             ],
-        }
+        })
+        self.context = Context(config=config)
         self.action = destroy.Action(self.context, provider=mock.MagicMock())
 
     def test_generate_plan(self):
@@ -74,14 +76,15 @@ class TestDestroyAction(unittest.TestCase):
     def test_destroy_stack_in_parallel(self):
         count = {"_count": 0}
         mock_provider = mock.MagicMock()
-        self.context.config = {
+        self.context.config = Config({
+            "namespace": "namespace",
             "stacks": [
                 {"name": "vpc"},
                 {"name": "bastion", "requires": ["vpc"]},
                 {"name": "instance", "requires": ["vpc"]},
-                {"name": "db", "requies": ["vpc"]},
+                {"name": "db", "requires": ["vpc"]},
             ],
-        }
+        })
         stacks_dict = self.context.get_stacks_dict()
 
         def get_stack(stack_name):

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -1,6 +1,7 @@
 from mock import MagicMock
 
 from stacker.context import Context
+from stacker.config import Config, Stack
 from stacker.lookups import Lookup
 
 
@@ -9,11 +10,12 @@ def mock_provider(**kwargs):
 
 
 def mock_context(namespace=None, **kwargs):
+    config = Config({"namespace": namespace})
     environment = kwargs.get("environment", {})
-    if namespace is not None:
-        environment["namespace"] = namespace
-
-    return Context(environment, **kwargs)
+    return Context(
+        config=config,
+        environment=environment,
+        **kwargs)
 
 
 def generate_definition(base_name, stack_id, **overrides):
@@ -21,11 +23,10 @@ def generate_definition(base_name, stack_id, **overrides):
         "name": "%s.%d" % (base_name, stack_id),
         "class_path": "stacker.tests.fixtures.mock_blueprints.%s" % (
             base_name.upper()),
-        "namespace": "example-com",
         "requires": []
     }
     definition.update(overrides)
-    return definition
+    return Stack(definition)
 
 
 def mock_lookup(lookup_input, lookup_type, raw=None):

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -1,4 +1,4 @@
-from troposphere import Output, Sub, Join, Ref
+from troposphere import Output, Sub, Ref
 from troposphere import iam
 
 from awacs.aws import Policy, Statement

--- a/stacker/tests/hooks/test_aws_lambda.py
+++ b/stacker/tests/hooks/test_aws_lambda.py
@@ -13,6 +13,7 @@ from moto import mock_s3
 from testfixtures import TempDirectory, ShouldRaise, compare
 
 from stacker.context import Context
+from stacker.config import Config
 from stacker.hooks.aws_lambda import (
     upload_lambda_functions,
     ZIP_PERMS_MASK,
@@ -77,7 +78,7 @@ class TestLambdaHooks(unittest.TestCase):
 
     def setUp(self):
         self.context = Context(
-            config={'namespace': 'test', 'stacker_bucket': 'test'})
+            config=Config({'namespace': 'test', 'stacker_bucket': 'test'}))
         self.provider = mock_provider(region="us-east-1")
 
     def run_hook(self, **kwargs):

--- a/stacker/tests/lookups/handlers/test_rxref.py
+++ b/stacker/tests/lookups/handlers/test_rxref.py
@@ -3,6 +3,7 @@ import unittest
 
 from stacker.lookups.handlers.rxref import handler
 from ....context import Context
+from ....config import Config
 
 
 class TestRxrefHandler(unittest.TestCase):
@@ -10,7 +11,7 @@ class TestRxrefHandler(unittest.TestCase):
     def setUp(self):
         self.provider = MagicMock()
         self.context = Context(
-            environment={"namespace": "ns"}
+            config=Config({"namespace": "ns"})
         )
 
     def test_rxref_handler(self):

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -1,8 +1,17 @@
+import sys
 import unittest
 
-from stacker.config import parse_config
+from stacker.config import (
+    render_parse_load,
+    load,
+    render,
+    parse,
+    dump
+)
+from stacker.config import Config, Stack
 from stacker.environment import parse_environment
 from stacker import exceptions
+from stacker.lookups.registry import LOOKUP_HANDLERS
 
 config = """a: $a
 b: $b
@@ -10,25 +19,307 @@ c: $c"""
 
 
 class TestConfig(unittest.TestCase):
-    def test_missing_env(self):
+    def test_render_missing_env(self):
         env = {"a": "A"}
         with self.assertRaises(exceptions.MissingEnvironment) as expected:
-            parse_config(config, env)
+            render(config, env)
         self.assertEqual(expected.exception.key, "b")
 
-    def test_no_variable_config(self):
-        c = parse_config("a: A", {})
-        self.assertEqual(c["a"], "A")
+    def test_render_no_variable_config(self):
+        c = render("namespace: prod", {})
+        self.assertEqual("namespace: prod", c)
 
-    def test_valid_env_substitution(self):
-        c = parse_config("a: $a", {"a": "A"})
-        self.assertEqual(c["a"], "A")
+    def test_render_valid_env_substitution(self):
+        c = render("namespace: $namespace", {"namespace": "prod"})
+        self.assertEqual("namespace: prod", c)
 
-    def test_blank_env_values(self):
-        conf = """a: ${key1}"""
-        e = parse_environment("""key1:""")
-        c = parse_config(conf, e)
-        self.assertEqual(c["a"], None)
-        e = parse_environment("""key1: !!str""")
-        c = parse_config(conf, e)
-        self.assertEqual(c["a"], "")
+    def test_render_blank_env_values(self):
+        conf = """namespace: ${namespace}"""
+        e = parse_environment("""namespace:""")
+        c = render(conf, e)
+        self.assertEqual("namespace: ", c)
+        e = parse_environment("""namespace: !!str""")
+        c = render(conf, e)
+        self.assertEqual("namespace: !!str", c)
+
+    def test_config_validate_missing_stack_class_path(self):
+        config = Config({
+            "namespace": "prod",
+            "stacks": [
+                {
+                    "name": "bastion"}]})
+        with self.assertRaises(exceptions.InvalidConfig) as ex:
+            config.validate()
+
+        error = ex.exception.errors['stacks'][0]['class_path'].errors[0]
+        self.assertEquals(
+            error.__str__(),
+            "This field is required.")
+
+    def test_config_validate_no_stacks(self):
+        config = Config({"namespace": "prod"})
+        with self.assertRaises(exceptions.InvalidConfig) as ex:
+            config.validate()
+
+        error = ex.exception.errors['stacks'].errors[0]
+        self.assertEquals(
+            error.__str__(),
+            "Should have more than one element.")
+
+    def test_config_validate_missing_name(self):
+        config = Config({
+            "namespace": "prod",
+            "stacks": [
+                {
+                    "class_path": "blueprints.Bastion"}]})
+        with self.assertRaises(exceptions.InvalidConfig) as ex:
+            config.validate()
+
+        error = ex.exception.errors['stacks'][0]['name'].errors[0]
+        self.assertEquals(
+            error.__str__(),
+            "This field is required.")
+
+    def test_config_validate_duplicate_stack_names(self):
+        config = Config({
+            "namespace": "prod",
+            "stacks": [
+                {
+                    "name": "bastion",
+                    "class_path": "blueprints.Bastion"},
+                {
+                    "name": "bastion",
+                    "class_path": "blueprints.BastionV2"}]})
+        with self.assertRaises(exceptions.InvalidConfig) as ex:
+            config.validate()
+
+        error = ex.exception.errors['stacks'][0]
+        self.assertEquals(
+            error.__str__(),
+            "Duplicate stack bastion found at index 1.")
+
+    def test_dump_unicode(self):
+        config = Config()
+        config.namespace = "test"
+        self.assertEquals(dump(config), """namespace: test
+stacks: []
+""")
+
+        config = Config({"namespace": "test"})
+        # Ensure that we're producing standard yaml, that doesn't include
+        # python specific objects.
+        self.assertNotEquals(
+            dump(config), "namespace: !!python/unicode 'test'\n")
+        self.assertEquals(dump(config), """namespace: test
+stacks: []
+""")
+
+    def test_parse_tags(self):
+        config = parse("""
+        namespace: prod
+        tags:
+          "a:b": "c"
+          "hello": 1
+          simple_tag: simple value
+        """)
+        self.assertEquals(config.tags, {
+            "a:b": "c",
+            "hello": "1",
+            "simple_tag": "simple value"})
+
+    def test_parse_with_arbitrary_anchors(self):
+        config = parse("""
+        namespace: prod
+        common_variables: &common_variables
+          Foo: bar
+        stacks:
+        - name: vpc
+          class_path: blueprints.VPC
+          variables:
+            << : *common_variables
+        """)
+
+        stack = config.stacks[0]
+        self.assertEquals(stack.variables, {"Foo": "bar"})
+
+    def test_parse_with_deprecated_parameters(self):
+        config = parse("""
+        namespace: prod
+        stacks:
+        - name: vpc
+          class_path: blueprints.VPC
+          parameters:
+            Foo: bar
+        """)
+        with self.assertRaises(exceptions.InvalidConfig) as ex:
+            config.validate()
+
+        error = ex.exception.errors['stacks'][0]['parameters'][0]
+        self.assertEquals(
+            error.__str__(),
+            "Stack definition vpc contains deprecated 'parameters', rather "
+            "than 'variables'. Please update your config.")
+
+    def test_config_build(self):
+        vpc = Stack({"name": "vpc", "class_path": "blueprints.VPC"})
+        config = Config({"namespace": "prod", "stacks": [vpc]})
+        self.assertEquals(config.namespace, "prod")
+        self.assertEquals(config.stacks[0].name, "vpc")
+        self.assertEquals(config["namespace"], "prod")
+        config.validate()
+
+    def test_parse(self):
+        config = parse("""
+        namespace: prod
+        stacker_bucket: stacker-prod
+        pre_build:
+          - path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        post_build:
+          - path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        pre_destroy:
+          - path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        post_destroy:
+          - path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        package_sources:
+          git:
+            - uri: git@github.com:acmecorp/stacker_blueprints.git
+            - uri: git@github.com:remind101/stacker_blueprints.git
+              tag: 1.0.0
+              paths:
+                - stacker_blueprints
+            - uri: git@github.com:contoso/webapp.git
+              branch: staging
+            - uri: git@github.com:contoso/foo.git
+              commit: 12345678
+        tags:
+          environment: production
+        stacks:
+        - name: vpc
+          class_path: blueprints.VPC
+          variables:
+            PrivateSubnets:
+            - 10.0.0.0/24
+        - name: bastion
+          class_path: blueprints.Bastion
+          requires: ['vpc']
+          variables:
+            VpcId: ${output vpc::VpcId}
+        """)
+
+        config.validate()
+
+        self.assertEqual(config.namespace, "prod")
+        self.assertEqual(config.stacker_bucket, "stacker-prod")
+
+        for hooks in [config.pre_build, config.post_build,
+                      config.pre_destroy, config.post_destroy]:
+            self.assertEqual(
+                hooks[0].path, "stacker.hooks.route53.create_domain")
+            self.assertEqual(
+                hooks[0].required, True)
+            self.assertEqual(
+                hooks[0].args, {"domain": "mydomain.com"})
+
+        self.assertEqual(
+            config.package_sources.git[0].uri,
+            "git@github.com:acmecorp/stacker_blueprints.git")
+        self.assertEqual(
+            config.package_sources.git[1].uri,
+            "git@github.com:remind101/stacker_blueprints.git")
+        self.assertEqual(
+            config.package_sources.git[1].tag,
+            "1.0.0")
+        self.assertEqual(
+            config.package_sources.git[1].paths,
+            ["stacker_blueprints"])
+        self.assertEqual(
+            config.package_sources.git[2].branch,
+            "staging")
+
+        self.assertEqual(config.tags, {"environment": "production"})
+
+        self.assertEqual(len(config.stacks), 2)
+        vpc = config.stacks[0]
+        self.assertEqual(vpc.name, "vpc")
+        self.assertEqual(vpc.class_path, "blueprints.VPC")
+        self.assertEqual(vpc.requires, None)
+        self.assertEqual(vpc.variables, {"PrivateSubnets": ["10.0.0.0/24"]})
+
+        bastion = config.stacks[1]
+        self.assertEqual(bastion.name, "bastion")
+        self.assertEqual(bastion.class_path, "blueprints.Bastion")
+        self.assertEqual(bastion.requires, ["vpc"])
+        self.assertEqual(bastion.variables, {"VpcId": "${output vpc::VpcId}"})
+
+    def test_dump_complex(self):
+        config = Config({
+            "namespace": "prod",
+            "stacks": [
+                Stack({
+                    "name": "vpc",
+                    "class_path": "blueprints.VPC"}),
+                Stack({
+                    "name": "bastion",
+                    "class_path": "blueprints.Bastion",
+                    "requires": ["vpc"]})]})
+
+        self.assertEqual(dump(config), """namespace: prod
+stacks:
+- class_path: blueprints.VPC
+  enabled: true
+  locked: false
+  name: vpc
+- class_path: blueprints.Bastion
+  enabled: true
+  locked: false
+  name: bastion
+  requires:
+  - vpc
+""")
+
+    def test_load_register_custom_lookups(self):
+        config = Config({
+            "lookups": {
+                "custom": "importlib.import_module"}})
+        load(config)
+        self.assertTrue(callable(LOOKUP_HANDLERS["custom"]))
+
+    def test_load_adds_sys_path(self):
+        config = Config({"sys_path": "/foo/bar"})
+        load(config)
+        self.assertIn("/foo/bar", sys.path)
+
+    def test_lookup_with_sys_path(self):
+        config = Config({
+            "sys_path": "stacker/tests",
+            "lookups": {
+                "custom": "fixtures.mock_lookups.handler"}})
+        load(config)
+        self.assertTrue(callable(LOOKUP_HANDLERS["custom"]))
+
+    def test_render_parse_load_namespace_fallback(self):
+        conf = """
+        stacks:
+        - name: vpc
+          class_path: blueprints.VPC
+        """
+        config = render_parse_load(
+            conf, environment={"namespace": "prod"}, validate=False)
+        config.validate()
+        self.assertEquals(config.namespace, "prod")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -1,162 +1,122 @@
-import sys
-import textwrap
 import unittest
 
-from ..context import Context, get_fqn
-from ..lookups.registry import LOOKUP_HANDLERS
-from ..util import handle_hooks
-from ..exceptions import MissingConfig
+from stacker.context import Context, get_fqn
+from stacker.config import load, Config
+from stacker.util import handle_hooks
 
 
 class TestContext(unittest.TestCase):
 
     def setUp(self):
-        self.environment = {"namespace": "namespace"}
-        self.config = {"stacks": [{"name": "stack1"}, {"name": "stack2"}]}
+        self.config = Config({
+            "namespace": "namespace",
+            "stacks": [
+                {"name": "stack1"}, {"name": "stack2"}]})
 
     def test_context_optional_keys_set(self):
         context = Context(
-            environment=self.environment,
+            config=Config({}),
             stack_names=["stack"],
-            config={},
         )
-        for key in ["mappings", "config"]:
-            self.assertEqual(getattr(context, key), {})
+        self.assertEqual(context.mappings, {})
         self.assertEqual(context.stack_names, ["stack"])
 
     def test_context_get_stacks_specific_stacks(self):
         context = Context(
-            environment=self.environment,
             config=self.config,
             stack_names=["stack2"],
         )
         self.assertEqual(len(context.get_stacks()), 1)
 
     def test_context_get_stacks(self):
-        context = Context(self.environment, config=self.config)
+        context = Context(config=self.config)
         self.assertEqual(len(context.get_stacks()), 2)
 
     def test_context_get_stacks_dict_use_fqn(self):
-        context = Context(self.environment, config=self.config)
+        context = Context(config=self.config)
         stacks_dict = context.get_stacks_dict()
         stack_names = sorted(stacks_dict.keys())
         self.assertEqual(stack_names[0], "namespace-stack1")
         self.assertEqual(stack_names[1], "namespace-stack2")
 
     def test_context_get_fqn(self):
-        context = Context(self.environment)
+        context = Context(config=self.config)
         fqn = context.get_fqn()
         self.assertEqual(fqn, "namespace")
 
     def test_context_get_fqn_replace_dot(self):
-        context = Context({"namespace": "my.namespace"})
+        context = Context(config=Config({"namespace": "my.namespace"}))
         fqn = context.get_fqn()
         self.assertEqual(fqn, "my-namespace")
 
     def test_context_get_fqn_empty_namespace(self):
-        context = Context(config={"namespace": ""})
+        context = Context(config=Config({"namespace": ""}))
         fqn = context.get_fqn("vpc")
         self.assertEqual(fqn, "vpc")
+        self.assertEqual(context.tags, {})
 
-    def test_context_get_fqn_missing_namespace(self):
-        context = Context(config={}, environment={})
-        with self.assertRaises(MissingConfig):
-            context.get_fqn("stack")
+    def test_context_namespace(self):
+        context = Context(config=Config({"namespace": "namespace"}))
+        self.assertEqual(context.namespace, "namespace")
 
     def test_context_get_fqn_stack_name(self):
-        context = Context(self.environment)
+        context = Context(config=self.config)
         fqn = context.get_fqn("stack1")
         self.assertEqual(fqn, "namespace-stack1")
 
     def test_context_default_bucket_name(self):
-        context = Context({"namespace": "test"})
-        context.load_config("""mappings:""")
+        context = Context(config=Config({"namespace": "test"}))
         self.assertEqual(context.bucket_name, "stacker-test")
 
-    def test_context_register_custom_lookups(self):
-        context = Context({"namespace": "test"})
-        config = """
-            lookups:
-                custom: importlib.import_module
-        """
-        context.load_config(config)
-        self.assertTrue(callable(LOOKUP_HANDLERS["custom"]))
-
     def test_context_bucket_name_is_overriden_but_is_none(self):
-        context = Context({"namespace": "test"})
-        context.load_config("""stacker_bucket:""")
+        config = Config({"namespace": "test", "stacker_bucket": ""})
+        context = Context(config=config)
+        self.assertEqual(context.bucket_name, "stacker-test")
+
+        config = Config({"namespace": "test", "stacker_bucket": None})
+        context = Context(config=config)
         self.assertEqual(context.bucket_name, "stacker-test")
 
     def test_context_bucket_name_is_overriden(self):
-        context = Context({"namespace": "test"})
-        context.load_config("""stacker_bucket: bucket123""")
+        config = Config({"namespace": "test", "stacker_bucket": "bucket123"})
+        context = Context(config=config)
         self.assertEqual(context.bucket_name, "bucket123")
 
     def test_context_namespace_delimiter_is_overriden_and_not_none(self):
-        context = Context({"namespace": "namespace"})
-        context.load_config("""namespace_delimiter: '_'""")
+        config = Config({"namespace": "namespace", "namespace_delimiter": "_"})
+        context = Context(config=config)
         fqn = context.get_fqn("stack1")
         self.assertEqual(fqn, "namespace_stack1")
 
     def test_context_namespace_delimiter_is_overriden_and_is_empty(self):
-        context = Context({"namespace": "namespace"})
-        context.load_config("""namespace_delimiter: ''""")
+        config = Config({"namespace": "namespace", "namespace_delimiter": ""})
+        context = Context(config=config)
         fqn = context.get_fqn("stack1")
         self.assertEqual(fqn, "namespacestack1")
 
-    def test_context_tags(self):
-        context = Context({"namespace": "test", "dynamic_context": "baz"})
-        context.load_config("""
-        tags:
-            "a:b": "c"
-            "hello": 1
-            "test_dynamic": ${dynamic_context}
-            simple_tag: simple value
-        """)
-        self.assertEqual(context.tags, {
-            "a:b": "c",
-            "hello": "1",
-            "test_dynamic": "baz",
-            "simple_tag": "simple value"
-        })
-
     def test_context_tags_with_empty_map(self):
-        context = Context({"namespace": "test"})
-        context.load_config("""tags: {}""")
+        config = Config({"namespace": "test", "tags": {}})
+        context = Context(config=config)
         self.assertEqual(context.tags, {})
 
     def test_context_no_tags_specified(self):
-        context = Context({"namespace": "test"})
+        config = Config({"namespace": "test"})
+        context = Context(config=config)
         self.assertEqual(context.tags, {"stacker_namespace": "test"})
 
-    def test_load_config_adds_sys_path(self):
-        context = Context({"namespace": "test"})
-        p = "/foo/bar"
-        context.load_config("sys_path: %s" % p)
-        self.assertIn(p, sys.path)
-
-    def test_lookup_with_sys_path(self):
-        context = Context({"namespace": "test"})
-        config = textwrap.dedent("""\
-            sys_path: stacker/tests
-            lookups:
-              custom: fixtures.mock_lookups.handler
-        """)
-        context.load_config(config)
-        self.assertTrue(callable(LOOKUP_HANDLERS["custom"]))
-
     def test_hook_with_sys_path(self):
-        config = textwrap.dedent("""\
-            sys_path: stacker/tests
-            pre_build:
-              - data_key: myHook
-                path: fixtures.mock_hooks.mock_hook
-                required: True
-                args:
-                  value: mockResult
-        """)
-        context = Context({"namespace": "test"})
-        context.load_config(config)
+        config = Config({
+            "namespace": "test",
+            "sys_path": "stacker/tests",
+            "pre_build": [
+                {
+                    "data_key": "myHook",
+                    "path": "fixtures.mock_hooks.mock_hook",
+                    "required": True,
+                    "args": {
+                        "value": "mockResult"}}]})
+        load(config)
+        context = Context(config=config)
         stage = "pre_build"
         handle_hooks(stage, context.config[stage], "mock-region-1", context)
         self.assertEqual("mockResult", context.hook_data["myHook"]["result"])
@@ -183,3 +143,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(get_fqn(base, '-', name), "%s-%s" % (base, name))
         self.assertEqual(get_fqn(base, '', name), "%s%s" % (base, name))
         self.assertEqual(get_fqn(base, '_', name), "%s_%s" % (base, name))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -3,6 +3,7 @@ import unittest
 import mock
 
 from stacker.context import Context
+from stacker.context import Config
 from stacker.exceptions import ImproperlyConfigured, FailedVariableLookup
 from stacker.lookups.registry import (
     register_lookup_handler,
@@ -31,7 +32,8 @@ count = 0
 class TestStep(unittest.TestCase):
 
     def setUp(self):
-        self.context = Context({"namespace": "namespace"})
+        self.config = Config({"namespace": "namespace"})
+        self.context = Context(config=self.config)
         stack = Stack(
             definition=generate_definition("vpc", 1),
             context=self.context,
@@ -56,8 +58,8 @@ class TestPlan(unittest.TestCase):
 
     def setUp(self):
         self.count = 0
-        self.environment = {"namespace": "namespace"}
-        self.context = Context(self.environment)
+        self.config = Config({"namespace": "namespace"})
+        self.context = Context(config=self.config)
         register_lookup_handler("noop", lambda **kwargs: "test")
 
     def tearDown(self):

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -2,7 +2,8 @@ from mock import MagicMock
 import unittest
 
 from stacker.context import Context
-from stacker.stack import _gather_variables, Stack
+from stacker.config import Config
+from stacker.stack import Stack
 from .factories import generate_definition
 
 
@@ -10,7 +11,8 @@ class TestStack(unittest.TestCase):
 
     def setUp(self):
         self.sd = {"name": "test"}
-        self.context = Context({"namespace": "namespace"})
+        self.config = Config({"namespace": "namespace"})
+        self.context = Context(config=self.config)
         self.stack = Stack(
             definition=generate_definition("vpc", 1),
             context=self.context,
@@ -70,9 +72,3 @@ class TestStack(unittest.TestCase):
         self.assertEqual(len(stack.parameter_values.keys()), 1)
         param = stack.parameter_values["Param2"]
         self.assertEqual(param, "Some Resolved Value")
-
-    def test_gather_variables_fails_on_parameters_in_stack_def(self):
-        sdef = self.sd
-        sdef["parameters"] = {"Address": "10.0.0.1", "Foo": "BAR"}
-        with self.assertRaises(AttributeError):
-            _gather_variables(sdef)

--- a/stacker/tests/test_stacker.py
+++ b/stacker/tests/test_stacker.py
@@ -1,6 +1,7 @@
 import unittest
 
 from stacker.commands import Stacker
+from stacker.exceptions import InvalidConfig
 
 
 class TestStacker(unittest.TestCase):
@@ -85,6 +86,9 @@ class TestStacker(unittest.TestCase):
              "stacker/tests/fixtures/basic.env",
              "stacker/tests/fixtures/vpc-bastion-db-web-pre-1.0.yaml"]
         )
-        stacker.configure(args)
-        with self.assertRaises(AttributeError):
-            args.context.get_stacks_dict()
+        with self.assertRaises(InvalidConfig):
+            stacker.configure(args)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
While I was working on adding the [functional test suite](https://github.com/remind101/stacker/pull/439), I encountered a lot of scenarios where you could provide stacker with an invalid config file and get back ugly and confusing errors.

This implements a structured `stacker.config.Config` object, which would replace the unstructed dict returned from `parse_config` that we pass to `stacker.Context`. `stacker.config.Config` is a first class object that represents the stacker config format in Python, and can be pre-validated for sanity (e.g. `namespace` key is provided, `stacks` isn't empty, each stack has a `name` and `class_path`, etc).

You could also use this as a consumer of stacker to generate valid stacker config files (almost like troposphere for stacker). For example:

```python
#!/usr/bin/env python

from stacker.config import dump, Config, Stack

vpc = Stack({
    "name": "vpc",
    "class_path": "blueprints.VPC"})

bastion = Stack({
    "name": "bastion",
    "class_path": "blueprints.Bastion",
    "variables": {
        "VpcId": "${output vpc::VpcId}"}})

config = Config()
config.namespace = "prod"
config.stacks = [vpc, bastion]

config.validate()

print dump(config)
```

```console
$ ./gen.py | stacker build -
```