### PR TITLE
Add handling of stack rollbacks and recreations

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -12,13 +12,20 @@ that stack to be finished before updating/creating).
 
 It also provides the *--dump* flag for testing out blueprints before
 pushing them up into CloudFormation.
+Even then, some errors might only be noticed after first submitting a stack,
+at which point it can no longer be updated by Stacker.
+When that situation is detected in interactive mode, you will be prompted to
+delete and re-create the stack, so that you don't need to do it manually in the
+AWS console.
+If that behavior is also desired in non-interactive mode, enable the
+*--recreate-failed* flag.
 
 ::
 
   # stacker build -h
   usage: stacker build [-h] [-e ENV=VALUE] [-r REGION] [-v] [-i]
-                       [--replacements-only] [-o] [--force STACKNAME]
-                       [--stacks STACKNAME] [-t] [-d DUMP]
+                       [--replacements-only] [--recreate-failed] [-o]
+                       [--force STACKNAME] [--stacks STACKNAME] [-t] [-d DUMP]
                        [environment] config
 
   Launches or updates CloudFormation stacks based on the given config. Stacker
@@ -31,7 +38,7 @@ pushing them up into CloudFormation.
                           The values in the environment file can be used in the
                           stack config as if it were a string.Template type:
                           https://docs.python.org/2/library/string.html
-                          #template-strings. Must define at least a "namespace".
+                          #template-strings.
     config                The config file where stack configuration is located.
                           Must be in yaml format. If `-` is provided, then the
                           config will be read from stdin.
@@ -55,6 +62,8 @@ pushing them up into CloudFormation.
                           only" as well.
     --replacements-only   If interactive mode is enabled, stacker will only
                           prompt to authorize replacements.
+    --recreate-failed     Destroy and re-create stacks that are stuck in a
+                          failed state from an initial deployment when updating.
     -o, --outline         Print an outline of what steps will be taken to build
                           the stacks
     --force STACKNAME     If a stackname is provided to --force, it will be

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,8 +1,10 @@
 import copy
 import logging
+import sys
 
 import botocore.exceptions
 from stacker.session_cache import get_session
+from stacker.exceptions import PlanFailed
 
 from stacker.util import (
     ensure_s3_bucket,
@@ -121,9 +123,13 @@ class BaseAction(object):
         return template_url
 
     def execute(self, *args, **kwargs):
-        self.pre_run(*args, **kwargs)
-        self.run(*args, **kwargs)
-        self.post_run(*args, **kwargs)
+        try:
+            self.pre_run(*args, **kwargs)
+            self.run(*args, **kwargs)
+            self.post_run(*args, **kwargs)
+        except PlanFailed as e:
+            logger.error(e.message)
+            sys.exit(1)
 
     def pre_run(self, *args, **kwargs):
         pass

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -290,8 +290,6 @@ class Action(BaseAction):
                 logger.debug("Updating existing stack: %s", stack.fqn)
                 return SubmittedStatus("updating existing stack")
             else:
-                logger.debug("Destroying stack for recreation: %s",
-                             stack.fqn)
                 return SubmittedStatus("destroying stack for re-creation")
         except StackDidNotChange:
             return DidNotChangeStatus()

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -245,6 +245,9 @@ class Action(BaseAction):
                 logger.debug("Stack %s finished deleting", stack.fqn)
                 recreate = True
                 # Continue with creation afterwards
+            # Failure must be checked *before* completion, as both will be true
+            # when completing a rollback, and we don't want to consider it as
+            # a successful update.
             elif self.provider.is_stack_failed(provider_stack):
                 reason = old_status.reason
                 if 'rolling' in reason:

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -28,7 +28,8 @@ class Stacker(BaseCommand):
         options.provider = default.Provider(
             region=options.region,
             interactive=options.interactive,
-            replacements_only=options.replacements_only
+            replacements_only=options.replacements_only,
+            recreate_failed=options.recreate_failed
         )
 
         config = load_config(

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -159,3 +159,7 @@ class BaseCommand(object):
             "--replacements-only", action="store_true",
             help="If interactive mode is enabled, stacker will only prompt to "
                  "authorize replacements.")
+        parser.add_argument(
+            "--recreate-failed", action="store_true",
+            help="Destroy and re-create stacks that are stuck in a failed "
+                 "state from an initial deployment when updating.")

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -195,3 +195,14 @@ class UnableToExecuteChangeSet(Exception):
                    "%s" % (change_set_id, stack_name, execution_status))
 
         super(UnableToExecuteChangeSet, self).__init__(message)
