### PR TITLE
add remote config support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -182,7 +182,8 @@ the build action::
 Dictionary Hook Paths
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Hooks can also be defined as a dictionary::
+Hooks can also be defined as a dictionary (as long as their execution order
+isn't important)::
 
   pre_build:
     my_route53_hook:

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -145,6 +145,27 @@ In this example, the configuration in ``vpc.yaml`` will be merged into the
 running current configuration, with the current configuration's values taking
 priority over the values in ``vpc.yaml``.
 
+Dictionary Stack Names & Hook Paths
+:::::::::::::::::::::::::::::::::::
+To allow remote configs to be selectively overriden, stack names & hook
+paths can optionally be defined as dictionaries, e.g.::
+
+  pre_build:
+    my_route53_hook:
+      path: stacker.hooks.route53.create_domain:
+      required: true
+      args:
+        domain: mydomain.com
+  stacks:
+    vpc-example:
+      class_path: stacker_blueprints.vpc.VPC
+      locked: false
+      enabled: true
+    bastion-example:
+      class_path: stacker_blueprints.bastion.Bastion
+      locked: false
+      enabled: true
+
 Pre & Post Hooks
 ----------------
 
@@ -178,22 +199,6 @@ the build action::
       required: true
       args:
         domain: mydomain.com
-
-Dictionary Hook Paths
-~~~~~~~~~~~~~~~~~~~~~~
-
-Hooks can also be defined as a dictionary (as long as their execution order
-isn't important)::
-
-  pre_build:
-    my_route53_hook:
-      path: stacker.hooks.route53.create_domain:
-      required: true
-      args:
-        domain: mydomain.com
-
-This is useful when working with `Remote Configs`_ to allow the merging of
-remote and local configuration values.
 
 Tags
 ----
@@ -327,24 +332,6 @@ Here's an example from stacker_blueprints_, used to create a VPC::
           - 10.128.16.0/22
           - 10.128.20.0/22
         CidrBlock: 10.128.0.0/16
-
-Dictionary Stack Names
-~~~~~~~~~~~~~~~~~~~~~~
-
-The *stacks* top level keyword can also be defined as a dictionary::
-
-  stacks:
-    vpc-example:
-      class_path: stacker_blueprints.vpc.VPC
-      locked: false
-      enabled: true
-    bastion-example:
-      class_path: stacker_blueprints.bastion.Bastion
-      locked: false
-      enabled: true
-
-This is useful when working with `Remote Configs`_ to allow the merging of
-remote and local configuration values.
 
 Variables
 ==========

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -130,6 +130,21 @@ Cloned repositories will be cached between builds; the cache location defaults
 to ~/.stacker but can be manually specified via the **stacker_cache_dir** top
 level keyword.
 
+Remote Configs
+~~~~~~~~~~~~~~
+Configuration yamls from remote configs can also be used by specifying a list
+of ``configs`` in the repo to use::
+
+    package_sources:
+      git:
+        - uri: git@github.com:acmecorp/stacker_blueprints.git
+          configs:
+            - vpc.yaml
+
+In this example, the configuration in ``vpc.yaml`` will be merged into the
+running current configuration, with the current configuration's values taking
+priority over the values in ``vpc.yaml``.
+
 Pre & Post Hooks
 ----------------
 
@@ -163,6 +178,21 @@ the build action::
       required: true
       args:
         domain: mydomain.com
+
+Dictionary Hook Paths
+~~~~~~~~~~~~~~~~~~~~~~
+
+Hooks can also be defined as a dictionary::
+
+  pre_build:
+    my_route53_hook:
+      path: stacker.hooks.route53.create_domain:
+      required: true
+      args:
+        domain: mydomain.com
+
+This is useful when working with `Remote Configs`_ to allow the merging of
+remote and local configuration values.
 
 Tags
 ----
@@ -297,6 +327,23 @@ Here's an example from stacker_blueprints_, used to create a VPC::
           - 10.128.20.0/22
         CidrBlock: 10.128.0.0/16
 
+Dictionary Stack Names
+~~~~~~~~~~~~~~~~~~~~~~
+
+The *stacks* top level keyword can also be defined as a dictionary::
+
+  stacks:
+    vpc-example:
+      class_path: stacker_blueprints.vpc.VPC
+      locked: false
+      enabled: true
+    bastion-example:
+      class_path: stacker_blueprints.bastion.Bastion
+      locked: false
+      enabled: true
+
+This is useful when working with `Remote Configs`_ to allow the merging of
+remote and local configuration values.
 
 Variables
 ==========

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -6,7 +6,8 @@ from stacker.config import (
     load,
     render,
     parse,
-    dump
+    dump,
+    process_remote_sources
 )
 from stacker.config import Config, Stack
 from stacker.environment import parse_environment
@@ -368,6 +369,15 @@ stacks:
         config = Config({"sys_path": "/foo/bar"})
         load(config)
         self.assertIn("/foo/bar", sys.path)
+
+    def test_process_empty_remote_sources(self):
+        config = """
+        namespace: prod
+        stacks:
+          - name: vpc
+            class_path: blueprints.VPC
+        """
+        self.assertEqual(config, process_remote_sources(config))
 
     def test_lookup_with_sys_path(self):
         config = Config({

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -171,7 +171,7 @@ stacks: []
         config.validate()
 
     def test_parse(self):
-        config = parse("""
+        config_with_lists = """
         namespace: prod
         stacker_bucket: stacker-prod
         pre_build:
@@ -218,52 +218,116 @@ stacks: []
           requires: ['vpc']
           variables:
             VpcId: ${output vpc::VpcId}
-        """)
+        """
+        config_with_dicts = """
+        namespace: prod
+        stacker_bucket: stacker-prod
+        pre_build:
+          prebuild_createdomain:
+            path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        post_build:
+          postbuild_createdomain:
+            path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        pre_destroy:
+          predestroy_createdomain:
+            path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        post_destroy:
+          postdestroy_createdomain:
+            path: stacker.hooks.route53.create_domain
+            required: true
+            args:
+              domain: mydomain.com
+        package_sources:
+          git:
+            - uri: git@github.com:acmecorp/stacker_blueprints.git
+            - uri: git@github.com:remind101/stacker_blueprints.git
+              tag: 1.0.0
+              paths:
+                - stacker_blueprints
+            - uri: git@github.com:contoso/webapp.git
+              branch: staging
+            - uri: git@github.com:contoso/foo.git
+              commit: 12345678
+        tags:
+          environment: production
+        stacks:
+          vpc:
+            class_path: blueprints.VPC
+            variables:
+              PrivateSubnets:
+              - 10.0.0.0/24
+          bastion:
+            class_path: blueprints.Bastion
+            requires: ['vpc']
+            variables:
+              VpcId: ${output vpc::VpcId}
+        """
 
-        config.validate()
+        for raw_config in [config_with_lists, config_with_dicts]:
+            config = parse(raw_config)
 
-        self.assertEqual(config.namespace, "prod")
-        self.assertEqual(config.stacker_bucket, "stacker-prod")
+            config.validate()
 
-        for hooks in [config.pre_build, config.post_build,
-                      config.pre_destroy, config.post_destroy]:
+            self.assertEqual(config.namespace, "prod")
+            self.assertEqual(config.stacker_bucket, "stacker-prod")
+
+            for hooks in [config.pre_build, config.post_build,
+                          config.pre_destroy, config.post_destroy]:
+                self.assertEqual(
+                    hooks[0].path, "stacker.hooks.route53.create_domain")
+                self.assertEqual(
+                    hooks[0].required, True)
+                self.assertEqual(
+                    hooks[0].args, {"domain": "mydomain.com"})
+
             self.assertEqual(
-                hooks[0].path, "stacker.hooks.route53.create_domain")
+                config.package_sources.git[0].uri,
+                "git@github.com:acmecorp/stacker_blueprints.git")
             self.assertEqual(
-                hooks[0].required, True)
+                config.package_sources.git[1].uri,
+                "git@github.com:remind101/stacker_blueprints.git")
             self.assertEqual(
-                hooks[0].args, {"domain": "mydomain.com"})
+                config.package_sources.git[1].tag,
+                "1.0.0")
+            self.assertEqual(
+                config.package_sources.git[1].paths,
+                ["stacker_blueprints"])
+            self.assertEqual(
+                config.package_sources.git[2].branch,
+                "staging")
 
-        self.assertEqual(
-            config.package_sources.git[0].uri,
-            "git@github.com:acmecorp/stacker_blueprints.git")
-        self.assertEqual(
-            config.package_sources.git[1].uri,
-            "git@github.com:remind101/stacker_blueprints.git")
-        self.assertEqual(
-            config.package_sources.git[1].tag,
-            "1.0.0")
-        self.assertEqual(
-            config.package_sources.git[1].paths,
-            ["stacker_blueprints"])
-        self.assertEqual(
-            config.package_sources.git[2].branch,
-            "staging")
+            self.assertEqual(config.tags, {"environment": "production"})
 
-        self.assertEqual(config.tags, {"environment": "production"})
+            self.assertEqual(len(config.stacks), 2)
 
-        self.assertEqual(len(config.stacks), 2)
-        vpc = config.stacks[0]
-        self.assertEqual(vpc.name, "vpc")
-        self.assertEqual(vpc.class_path, "blueprints.VPC")
-        self.assertEqual(vpc.requires, None)
-        self.assertEqual(vpc.variables, {"PrivateSubnets": ["10.0.0.0/24"]})
+            vpc_index = next(
+                i for (i, d) in enumerate(config.stacks) if d.name == "vpc"
+            )
+            vpc = config.stacks[vpc_index]
+            self.assertEqual(vpc.name, "vpc")
+            self.assertEqual(vpc.class_path, "blueprints.VPC")
+            self.assertEqual(vpc.requires, None)
+            self.assertEqual(vpc.variables,
+                             {"PrivateSubnets": ["10.0.0.0/24"]})
 
-        bastion = config.stacks[1]
-        self.assertEqual(bastion.name, "bastion")
-        self.assertEqual(bastion.class_path, "blueprints.Bastion")
-        self.assertEqual(bastion.requires, ["vpc"])
-        self.assertEqual(bastion.variables, {"VpcId": "${output vpc::VpcId}"})
+            bastion_index = next(
+                i for (i, d) in enumerate(config.stacks) if d.name == "bastion"
+            )
+            bastion = config.stacks[bastion_index]
+            self.assertEqual(bastion.name, "bastion")
+            self.assertEqual(bastion.class_path, "blueprints.Bastion")
+            self.assertEqual(bastion.requires, ["vpc"])
+            self.assertEqual(bastion.variables,
+                             {"VpcId": "${output vpc::VpcId}"})
 
     def test_dump_complex(self):
         config = Config({

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -15,6 +15,7 @@ from stacker.util import (
     camel_to_snake,
     handle_hooks,
     merge_map,
+    yaml_to_ordered_dict,
     retry_with_backoff,
     get_client_region,
     get_s3_endpoint,
@@ -99,6 +100,18 @@ class TestUtil(unittest.TestCase):
         for t in tests:
             self.assertEqual(merge_map(t[0], t[1]), t[2])
 
+    def test_yaml_to_ordered_dict(self):
+        raw_config = """
+        pre_build:
+          hook2:
+            path: foo.bar
+          hook1:
+            path: foo1.bar1
+        """
+        config = yaml_to_ordered_dict(raw_config)
+        self.assertEqual(config['pre_build'].keys()[0], 'hook2')
+        self.assertEqual(config['pre_build']['hook2']['path'], 'foo.bar')
+
     def test_get_client_region(self):
         regions = ["us-east-1", "us-west-1", "eu-west-1", "sa-east-1"]
         for region in regions:
@@ -132,7 +145,7 @@ class TestUtil(unittest.TestCase):
         with mock.patch.object(SourceProcessor,
                                'create_cache_directories',
                                new=mock_create_cache_directories):
-            sp = SourceProcessor()
+            sp = SourceProcessor(sources={})
 
             self.assertEqual(
                 sp.sanitize_git_path('git@github.com:foo/bar.git'),

--- a/stacker/tests/test_util.py
+++ b/stacker/tests/test_util.py
@@ -14,6 +14,7 @@ from stacker.util import (
     load_object_from_string,
     camel_to_snake,
     handle_hooks,
+    merge_map,
     retry_with_backoff,
     get_client_region,
     get_s3_endpoint,
@@ -66,6 +67,38 @@ class TestUtil(unittest.TestCase):
         for t in tests:
             self.assertEqual(camel_to_snake(t[0]), t[1])
 
+    def test_merge_map(self):
+        tests = [
+            # 2 lists of stacks defined
+            [{'stacks': [{'stack1': {'variables': {'a': 'b'}}}]},
+             {'stacks': [{'stack2': {'variables': {'c': 'd'}}}]},
+             {'stacks': [
+                 {'stack1': {
+                     'variables': {
+                         'a': 'b'}}},
+                 {'stack2': {
+                     'variables': {
+                         'c': 'd'}}}]}],
+            # A list of stacks combined with a higher precedence dict of stacks
+            [{'stacks': [{'stack1': {'variables': {'a': 'b'}}}]},
+             {'stacks': {'stack2': {'variables': {'c': 'd'}}}},
+             {'stacks': {'stack2': {'variables': {'c': 'd'}}}}],
+            # 2 dicts of stacks with non-overlapping variables merged
+            [{'stacks': {'stack1': {'variables': {'a': 'b'}}}},
+             {'stacks': {'stack1': {'variables': {'c': 'd'}}}},
+             {'stacks': {
+                 'stack1': {
+                     'variables': {
+                         'a': 'b',
+                         'c': 'd'}}}}],
+            # 2 dicts of stacks with overlapping variables merged
+            [{'stacks': {'stack1': {'variables': {'a': 'b'}}}},
+             {'stacks': {'stack1': {'variables': {'a': 'c'}}}},
+             {'stacks': {'stack1': {'variables': {'a': 'c'}}}}],
+        ]
+        for t in tests:
+            self.assertEqual(merge_map(t[0], t[1]), t[2])
+
     def test_get_client_region(self):
         regions = ["us-east-1", "us-west-1", "eu-west-1", "sa-east-1"]
         for region in regions:
@@ -110,14 +143,18 @@ class TestUtil(unittest.TestCase):
                 'git_github.com_foo_bar-v1'
             )
 
-            self.assertEqual(
-                sp.determine_git_ls_remote_ref(
-                    GitPackageSource({'branch': 'foo'})),
-                'refs/heads/foo'
-            )
+            for i in [GitPackageSource({'branch': 'foo'}), {'branch': 'foo'}]:
+                self.assertEqual(
+                    sp.determine_git_ls_remote_ref(i),
+                    'refs/heads/foo'
+                )
             for i in [{'uri': 'git@foo'}, {'tag': 'foo'}, {'commit': '1234'}]:
                 self.assertEqual(
                     sp.determine_git_ls_remote_ref(GitPackageSource(i)),
+                    'HEAD'
+                )
+                self.assertEqual(
+                    sp.determine_git_ls_remote_ref(i),
                     'HEAD'
                 )
 
@@ -138,6 +175,8 @@ class TestUtil(unittest.TestCase):
             for i in bad_configs:
                 with self.assertRaises(ImportError):
                     sp.determine_git_ref(GitPackageSource(i))
+                with self.assertRaises(ImportError):
+                    sp.determine_git_ref(i)
 
             self.assertEqual(
                 sp.determine_git_ref(
@@ -152,8 +191,16 @@ class TestUtil(unittest.TestCase):
                 '1234'
             )
             self.assertEqual(
+                sp.determine_git_ref({'uri': 'git@foo', 'commit': '1234'}),
+                '1234'
+            )
+            self.assertEqual(
                 sp.determine_git_ref(
                     GitPackageSource({'uri': 'git@foo', 'tag': 'v1.0.0'})),
+                'v1.0.0'
+            )
+            self.assertEqual(
+                sp.determine_git_ref({'uri': 'git@foo', 'tag': 'v1.0.0'}),
                 'v1.0.0'
             )
 

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -513,7 +513,7 @@ class SourceProcessor():
             stacker_cache_dir (string): Path where remote sources will be
                 cached.
         """
-        if stacker_cache_dir is None:
+        if not stacker_cache_dir:
             stacker_cache_dir = os.path.expanduser("~/.stacker")
         package_cache_dir = os.path.join(stacker_cache_dir, 'packages')
         self.stacker_cache_dir = stacker_cache_dir
@@ -532,9 +532,8 @@ class SourceProcessor():
     def get_package_sources(self):
         """Makes remote python packages available for local use."""
         # Checkout git repositories specified in config
-        if self.sources.get('git'):
-            for config in self.sources['git']:
-                self.fetch_git_package(config=config)
+        for config in self.sources.get('git', []):
+            self.fetch_git_package(config=config)
 
     def fetch_git_package(self, config):
         """Makes a remote git repository available for local use


### PR DESCRIPTION
There are some complex Stacker configs that I'd like to use in many accounts and repositories; this change always them to be referenced centrally and overridden as desired.