### PR TITLE
Potential resolution of Issue #463 `--replacements-only` set, but no `Replacement` key in the ResourceChange back from CFN due to addition only

### DIFF
--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -39,9 +39,11 @@ def requires_replacement(changeset):
         list: A list of changes that require replacement, if any.
 
     """
-    return [r for r in changeset if r["ResourceChange"]["Replacement"] ==
-            'True']
-
+    try:
+        return [r for r in changeset if r["ResourceChange"]["Replacement"] ==
+                'True']
+    except KeyError:
+        pass
 
 def get_raw_input(message):
     """ Just a wrapper for raw_input for testing purposes. """

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -39,11 +39,8 @@ def requires_replacement(changeset):
         list: A list of changes that require replacement, if any.
 
     """
-    try:
-        return [r for r in changeset if r["ResourceChange"]["Replacement"] ==
-                'True']
-    except KeyError:
-        pass
+    return [r for r in changeset if "Replacement" in r["ResourceChange"] and r[
+            "ResourceChange"]["Replacement"] == 'True']
 
 
 def get_raw_input(message):

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -39,8 +39,8 @@ def requires_replacement(changeset):
         list: A list of changes that require replacement, if any.
 
     """
-    return [r for r in changeset if "Replacement" in r["ResourceChange"] and r[
-            "ResourceChange"]["Replacement"] == 'True']
+    return [r for r in changeset if r["ResourceChange"].get(
+            "Replacement", False) == "True"]
 
 
 def get_raw_input(message):

--- a/stacker/providers/aws/interactive.py
+++ b/stacker/providers/aws/interactive.py
@@ -45,6 +45,7 @@ def requires_replacement(changeset):
     except KeyError:
         pass
 
+
 def get_raw_input(message):
     """ Just a wrapper for raw_input for testing purposes. """
     return raw_input(message)

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -109,6 +109,22 @@ class Dummy(Blueprint):
         self.template.add_resource(WaitConditionHandle("Dummy"))
         self.template.add_output(Output("DummyId", Value="dummy-1234"))
 
+class Dummy2(Blueprint):
+    """
+    This blueprint allows tests of only additional resources to occur.
+    Just swap out the Dummy class for Dummy2 on the same stack.
+    """
+    VARIABLES = {
+        "StringVariable": {
+            "type": str,
+            "default": ""}
+    }
+
+    def create_template(self):
+        self.template.add_resource(WaitConditionHandle("Dummy"))
+        self.template.add_output(Output("DummyId", Value="dummy-1234"))
+        self.template.add_resource(WaitConditionHandle("Dummy2"))
+
 
 class VPC(Blueprint):
     VARIABLES = {

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -109,6 +109,7 @@ class Dummy(Blueprint):
         self.template.add_resource(WaitConditionHandle("Dummy"))
         self.template.add_output(Output("DummyId", Value="dummy-1234"))
 
+
 class Dummy2(Blueprint):
     """
     This blueprint allows tests of only additional resources to occur.

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -298,3 +298,53 @@ EOF
   stacker diff <(config)
   assert "$status" -eq 0
 }
+
+@test "stacker build - replacements-only test with additional resource, no keyerror" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: add-resource-test-with-replacements-only
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+
+EOF
+  }
+
+config2() {
+  cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+- name: add-resource-test-with-replacements-only
+  class_path: stacker.tests.fixtures.mock_blueprints.Dummy2
+
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using Default AWS Provider"
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: pending"
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: complete (creating new stack)"
+
+  # Perform a additional resouce addition in replacements-only mode, should not crash
+  stacker build -i --replacements-only <(config2)
+  assert "$status" -eq 0
+  assert_has_line "Using Interactive AWS Provider"
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: pending"
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: complete (updating existing stack)"
+
+  # Cleanup
+  stacker destroy --force <(config2)
+  assert "$status" -eq 0
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: pending"
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: submitted (submitted for destruction)"
+  assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: complete (stack destroyed)"
+}

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -334,7 +334,7 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: submitted (creating new stack)"
   assert_has_line "${STACKER_NAMESPACE}-add-resource-test-with-replacements-only: complete (creating new stack)"
 
-  # Perform a additional resouce addition in replacements-only mode, should not crash
+  # Perform a additional resouce addition in replacements-only mode, should not crash.  This is testing issue #463.
   stacker build -i --replacements-only <(config2)
   assert "$status" -eq 0
   assert_has_line "Using Interactive AWS Provider"


### PR DESCRIPTION
I dug around this a bit, and it seems like this fix would work.  I don't see how this code path would ever not be executed when the --replacmenets-only flag is set.  Perhaps I missed something and this seemed way too easy to resolve (and I don't know what side effects this change will make)

If you were curious, this is what we got back from CFN when I printed it out to the shell in my test:

```
[{u'ResourceChange': {u'Action': 'Add', u'ResourceType': 'AWS::EC2::SecurityGroupIngress', u'Scope': [], u'Details': [], u'LogicalResourceId': 'RuleNumber1'}, u'Type': 'Resource'}]
```
No "Replacements" key existed, so yeah... this nich issue would always happen in this specific scenario.  

Is there another way you would prefer doing this? 