+
+
+class StackUpdateBadStatus(Exception):
+
+    def __init__(self, stack_name, stack_status, reason, *args, **kwargs):
+        self.stack_name = stack_name
+        self.stack_status = stack_status
+
+        message = ("Stack: \"%s\" cannot be updated nor re-created from state "
+                   "%s: %s" % (stack_name, stack_status, reason))
+        super(StackUpdateBadStatus, self).__init__(message, *args, **kwargs)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -214,6 +214,6 @@ class PlanFailed(Exception):
         self.failed_stacks = failed_stacks
 
         stack_names = ', '.join(stack.name for stack in failed_stacks)
-        message = ("The following stacks failed: %s\n" % (stack_names,))
+        message = "The following stacks failed: %s\n" % (stack_names,)
 
         super(PlanFailed, self).__init__(message, *args, **kwargs)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -206,3 +206,15 @@ class StackUpdateBadStatus(Exception):
         message = ("Stack: \"%s\" cannot be updated nor re-created from state "
                    "%s: %s" % (stack_name, stack_status, reason))
         super(StackUpdateBadStatus, self).__init__(message, *args, **kwargs)
+
+
+class PlanFailed(Exception):
+
+    def __init__(self, failed_stacks, *args, **kwargs):
+        self.failed_stacks = failed_stacks
+
+        stack_names = ', '.join(stack.name for stack in failed_stacks)
+        message = ("The following stacks failed their plans: %s\n"
+                   % (stack_names,))
+
+        super(PlanFailed, self).__init__(message, *args, **kwargs)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -214,7 +214,6 @@ class PlanFailed(Exception):
         self.failed_stacks = failed_stacks
 
         stack_names = ', '.join(stack.name for stack in failed_stacks)
-        message = ("The following stacks failed their plans: %s\n"
-                   % (stack_names,))
+        message = ("The following stacks failed: %s\n" % (stack_names,))
 
         super(PlanFailed, self).__init__(message, *args, **kwargs)

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -212,9 +212,10 @@ class Plan(OrderedDict):
             failed = False
             for required_stack in step.requires:
                 if self[required_stack].failed:
-                    logger.debug(
-                        'Failing stack \"%s\" due to failed dependency '
-                        '\"%s\"', step_name, required_stack)
+                    logger.warn(
+                        'Stack \"%s\" cannot be updated, as dependency \"%s\" '
+                        'has failed',
+                        step_name, required_stack)
                     step.set_status(FailedStatus("dependency has failed"))
                     failed = True
                     break

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -363,7 +363,20 @@ def create_change_set(cfn_client, fqn, template, parameters, tags,
     return changes, change_set_id
 
 
-def check_tags_present(actual, expected):
+def check_tags_contain(actual, expected):
+    """Check if a set of AWS resource tags is contained in another
+
+    Every tag key in `expected` must be present in `actual`, and have the same
+    value. Extra keys in `actual` but not in `expected` are ignored.
+
+    Args:
+        actual (list): Set of tags to be verified, usually from the description
+            of a resource. Each item must be a `dict` containing `Key` and
+            `Value` items.
+        expected (list): Set of tags that must be present in `actual` (in the
+            same format).
+    """
+
     actual_set = set((item["Key"], item["Value"]) for item in actual)
     expected_set = set((item["Key"], item["Value"]) for item in expected)
 
@@ -644,7 +657,7 @@ class Provider(BaseProvider):
                 'Re-creation disallowed by user option')
 
         stack_tags = self.get_stack_tags(stack)
