### PR TITLE
Allow directly uploading templates to CloudFormation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -83,6 +83,13 @@ the region where you want to create the bucket.
   as described above. You can specify this keyword now to remove the
   deprecation warning.
 
+If you want stacker to upload templates directly to CloudFormation, instead of
+first uploading to S3, you can set **stacker_bucket** to an empty string.
+However, note that template size is greatly limited when uploading directly.
+See the `CloudFormation Limits Reference`_.
+
+.. _`CloudFormation Limits Reference`: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
+
 Module Paths
 ----------------
 When setting the ``classpath`` for blueprints/hooks, it is sometimes desirable to

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -1,6 +1,7 @@
 import logging
 
 from .base import BaseAction
+from ..providers.base import Template
 from .. import util
 from ..exceptions import (
     MissingParameterException,
@@ -233,7 +234,7 @@ class Action(BaseAction):
         stack.resolve(self.context, self.provider)
 
         logger.debug("Launching stack %s now.", stack.fqn)
-        template_url = self.s3_stack_push(stack.blueprint)
+        template = self._template(stack.blueprint)
         tags = build_stack_tags(stack)
         parameters = self.build_parameters(stack, provider_stack)
 
@@ -241,7 +242,7 @@ class Action(BaseAction):
         if not provider_stack:
             new_status = SubmittedStatus("creating new stack")
             logger.debug("Creating new stack: %s", stack.fqn)
-            self.provider.create_stack(stack.fqn, template_url, parameters,
+            self.provider.create_stack(stack.fqn, template, parameters,
                                        tags)
         else:
             if not should_update(stack):
@@ -249,13 +250,26 @@ class Action(BaseAction):
             try:
                 new_status = SubmittedStatus("updating existing stack")
                 existing_params = provider_stack.get('Parameters', [])
-                self.provider.update_stack(stack.fqn, template_url,
+                self.provider.update_stack(stack.fqn, template,
                                            existing_params, parameters, tags)
                 logger.debug("Updating existing stack: %s", stack.fqn)
             except StackDidNotChange:
                 return DidNotChangeStatus()
 
         return new_status
+
+    def _template(self, blueprint):
+        """Generates a suitable template based on whether or not an S3 bucket
+        is set.
+
+        If an S3 bucket is set, then the template will be uploaded to S3 first,
+        and CreateStack/UpdateStack operations will use the uploaded template.
+        If not bucket is set, then the template will be inlined.
+        """
+        if self.bucket_name:
+            return Template(url=self.s3_stack_push(blueprint))
+        else:
+            return Template(body=blueprint.rendered)
 
     def _generate_plan(self, tail=False):
         plan_kwargs = {}

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -66,8 +66,32 @@ class Context(object):
 
     @property
     def bucket_name(self):
+        if not self.upload_templates_to_s3:
+            return None
+
         return self.config.stacker_bucket \
-                or "stacker-%s" % (self.get_fqn(),)
+            or "stacker-%s" % (self.get_fqn(),)
+
+    @property
+    def upload_templates_to_s3(self):
+        # Don't upload stack templates to S3 if `stacker_bucket` is explicitly
+        # set to an empty string.
+        if self.config.stacker_bucket == '':
+            logger.debug("Not uploading templates to s3 because "
+                         "`stacker_bucket` is explicity set to an "
+                         "empty string")
+            return False
+
+        # If no namespace is specificied, and there's no explicit stacker
+        # bucket specified, don't upload to s3. This makes sense because we
+        # can't realistically auto generate a stacker bucket name in this case.
+        if not self.namespace and not self.config.stacker_bucket:
+            logger.debug("Not uploading templates to s3 because "
+                         "there is no namespace set, and no "
+                         "stacker_bucket set")
+            return False
+
+        return True
 
     @property
     def tags(self):

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -16,6 +16,22 @@ logger = logging.getLogger(__name__)
 MAX_TAIL_RETRIES = 5
 
 
+def template_args(template):
+    """Given a template object, this will return a dict that can be used in
+    CreateStack/UpdateStack calls, based on whether or not the template is
+    inline, or uploaded to S3.
+
+    Args:
+        template (:class:`stacker.providers.base.Template`): The template
+            object.
+
+    """
+    if template.url:
+        return {'TemplateURL': template.url}
+    else:
+        return {'TemplateBody': template.body}
+
+
 def get_output_dict(stack):
     """Returns a dict of key/values for the outputs for a given CF stack.
 
@@ -235,44 +251,46 @@ class Provider(BaseProvider):
                             kwargs=dict(StackName=self.get_stack_name(stack)))
         return True
 
-    def create_stack(self, fqn, template_url, parameters, tags, **kwargs):
+    def create_stack(self, fqn, template, parameters, tags, **kwargs):
         try:
             logger.debug("Stack %s not found, creating.", fqn)
             logger.debug("Using parameters: %s", parameters)
             logger.debug("Using tags: %s", tags)
-            logger.debug("Using template_url: %s", template_url)
+            if template.url:
+                logger.debug("Using template_url: %s", template.url)
+            args = dict(StackName=fqn,
+                        Parameters=parameters,
+                        Tags=tags,
+                        Capabilities=["CAPABILITY_NAMED_IAM"])
             retry_on_throttling(
                 self.cloudformation.create_stack,
-                kwargs=dict(StackName=fqn,
-                            TemplateURL=template_url,
-                            Parameters=parameters,
-                            Tags=tags,
-                            Capabilities=["CAPABILITY_NAMED_IAM"]),
+                kwargs=dict(args, **template_args(template)),
             )
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Message'] == ('TemplateURL must reference '
                                                   'a valid S3 object to which '
                                                   'you have access.'):
-                s3_fallback(fqn, template_url, parameters, tags,
+                s3_fallback(fqn, template.url, parameters, tags,
                             self.cloudformation.create_stack)
             else:
                 raise
         return True
 
-    def update_stack(self, fqn, template_url, old_parameters, parameters,
+    def update_stack(self, fqn, template, old_parameters, parameters,
                      tags, **kwargs):
+        args = dict(StackName=fqn,
+                    Parameters=parameters,
+                    Tags=tags,
+                    Capabilities=["CAPABILITY_NAMED_IAM"])
         try:
             logger.debug("Attempting to update stack %s.", fqn)
             logger.debug("Using parameters: %s", parameters)
             logger.debug("Using tags: %s", tags)
-            logger.debug("Using template_url: %s", template_url)
+            if template.url:
+                logger.debug("Using template_url: %s", template.url)
             retry_on_throttling(
                 self.cloudformation.update_stack,
-                kwargs=dict(StackName=fqn,
-                            TemplateURL=template_url,
-                            Parameters=parameters,
-                            Tags=tags,
-                            Capabilities=["CAPABILITY_NAMED_IAM"]),
+                kwargs=dict(args, **template_args(template)),
             )
         except botocore.exceptions.ClientError as e:
             if "No updates are to be performed." in e.message:
@@ -285,7 +303,7 @@ class Provider(BaseProvider):
                                                     'reference a valid '
                                                     'S3 object to which '
                                                     'you have access.'):
-                s3_fallback(fqn, template_url, parameters, tags,
+                s3_fallback(fqn, template.url, parameters, tags,
                             self.cloudformation.update_stack)
             else:
                 raise

--- a/stacker/providers/base.py
+++ b/stacker/providers/base.py
@@ -31,3 +31,16 @@ class BaseProvider(object):
     def get_output(self, stack_name, output):
         # pylint: disable=unused-argument
         return self.get_outputs(stack_name)[output]
+
+
+class Template(object):
+    """A value object that represents a CloudFormation stack template, which
+    could be optionally uploaded to s3.
+
+    Presence of the url attribute indicates that the template was uploaded to
+    S3, and the uploaded template should be used for CreateStack/UpdateStack
+    calls.
+    """
+    def __init__(self, url=None, body=None):
+        self.url = url
+        self.body = body

--- a/stacker/tests/providers/aws/test_interactive.py
+++ b/stacker/tests/providers/aws/test_interactive.py
@@ -9,6 +9,7 @@ import boto3
 
 from ....actions.diff import DictValue
 
+from ....providers.base import Template
 from ....providers.aws.interactive import (
     Provider,
     requires_replacement,
@@ -252,7 +253,7 @@ class TestInteractiveProviderMethods(unittest.TestCase):
             with self.assertRaises(exceptions.StackDidNotChange):
                 create_change_set(
                     cfn_client=self.cfn, fqn="my-fake-stack",
-                    template_url="http://fake.template.url.com/",
+                    template=Template(url="http://fake.template.url.com/"),
                     parameters=[], tags=[]
                 )
 
@@ -273,7 +274,7 @@ class TestInteractiveProviderMethods(unittest.TestCase):
             with self.assertRaises(exceptions.UnhandledChangeSetStatus):
                 create_change_set(
                     cfn_client=self.cfn, fqn="my-fake-stack",
-                    template_url="http://fake.template.url.com/",
+                    template=Template(url="http://fake.template.url.com/"),
                     parameters=[], tags=[]
                 )
 
@@ -294,7 +295,7 @@ class TestInteractiveProviderMethods(unittest.TestCase):
             with self.assertRaises(exceptions.UnableToExecuteChangeSet):
                 create_change_set(
                     cfn_client=self.cfn, fqn="my-fake-stack",
-                    template_url="http://fake.template.url.com/",
+                    template=Template(url="http://fake.template.url.com/"),
                     parameters=[], tags=[]
                 )
 
@@ -334,7 +335,7 @@ class TestInteractiveProvider(unittest.TestCase):
         with self.stubber:
             self.provider.update_stack(
                 fqn="my-fake-stack",
-                template_url="http://fake.template.url.com/",
+                template=Template(url="http://fake.template.url.com/"),
                 old_parameters=[],
                 parameters=[], tags=[]
             )
@@ -367,7 +368,7 @@ class TestInteractiveProvider(unittest.TestCase):
         with self.stubber:
             self.provider.update_stack(
                 fqn="my-fake-stack",
-                template_url="http://fake.template.url.com/",
+                template=Template(url="http://fake.template.url.com/"),
                 old_parameters=[],
                 parameters=[], tags=[], diff=True
             )

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -71,7 +71,7 @@ class TestContext(unittest.TestCase):
     def test_context_bucket_name_is_overriden_but_is_none(self):
         config = Config({"namespace": "test", "stacker_bucket": ""})
         context = Context(config=config)
-        self.assertEqual(context.bucket_name, "stacker-test")
+        self.assertEqual(context.bucket_name, None)
 
         config = Config({"namespace": "test", "stacker_bucket": None})
         context = Context(config=config)
@@ -81,6 +81,17 @@ class TestContext(unittest.TestCase):
         config = Config({"namespace": "test", "stacker_bucket": "bucket123"})
         context = Context(config=config)
         self.assertEqual(context.bucket_name, "bucket123")
+
+    def test_context_default_bucket_no_namespace(self):
+        context = Context(config=Config({"namespace": ""}))
+        self.assertEqual(context.bucket_name, None)
+
+        context = Context(config=Config({"namespace": None}))
+        self.assertEqual(context.bucket_name, None)
+
+        context = Context(
+            config=Config({"namespace": None, "stacker_bucket": ""}))
+        self.assertEqual(context.bucket_name, None)
 
     def test_context_namespace_delimiter_is_overriden_and_not_none(self):
         config = Config({"namespace": "namespace", "namespace_delimiter": "_"})

--- a/tests/stacker.yaml.sh
+++ b/tests/stacker.yaml.sh
@@ -2,6 +2,7 @@
 
 cat - <<EOF
 namespace: ${STACKER_NAMESPACE}
+stacker_bucket: '' # No need to upload to S3
 stacks:
   - name: stackerFunctionalTests
     class_path: stacker.tests.fixtures.mock_blueprints.FunctionalTests

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -196,7 +196,6 @@ EOF
   config() {
     cat <<EOF
 namespace: ""
-stacker_bucket: stacker-${STACKER_NAMESPACE}
 stacks:
   - name: ${STACKER_NAMESPACE}-vpc
     class_path: stacker.tests.fixtures.mock_blueprints.Dummy


### PR DESCRIPTION
I think this would help with https://github.com/remind101/stacker/issues/288, and make the "first run" experience with stacker a little more pleasant. In most cases, your templates will eventually get large enough that you want to always upload them to S3, but it's nice to be able to play around with stacker without leaving zombie buckets around, or worrying about namespace collisions.

If `stacker_bucket` is explicitly set to `""`, then templates won't be uploaded to S3. Also, if there's no namespace set, and no `stacker_bucket` set, then it will default to this behavior, since we can't auto generate a bucket name. This makes the simplest working stacker config/command:

```console
$ cat <<-EOF | stacker build -
namespace: ''
stacks:
- name: dummy-vpc
  class_path: stacker.tests.fixtures.mock_blueprints.Dummy
EOF
```

Which will work for anyone (no bucket/namespace clashing).