### PR TITLE
Add stack specific tags

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -234,6 +234,9 @@ A stack has the following keys:
   (optional) a list of other stacks this stack requires. This is for explicit
   dependencies - you do not need to set this if you refer to another stack in
   a Parameter, so this is rarely necessary.
+**tags:**
+  (optional) a dictionary of CloudFormation tags to apply to this stack. This
+  will be combined with the global tags, but these tags will take precendence.
 
 Here's an example from stacker_blueprints_, used to create a VPC::
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -22,6 +22,12 @@ from ..status import (
 logger = logging.getLogger(__name__)
 
 
+def build_stack_tags(stack):
+    """Builds a common set of tags to attach to a stack"""
+    return [
+        {'Key': t[0], 'Value': t[1]} for t in stack.tags.items()]
+
+
 def should_update(stack):
     """Tests whether a stack should be submitted for updates to CF.
 
@@ -194,11 +200,6 @@ class Action(BaseAction):
              'ParameterValue': str(p[1])} for p in parameters
         ]
 
-    def _build_stack_tags(self, stack):
-        """Builds a common set of tags to attach to a stack"""
-        return [
-            {'Key': t[0], 'Value': t[1]} for t in self.context.tags.items()]
-
     def _launch_stack(self, stack, **kwargs):
         """Handles the creating or updating of a stack in CloudFormation.
 
@@ -233,7 +234,7 @@ class Action(BaseAction):
 
         logger.debug("Launching stack %s now.", stack.fqn)
         template_url = self.s3_stack_push(stack.blueprint)
-        tags = self._build_stack_tags(stack)
+        tags = build_stack_tags(stack)
         parameters = self.build_parameters(stack, provider_stack)
 
         new_status = None

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -217,6 +217,8 @@ class Stack(Model):
 
     parameters = DictType(AnyType, serialize_when_none=False)
 
+    tags = DictType(StringType, serialize_when_none=False)
+
     def validate_parameters(self, data, value):
         if value:
             stack_name = data['name']
@@ -279,7 +281,8 @@ class Config(Model):
 
     lookups = DictType(StringType, serialize_when_none=False)
 
-    stacks = ListType(ModelType(Stack), default=[], validators=[not_empty_list])
+    stacks = ListType(
+        ModelType(Stack), default=[], validators=[not_empty_list])
 
     def validate(self):
         try:

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -116,6 +116,19 @@ class Stack(object):
         return self._blueprint
 
     @property
+    def tags(self):
+        """Returns the tags that should be set on this stack. Includes both the
+        global tags, as well as any stack specific tags or overrides.
+
+        Returns:
+
+            dict: dictionary of tags
+
+        """
+        tags = self.definition.tags or {}
+        return dict(self.context.tags, **tags)
+
+    @property
     def parameter_values(self):
         """Return all CloudFormation Parameters for the stack.
 

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -72,3 +72,36 @@ class TestStack(unittest.TestCase):
         self.assertEqual(len(stack.parameter_values.keys()), 1)
         param = stack.parameter_values["Param2"]
         self.assertEqual(param, "Some Resolved Value")
+
+    def test_stack_tags_default(self):
+        self.config.tags = {"environment": "prod"}
+        definition = generate_definition(
+            base_name="vpc",
+            stack_id=1
+        )
+        stack = Stack(definition=definition, context=self.context)
+        self.assertEquals(stack.tags, {"environment": "prod"})
+
+    def test_stack_tags_override(self):
+        self.config.tags = {"environment": "prod"}
+        definition = generate_definition(
+            base_name="vpc",
+            stack_id=1,
+            tags={"environment": "stage"}
+        )
+        stack = Stack(definition=definition, context=self.context)
+        self.assertEquals(stack.tags, {"environment": "stage"})
+
+    def test_stack_tags_extra(self):
+        self.config.tags = {"environment": "prod"}
+        definition = generate_definition(
+            base_name="vpc",
+            stack_id=1,
+            tags={"app": "graph"}
+        )
+        stack = Stack(definition=definition, context=self.context)
+        self.assertEquals(stack.tags, {"environment": "prod", "app": "graph"})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes https://github.com/remind101/stacker/issues/172

This adds a `tags` option to `stacker.config.Stack`, so that you can set stack specific tags.