-        if not check_tags_present(stack_tags, tags):
+        if not check_tags_contain(stack_tags, tags):
             raise exceptions.StackUpdateBadStatus(
                 stack_name, stack_status,
                 'Tags differ from current configuration, possibly not created '

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -407,6 +407,9 @@ class Provider(BaseProvider):
         "ROLLBACK_COMPLETE",
         "DELETE_FAILED",
         "UPDATE_ROLLBACK_FAILED",
+        # Note: UPDATE_ROLLBACK_COMPLETE is in both the FAILED and COMPLETE
+        # sets, because we need to wait for it when a rollback is triggered,
+        # but still mark the stack as failed.
         "UPDATE_ROLLBACK_COMPLETE",
     )
 

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -652,12 +652,14 @@ class Provider(BaseProvider):
         if not self.is_stack_recreatable(stack):
             raise exceptions.StackUpdateBadStatus(
                 stack_name, stack_status,
-                'Invalid status')
+                'Unsupported state for re-creation')
 
         if not self.recreate_failed:
             raise exceptions.StackUpdateBadStatus(
                 stack_name, stack_status,
-                'Re-creation disallowed by user option')
+                'Stack re-creation is disabled. Run stacker again with the '
+                '--recreate-failed option to force it to be deleted and '
+                'created from scratch.')
 
         stack_tags = self.get_stack_tags(stack)
         if not check_tags_contain(stack_tags, tags):

--- a/stacker/status.py
+++ b/stacker/status.py
@@ -30,6 +30,11 @@ class SkippedStatus(Status):
         super(SkippedStatus, self).__init__("skipped", 3, reason)
 
 
+class FailedStatus(Status):
+    def __init__(self, reason=None):
+        super(FailedStatus, self).__init__("failed", 4, reason)
+
+
 class NotSubmittedStatus(SkippedStatus):
     reason = "disabled"
 
@@ -50,3 +55,4 @@ PENDING = PendingStatus()
 SUBMITTED = SubmittedStatus()
 COMPLETE = CompleteStatus()
 SKIPPED = SkippedStatus()
