### PR TITLE
Cleanup help text for `environment` argument

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -50,8 +50,8 @@ S3 Bucket
 Stacker, by default, pushes your CloudFormation templates into an S3 bucket
 and points CloudFormation at the template in that bucket when launching or
 updating your stacks. By default it uses a bucket named
-**stacker-${namespace}**, where the namespace is the namespace provided in the
-`environment <environments.html>`_ file.
+**stacker-${namespace}**, where the namespace is the namespace provided the
+config.
 
 If you want to change this, provide the **stacker_bucket** top level key word
 in the config.

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -141,8 +141,7 @@ class BaseCommand(object):
                  "values in the environment file can be used in the stack "
                  "config as if it were a string.Template type: "
                  "https://docs.python.org/2/library/"
-                 "string.html#template-strings. Must define at least a "
-                 "\"namespace\".")
+                 "string.html#template-strings.")
         parser.add_argument(
             "config", type=argparse.FileType(),
             help="The config file where stack configuration is located. Must "


### PR DESCRIPTION
Missed this in https://github.com/remind101/stacker/pull/436. `namespace` isn't required inside the environment file, since it was moved to [stacker.confg.Config](https://github.com/remind101/stacker/blob/e7e0e02575bbbc162249af7ceb2418f50b9b06d2/stacker/config/__init__.py#L253).