+FAILED = FailedStatus()

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -12,16 +12,16 @@ from stacker.actions.build import (
 from stacker.blueprints.variables.types import CFNString
 from stacker.context import Context
 from stacker.config import Config
-from stacker.exceptions import (
-    StackDidNotChange,
-    StackDoesNotExist,
-)
+from stacker.exceptions import StackDidNotChange, StackDoesNotExist
 from stacker.providers.base import BaseProvider
+from stacker.providers.aws.default import Provider
 from stacker.status import (
+    NotSubmittedStatus,
     COMPLETE,
     PENDING,
     SKIPPED,
-    SUBMITTED
+    SUBMITTED,
+    FAILED
 )
 
 
@@ -152,68 +152,6 @@ class TestBuildAction(unittest.TestCase):
             build_action.run(outline=False)
             self.assertEqual(mock_generate_plan().execute.call_count, 1)
 
-    def test_launch_stack_step_statuses(self):
-        mock_provider = mock.MagicMock()
-        mock_stack = mock.MagicMock()
-
-        context = self._get_context()
-        build_action = build.Action(context, provider=mock_provider)
-        plan = build_action._generate_plan()
-        _, step = plan.list_pending()[0]
-        step.stack = mock.MagicMock()
-        step.stack.locked = False
-
-        # mock provider shouldn't return a stack at first since it hasn't been
-        # launched
-        mock_provider.get_stack.return_value = None
-        with mock.patch.object(build_action, "s3_stack_push"):
-            # initial status should be PENDING
-            self.assertEqual(step.status, PENDING)
-            # initial run should return SUBMITTED since we've passed off to CF
-            status = step.run()
-            step.set_status(status)
-            self.assertEqual(status, SUBMITTED)
-            self.assertEqual(status.reason, "creating new stack")
-
-            # provider should now return the CF stack since it exists
-            mock_provider.get_stack.return_value = mock_stack
-            # simulate that we're still in progress
-            mock_provider.is_stack_in_progress.return_value = True
-            mock_provider.is_stack_completed.return_value = False
-            mock_provider.is_stack_rolling_back.return_value = False
-            status = step.run()
-            step.set_status(status)
-            # status should still be SUBMITTED since we're waiting for it to
-            # complete
-            self.assertEqual(status, SUBMITTED)
-            self.assertEqual(status.reason, "creating new stack")
-            # simulate completed stack
-            mock_provider.is_stack_completed.return_value = True
-            mock_provider.is_stack_in_progress.return_value = False
-            status = step.run()
-            step.set_status(status)
-            self.assertEqual(status, COMPLETE)
-            self.assertEqual(status.reason, "creating new stack")
-
-            # simulate stack should be skipped
-            mock_provider.is_stack_completed.return_value = False
-            mock_provider.is_stack_in_progress.return_value = False
-            mock_provider.update_stack.side_effect = StackDidNotChange
-            status = step.run()
-            step.set_status(status)
-            self.assertEqual(status, SKIPPED)
-            self.assertEqual(status.reason, "nochange")
-
-            # simulate an update is required
-            mock_provider.reset_mock()
-            mock_provider.update_stack.side_effect = None
-            step.set_status(PENDING)
-            status = step.run()
-            step.set_status(status)
-            self.assertEqual(status, SUBMITTED)
-            self.assertEqual(status.reason, "updating existing stack")
-            self.assertEqual(mock_provider.update_stack.call_count, 1)
-
     def test_should_update(self):
         test_scenario = namedtuple("test_scenario",
                                    ["locked", "force", "result"])
@@ -260,6 +198,161 @@ class TestBuildAction(unittest.TestCase):
         build_action = build.Action(context, provider=mock_provider)
         with self.assertRaises(StackDoesNotExist):
             build_action._generate_plan()
+
+
+class TestLaunchStack(TestBuildAction):
+    def setUp(self):
+        self.context = self._get_context()
+        self.provider = Provider(None, interactive=False, recreate_failed=True)
+        self.build_action = build.Action(self.context, provider=self.provider)
+
+        self.stack = mock.MagicMock()
+        self.stack.name = 'vpc'
+        self.stack.fqn = 'vpc'
+        self.stack.locked = False
+        self.stack_status = None
+
+        plan = self.build_action._generate_plan()
+        _, self.step = plan.list_pending()[0]
+        self.step.stack = self.stack
+
+        def patch_object(*args, **kwargs):
+            m = mock.patch.object(*args, **kwargs)
+            self.addCleanup(m.stop)
+            m.start()
+
+        def get_stack(name, *args, **kwargs):
+            if name != self.stack.name or not self.stack_status:
+                raise StackDoesNotExist(name)
+
+            return {'StackName': self.stack.name,
+                    'StackStatus': self.stack_status,
+                    'Tags': []}
+
+        patch_object(self.provider, 'get_stack', side_effect=get_stack)
+        patch_object(self.provider, 'update_stack')
+        patch_object(self.provider, 'create_stack')
+        patch_object(self.provider, 'destroy_stack')
+
+        patch_object(self.build_action, "s3_stack_push")
+
+    def _advance(self, new_provider_status, expected_status, expected_reason):
+        self.stack_status = new_provider_status
+        status = self.step.run()
+        self.step.set_status(status)
+        self.assertEqual(status, expected_status)
+        self.assertEqual(status.reason, expected_reason)
+
+    def test_launch_stack_disabled(self):
+        self.assertEqual(self.step.status, PENDING)
+
+        self.stack.enabled = False
+        self._advance(None, NotSubmittedStatus(), "disabled")
+
+    def test_launch_stack_create(self):
+        # initial status should be PENDING
+        self.assertEqual(self.step.status, PENDING)
+
+        # initial run should return SUBMITTED since we've passed off to CF
+        self._advance(None, SUBMITTED, "creating new stack")
+
+        # status should stay as SUBMITTED when the stack becomes available
+        self._advance('CREATE_IN_PROGRESS', SUBMITTED, "creating new stack")
+
+        # status should become COMPLETE once the stack finishes
+        self._advance('CREATE_COMPLETE', COMPLETE, "creating new stack")
+
+    def test_launch_stack_create_rollback(self):
+        # initial status should be PENDING
+        self.assertEqual(self.step.status, PENDING)
+
+        # initial run should return SUBMITTED since we've passed off to CF
+        self._advance(None, SUBMITTED, "creating new stack")
+
+        # provider should now return the CF stack since it exists
+        self._advance("CREATE_IN_PROGRESS", SUBMITTED,
+                      "creating new stack")
+
+        # rollback should be noticed
+        self._advance("ROLLBACK_IN_PROGRESS", SUBMITTED,
+                      "rolling back new stack")
+
+        # rollback should not be added twice to the reason
+        self._advance("ROLLBACK_IN_PROGRESS", SUBMITTED,
+                      "rolling back new stack")
+
+        # rollback should finish with failure
+        self._advance("ROLLBACK_COMPLETE", FAILED,
+                      "rolled back new stack")
+
+    def test_launch_stack_recreate(self):
+        # initial status should be PENDING
+        self.assertEqual(self.step.status, PENDING)
+
+        # first action with an existing failed stack should be deleting it
+        self._advance("ROLLBACK_COMPLETE", SUBMITTED,
+                      "destroying stack for re-creation")
+
+        # status should stay as submitted during deletion
+        self._advance("DELETE_IN_PROGRESS", SUBMITTED,
+                      "destroying stack for re-creation")
+
+        # deletion being complete must trigger re-creation
+        self._advance("DELETE_COMPLETE", SUBMITTED,
+                      "re-creating stack")
+
+        # re-creation should continue as SUBMITTED
+        self._advance("CREATE_IN_PROGRESS", SUBMITTED,
+                      "re-creating stack")
+
+        # re-creation should finish with success
+        self._advance("CREATE_COMPLETE", COMPLETE,
+                      "re-creating stack")
+
+    def test_launch_stack_update_skipped(self):
+        # initial status should be PENDING
+        self.assertEqual(self.step.status, PENDING)
+
+        # start the upgrade, that will be skipped
+        self.provider.update_stack.side_effect = StackDidNotChange
+        self._advance("CREATE_COMPLETE", SKIPPED,
+                      "nochange")
+
+    def test_launch_stack_update_rollback(self):
+        # initial status should be PENDING
+        self.assertEqual(self.step.status, PENDING)
+
+        # initial run should return SUBMITTED since we've passed off to CF
+        self._advance("CREATE_COMPLETE", SUBMITTED,
+                      "updating existing stack")
+
+        # update should continue as SUBMITTED
+        self._advance("UPDATE_IN_PROGRESS", SUBMITTED,
+                      "updating existing stack")
+
+        # rollback should be noticed
+        self._advance("UPDATE_ROLLBACK_IN_PROGRESS", SUBMITTED,
+                      "rolling back update")
+
+        # rollback should finish with failure
+        self._advance("UPDATE_ROLLBACK_COMPLETE", FAILED,
+                      "rolled back update")
+
+    def test_launch_stack_update_success(self):
+        # initial status should be PENDING
+        self.assertEqual(self.step.status, PENDING)
+
+        # initial run should return SUBMITTED since we've passed off to CF
+        self._advance("CREATE_COMPLETE", SUBMITTED,
+                      "updating existing stack")
+
+        # update should continue as SUBMITTED
+        self._advance("UPDATE_IN_PROGRESS", SUBMITTED,
+                      "updating existing stack")
+
+        # update should finish with sucess
+        self._advance("UPDATE_COMPLETE", COMPLETE,
+                      "updating existing stack")
 
 
 class TestFunctions(unittest.TestCase):

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -180,6 +180,7 @@ class TestBuildAction(unittest.TestCase):
             # simulate that we're still in progress
             mock_provider.is_stack_in_progress.return_value = True
             mock_provider.is_stack_completed.return_value = False
+            mock_provider.is_stack_rolling_back.return_value = False
             status = step.run()
             step.set_status(status)
             # status should still be SUBMITTED since we're waiting for it to

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -203,7 +203,8 @@ class TestBuildAction(unittest.TestCase):
 class TestLaunchStack(TestBuildAction):
     def setUp(self):
         self.context = self._get_context()
-        self.provider = Provider(None, interactive=False, recreate_failed=True)
+        self.provider = Provider(None, interactive=False,
+                                 recreate_failed=False)
         self.build_action = build.Action(self.context, provider=self.provider)
 
         self.stack = mock.MagicMock()
@@ -286,6 +287,8 @@ class TestLaunchStack(TestBuildAction):
                       "rolled back new stack")
 
     def test_launch_stack_recreate(self):
+        self.provider.recreate_failed = True
+
         # initial status should be PENDING
         self.assertEqual(self.step.status, PENDING)
 

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -7,7 +7,7 @@ import awacs.s3
 import awacs.cloudformation
 import awacs.iam
 
-from troposphere.cloudformation import WaitConditionHandle
+from troposphere.cloudformation import WaitCondition, WaitConditionHandle
 
 from stacker.blueprints.base import Blueprint
 from stacker.blueprints.variables.types import (
@@ -138,6 +138,28 @@ class Dummy2(Blueprint):
         self.template.add_resource(WaitConditionHandle("Dummy"))
         self.template.add_output(Output("DummyId", Value="dummy-1234"))
         self.template.add_resource(WaitConditionHandle("Dummy2"))
+
+
+class Broken(Blueprint):
+    """
+    This blueprint deliberately fails validation, so that it can be used to
+    test re-creation of a failed stack
+    """
+    VARIABLES = {
+        "StringVariable": {
+            "type": str,
+            "default": ""}
+    }
+
+    def create_template(self):
+        t = self.template
+        t.add_resource(WaitConditionHandle("BrokenDummy"))
+        t.add_resource(WaitCondition(
+            "BrokenWaitCondition",
+            Handle=Ref("BrokenDummy"),
+            Timeout=2 ** 32,
+            Count=0))
+        t.add_output(Output("DummyId", Value="dummy-1234"))
 
 
 class VPC(Blueprint):

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -157,6 +157,7 @@ class Broken(Blueprint):
         t.add_resource(WaitCondition(
             "BrokenWaitCondition",
             Handle=Ref("BrokenDummy"),
+            # Timeout is made deliberately large so CF rejects it
             Timeout=2 ** 32,
             Count=0))
         t.add_output(Output("DummyId", Value="dummy-1234"))

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -1,4 +1,4 @@
-from troposphere import Output, Sub, Ref
+from troposphere import GetAtt, Output, Sub, Ref
 from troposphere import iam
 
 from awacs.aws import Policy, Statement
@@ -97,7 +97,18 @@ class FunctionalTests(Blueprint):
                 Policies=[
                     stacker_policy]))
 
+        key = t.add_resource(
+            iam.AccessKey(
+                "FunctionalTestKey",
+                Serial=1,
+                UserName=Ref(user)))
+
         t.add_output(Output("User", Value=Ref(user)))
+        t.add_output(Output("AccessKeyId", Value=Ref(key)))
+        t.add_output(
+            Output(
+                "SecretAccessKey",
+                Value=GetAtt("FunctionalTestKey", "SecretAccessKey")))
 
 
 class Dummy(Blueprint):

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -429,7 +429,7 @@ class TestProviderDefaultMode(unittest.TestCase):
             with self.stubber:
                 self.provider.prepare_stack_for_update(stack_name, [])
 
-        self.assertIn('invalid status', raised.exception.message.lower())
+        self.assertIn('Unsupported state', raised.exception.message)
 
     def test_prepare_stack_for_update_disallowed(self):
         stack_name = "MockStack"
@@ -449,7 +449,9 @@ class TestProviderDefaultMode(unittest.TestCase):
             with self.stubber:
                 self.provider.prepare_stack_for_update(stack_name, [])
 
-        self.assertIn('disallowed', raised.exception.message)
+        self.assertIn('re-creation is disabled', raised.exception.message)
+        # Ensure we point out to the user how to enable re-creation
+        self.assertIn('--recreate-failed', raised.exception.message)
 
     def test_prepare_stack_for_update_bad_tags(self):
         stack_name = "MockStack"

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -39,11 +39,14 @@ def random_string(length=12):
 
 def generate_describe_stacks_stack(stack_name,
                                    creation_time=None,
-                                   stack_status="CREATE_COMPLETE"):
+                                   stack_status="CREATE_COMPLETE",
+                                   tags=None):
+    tags = tags or []
     return {
         "StackName": stack_name,
         "CreationTime": creation_time or datetime(2015, 1, 1),
         "StackStatus": stack_status,
+        "Tags": tags
     }
 
 
@@ -314,7 +317,7 @@ class TestMethods(unittest.TestCase):
 class TestProviderDefaultMode(unittest.TestCase):
     def setUp(self):
         region = "us-east-1"
-        self.provider = Provider(region=region)
+        self.provider = Provider(region=region, recreate_failed=False)
         self.stubber = Stubber(self.provider.cloudformation)
 
     def test_get_stack_stack_does_not_exist(self):
@@ -357,11 +360,153 @@ class TestProviderDefaultMode(unittest.TestCase):
             self.provider.interactive_update_stack
         )
 
+    def test_prepare_stack_for_update_missing(self):
+        stack_name = "MockStack"
+        self.stubber.add_client_error(
+            "describe_stacks",
+            service_error_code="ValidationError",
+            service_message="Stack with id %s does not exist" % stack_name,
+            expected_params={"StackName": stack_name}
+        )
+
+        with self.assertRaises(exceptions.StackDoesNotExist):
+            with self.stubber:
+                self.provider.prepare_stack_for_update(stack_name, [])
+
+    def test_prepare_stack_for_update_completed(self):
+        stack_name = "MockStack"
+        stack_response = {
+            "Stacks": [
+                generate_describe_stacks_stack(
+                    stack_name, stack_status="UPDATE_COMPLETE")
+            ]
+        }
+        self.stubber.add_response(
+            "describe_stacks",
+            stack_response,
+            expected_params={"StackName": stack_name}
+        )
+
+        with self.stubber:
+            self.assertTrue(
+                self.provider.prepare_stack_for_update(stack_name, []))
+
+    def test_prepare_stack_for_update_in_progress(self):
+        stack_name = "MockStack"
+        stack_response = {
+            "Stacks": [
+                generate_describe_stacks_stack(
+                    stack_name, stack_status="UPDATE_IN_PROGRESS")
+            ]
+        }
+        self.stubber.add_response(
+            "describe_stacks",
+            stack_response,
+            expected_params={"StackName": stack_name}
+        )
+
+        with self.assertRaises(exceptions.StackUpdateBadStatus) as raised:
+            with self.stubber:
+                self.provider.prepare_stack_for_update(stack_name, [])
+
+            self.assertIn('in-progress', raised.exception.message)
+
+    def test_prepare_stack_for_update_non_recreatable(self):
+        stack_name = "MockStack"
+        stack_response = {
+            "Stacks": [
+                generate_describe_stacks_stack(
+                    stack_name, stack_status="REVIEW_IN_PROGRESS")
+            ]
+        }
+        self.stubber.add_response(
+            "describe_stacks",
+            stack_response,
+            expected_params={"StackName": stack_name}
+        )
+
+        with self.assertRaises(exceptions.StackUpdateBadStatus) as raised:
+            with self.stubber:
+                self.provider.prepare_stack_for_update(stack_name, [])
+
+        self.assertIn('invalid status', raised.exception.message.lower())
+
+    def test_prepare_stack_for_update_disallowed(self):
+        stack_name = "MockStack"
+        stack_response = {
+            "Stacks": [
+                generate_describe_stacks_stack(
+                    stack_name, stack_status="ROLLBACK_COMPLETE")
+            ]
+        }
+        self.stubber.add_response(
+            "describe_stacks",
+            stack_response,
+            expected_params={"StackName": stack_name}
+        )
+
+        with self.assertRaises(exceptions.StackUpdateBadStatus) as raised:
+            with self.stubber:
+                self.provider.prepare_stack_for_update(stack_name, [])
+
+        self.assertIn('disallowed', raised.exception.message)
+
+    def test_prepare_stack_for_update_bad_tags(self):
+        stack_name = "MockStack"
+        stack_response = {
+            "Stacks": [
+                generate_describe_stacks_stack(
+                    stack_name, stack_status="ROLLBACK_COMPLETE")
+            ]
+        }
+        self.stubber.add_response(
+            "describe_stacks",
+            stack_response,
+            expected_params={"StackName": stack_name}
+        )
+
+        self.provider.recreate_failed = True
+
+        with self.assertRaises(exceptions.StackUpdateBadStatus) as raised:
+            with self.stubber:
+                self.provider.prepare_stack_for_update(
+                    stack_name,
+                    tags=[{'Key': 'stacker_namespace', 'Value': 'test'}])
+
+        self.assertIn('tags differ', raised.exception.message.lower())
+
+    def test_prepare_stack_for_update_recreate(self):
+        stack_name = "MockStack"
+        stack_response = {
+            "Stacks": [
+                generate_describe_stacks_stack(
+                    stack_name, stack_status="ROLLBACK_COMPLETE")
+            ]
+        }
+        self.stubber.add_response(
+            "describe_stacks",
+            stack_response,
+            expected_params={"StackName": stack_name}
+        )
+
+        self.stubber.add_response(
+            "delete_stack",
+            {},
+            expected_params={"StackName": stack_name}
+        )
+
+        self.provider.recreate_failed = True
+
+        with self.stubber:
+            self.assertFalse(
+                self.provider.prepare_stack_for_update(stack_name, []))
+
 
 class TestProviderInteractiveMode(unittest.TestCase):
     def setUp(self):
         region = "us-east-1"
-        self.provider = Provider(region=region, interactive=True)
+        self.provider = Provider(region=region, interactive=True,
+                                 recreate_failed=True)
         self.stubber = Stubber(self.provider.cloudformation)
 
     def test_successful_init(self):
@@ -374,6 +519,8 @@ class TestProviderInteractiveMode(unittest.TestCase):
 
     @patch("stacker.providers.aws.default.ask_for_approval")
     def test_update_stack_execute_success(self, patched_approval):
+        stack_name = "my-fake-stack"
+
         self.stubber.add_response(
             "create_change_set",
             {'Id': 'CHANGESETID', 'StackId': 'STACKID'}
@@ -393,7 +540,7 @@ class TestProviderInteractiveMode(unittest.TestCase):
 
         with self.stubber:
             self.provider.update_stack(
-                fqn="my-fake-stack",
+                fqn=stack_name,
                 template=Template(url="http://fake.template.url.com/"),
                 old_parameters=[],
                 parameters=[], tags=[]

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,9 +18,10 @@ This directory contains the functional testing suite for stacker. It exercises a
   ```console
   $ ./stacker.yaml.sh | stacker build -
   ```
-4. In the AWS console, generate a new IAM access key pair for the user and set it in your shell:
+4. Grab the generated key pair for the user and set it in your shell:
 
   ```console
+  $ ./stacker.yaml.sh | stacker info -
   $ export AWS_ACCESS_KEY_ID=access-key
   $ export AWS_SECRET_ACCESS_KEY=secret-access-key
   ```

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -634,5 +634,5 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: submitted (rolling back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: failed (rolled back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-child:  failed (dependency has failed)"
-  assert_has_line "The following stacks failed their plans: dependent-rollback-parent, dependent-rollback-child"
+  assert_has_line "The following stacks failed: dependent-rollback-parent, dependent-rollback-child"
 }


### PR DESCRIPTION
Currently stacker bails out at the first sight of an error when handling a stack. While that works for simple cases, it does not make it easy to handle rollbacks, re-creations and other exceptional situations automatically.

To improve that, implement:
- Waiting for rollbacks of each stack during deployment
- Propagate failures from stacks to ther dependents
- Support deleting and re-creating stacks that failed their initial deployment, when confirmed interactively by an user, or through a command line option
- Fail plans gracefully by printing which stacks did not succeed after completing everything, instead of just a traceback

To make sure nothing is broken in the process:
- Re-implement the build action tests to cover multiple different cases and the corresponding state transitions
- Add integration tests that cover rollbacks during new stacks and updates, including dependencies
- Add integration tests for re-creating stacks that previously failed

This PR can only land after #469.