### PR TITLE
Enable `service_role` config option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -104,7 +104,7 @@ Service Role
 
 By default stacker doesn't specify a service role when executing changes to
 CloudFormation stacks. If you would prefer that it do so, you can set
-``service_role`` to be the ARN of the service that stacker should use when
+**service_role** to be the ARN of the service that stacker should use when
 executing CloudFormation changes.
 
 This is the equivalent of setting ``RoleARN`` on a call to the following

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -91,7 +91,7 @@ See the `CloudFormation Limits Reference`_.
 .. _`CloudFormation Limits Reference`: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
 
 Module Paths
-----------------
+------------
 When setting the ``classpath`` for blueprints/hooks, it is sometimes desirable to
 load modules from outside the default ``sys.path`` (e.g., to include modules
 inside the same repo as config files).
@@ -99,8 +99,24 @@ inside the same repo as config files).
 Adding a path (e.g. ``./``) to the **sys_path** top level key word will allow
 modules from that path location to be used.
 
+Service Role
+------------
+
+By default stacker doesn't specify a service role when executing changes to
+CloudFormation stacks. If you would prefer that it do so, you can set
+``service_role`` to be the ARN of the service that stacker should use when
+executing CloudFormation changes.
+
+This is the equivalent of setting ``RoleARN`` on a call to the following
+CloudFormation api calls: ``CreateStack``, ``UpdateStack``,
+``CreateChangeSet``.
+
+See the AWS documentation for `AWS CloudFormation Service Roles`_.
+
+.. _`AWS CloudFormation Service Roles`: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html?icmpid=docs_cfn_console
+
 Remote Packages
-----------------
+---------------
 The **package_sources** top level keyword can be used to define remote git
 sources for blueprints (e.g., retrieving ``stacker_blueprints`` on github at
 tag ``v1.0.2``).
@@ -168,7 +184,7 @@ Tags
 ----
 
 CloudFormation supports arbitrary key-value pair tags. All stack-level, including automatically created tags, are
-propagated to resources that AWS CloudFormation supports. See `AWS Cloudformation Resource Tags Type`_ for more details.
+propagated to resources that AWS CloudFormation supports. See `AWS CloudFormation Resource Tags Type`_ for more details.
 If no tags are specified, the `stacker_namespace` tag is applied to your stack with the value of `namespace` as the
 tag value.
 

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -25,17 +25,18 @@ class Stacker(BaseCommand):
         else:
             logger.info("Using default AWS provider mode")
 
-        options.provider = default.Provider(
-            region=options.region,
-            interactive=options.interactive,
-            replacements_only=options.replacements_only,
-            recreate_failed=options.recreate_failed
-        )
-
         config = load_config(
             options.config.read(),
             environment=options.environment,
             validate=True)
+
+        options.provider = default.Provider(
+            region=options.region,
+            interactive=options.interactive,
+            replacements_only=options.replacements_only,
+            recreate_failed=options.recreate_failed,
+            service_role=config.service_role,
+        )
 
         options.context = Context(
             environment=options.environment,

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -274,6 +274,8 @@ class Config(Model):
 
     package_sources = ModelType(PackageSources, serialize_when_none=False)
 
+    service_role = StringType(serialize_when_none=False)
+
     pre_build = ListType(ModelType(Hook), serialize_when_none=False)
 
     post_build = ListType(ModelType(Hook), serialize_when_none=False)

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -591,8 +591,11 @@ class Provider(BaseProvider):
 
     def destroy_stack(self, stack, **kwargs):
         logger.debug("Destroying stack: %s" % (self.get_stack_name(stack)))
-        retry_on_throttling(self.cloudformation.delete_stack,
-                            kwargs=dict(StackName=self.get_stack_name(stack)))
+        args = {"StackName": self.get_stack_name(stack)}
+        if self.service_role:
+            args["RoleARN"] = self.service_role
+
+        retry_on_throttling(self.cloudformation.delete_stack, kwargs=args)
         return True
 
     def create_stack(self, fqn, template, parameters, tags, **kwargs):

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -22,22 +22,7 @@ from ...actions.diff import (
 logger = logging.getLogger(__name__)
 
 MAX_TAIL_RETRIES = 5
-
-
-def template_args(template):
-    """Given a template object, this will return a dict that can be used in
-    CreateStack/UpdateStack calls, based on whether or not the template is
-    inline, or uploaded to S3.
-
-    Args:
-        template (:class:`stacker.providers.base.Template`): The template
-            object.
-
-    """
-    if template.url:
-        return {'TemplateURL': template.url}
-    else:
-        return {'TemplateBody': template.body}
+DEFAULT_CAPABILITIES = ["CAPABILITY_NAMED_IAM", ]
 
 
 def get_output_dict(stack):
@@ -96,8 +81,8 @@ def retry_on_throttling(fn, attempts=3, args=None, kwargs=None):
                               retry_checker=_throttling_checker)
 
 
-def s3_fallback(fqn, template_url, parameters, tags, method,
-                change_set_name=None):
+def s3_fallback(fqn, template, parameters, tags, method,
+                change_set_name=None, service_role=None):
     logger.warn("DEPRECATION WARNING: Falling back to legacy "
                 "stacker S3 bucket region for templates. See "
                 "http://stacker.readthedocs.io/en/latest/config.html#s3-bucket"
@@ -107,20 +92,19 @@ def s3_fallback(fqn, template_url, parameters, tags, method,
     logger.warn("\n")
     logger.debug("Modifying the S3 TemplateURL to point to "
                  "us-east-1 endpoint")
+    template_url = template.url
     template_url_parsed = urlparse.urlparse(template_url)
     template_url_parsed = template_url_parsed._replace(
         netloc="s3.amazonaws.com")
     template_url = urlparse.urlunparse(template_url_parsed)
     logger.debug("Using template_url: %s", template_url)
-    kwargs = dict(StackName=fqn,
-                  TemplateURL=template_url,
-                  Parameters=parameters,
-                  Tags=tags,
-                  Capabilities=["CAPABILITY_NAMED_IAM"],
-                  )
-    if change_set_name:
-        kwargs['ChangeSetName'] = change_set_name
-    response = retry_on_throttling(method, kwargs=kwargs)
+    args = generate_cloudformation_args(
+        fqn, parameters, tags, template,
+        service_role=service_role,
+        change_set_name=get_change_set_name()
+    )
+
+    response = retry_on_throttling(method, kwargs=args)
     return response
 
 
@@ -315,25 +299,26 @@ def wait_till_change_set_complete(cfn_client, change_set_id, try_count=25,
 
 
 def create_change_set(cfn_client, fqn, template, parameters, tags,
-                      replacements_only=False):
+                      replacements_only=False, service_role=None):
     logger.debug("Attempting to create change set for stack: %s.", fqn)
-    args = {'StackName': fqn,
-            'Parameters': parameters,
-            'Tags': tags,
-            'Capabilities': ["CAPABILITY_NAMED_IAM"],
-            'ChangeSetName': get_change_set_name()}
+    args = generate_cloudformation_args(
+        fqn, parameters, tags, template,
+        service_role=service_role,
+        change_set_name=get_change_set_name()
+    )
     try:
         response = retry_on_throttling(
             cfn_client.create_change_set,
-            kwargs=dict(args, **template_args(template))
+            kwargs=args
         )
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Message'] == ('TemplateURL must reference '
                                               'a valid S3 object to which '
                                               'you have access.'):
-            response = s3_fallback(fqn, template.url, parameters,
+            response = s3_fallback(fqn, template, parameters,
                                    tags, cfn_client.create_change_set,
-                                   get_change_set_name())
+                                   get_change_set_name(),
+                                   service_role)
         else:
             raise
     change_set_id = response["Id"]
@@ -383,6 +368,55 @@ def check_tags_contain(actual, expected):
     return actual_set >= expected_set
 
 
+def generate_cloudformation_args(stack_name, parameters, tags, template,
+                                 capabilities=DEFAULT_CAPABILITIES,
+                                 service_role=None,
+                                 change_set_name=None):
+    """Used to generate the args for common cloudformation API interactions.
+
+    This is used for create_stack/update_stack/create_change_set calls in
+    cloudformation.
+
+    Args:
+        stack_name (str): The fully qualified stack name in Cloudformation.
+        parameters (list): A list of dictionaries that defines the
+            parameter list to be applied to the Cloudformation stack.
+        tags (list): A list of dictionaries that defines the tags
+            that should be applied to the Cloudformation stack.
+        template (:class:`stacker.provider.base.Template`): The template
+            object.
+        capabilities (list, optional): A list of capabilities to use when
+            updating Cloudformation.
+        service_role (str, optional): An optional service role to use when
+            interacting with Cloudformation.
+        change_set_name (str, optional): An optional change set name to use
+            with create_change_set.
+
+    Returns:
+        dict: A dictionary of arguments to be used in the Cloudformation API
+            call.
+    """
+    args = {
+        "StackName": stack_name,
+        "Parameters": parameters,
+        "Tags": tags,
+        "Capabilities": capabilities,
+    }
+
+    if service_role:
+        args["RoleARN"] = service_role
+
+    if change_set_name:
+        args["ChangeSetName"] = change_set_name
+
+    if template.url:
+        args["TemplateURL"] = template.url
+    else:
+        args["TemplateBody"] = template.body
+
+    return args
+
+
 class Provider(BaseProvider):
 
     """AWS CloudFormation Provider"""
@@ -427,7 +461,7 @@ class Provider(BaseProvider):
     )
 
     def __init__(self, region, interactive=False, replacements_only=False,
-                 recreate_failed=False, **kwargs):
+                 recreate_failed=False, service_role=None, **kwargs):
         self.region = region
         self._outputs = {}
         self._cloudformation = None
@@ -435,6 +469,7 @@ class Provider(BaseProvider):
         # replacements only is only used in interactive mode
         self.replacements_only = interactive and replacements_only
         self.recreate_failed = interactive or recreate_failed
+        self.service_role = service_role
 
         # Necessary to deal w/ multiprocessing issues w/ sharing ssl conns
         # see: https://github.com/remind101/stacker/issues/196
@@ -581,21 +616,23 @@ class Provider(BaseProvider):
         else:
             logger.debug("    no template url, uploading template "
                          "directly.")
-        args = dict(StackName=fqn,
-                    Parameters=parameters,
-                    Tags=tags,
-                    Capabilities=["CAPABILITY_NAMED_IAM"])
+        args = generate_cloudformation_args(
+            fqn, parameters, tags, template,
+            service_role=self.service_role,
+        )
+
         try:
             retry_on_throttling(
                 self.cloudformation.create_stack,
-                kwargs=dict(args, **template_args(template)),
+                kwargs=args
             )
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Message'] == ('TemplateURL must reference '
                                                   'a valid S3 object to which '
                                                   'you have access.'):
-                s3_fallback(fqn, template.url, parameters, tags,
-                            self.cloudformation.create_stack)
+                s3_fallback(fqn, template, parameters, tags,
+                            self.cloudformation.create_stack,
+                            self.service_role)
             else:
                 raise
 
@@ -730,9 +767,10 @@ class Provider(BaseProvider):
                 that should be applied to the Cloudformation stack.
         """
         logger.debug("Using interactive provider mode for %s.", fqn)
-        changes, change_set_id = create_change_set(self.cloudformation, fqn,
-                                                   template, parameters,
-                                                   tags, **kwargs)
+        changes, change_set_id = create_change_set(
+            self.cloudformation, fqn, template, parameters, tags,
+            service_role=self.service_role, **kwargs
+        )
         params_diff = diff_parameters(
             self.params_as_dict(old_parameters),
             self.params_as_dict(parameters))
@@ -775,14 +813,15 @@ class Provider(BaseProvider):
         """
 
         logger.debug("Using default provider mode for %s.", fqn)
-        args = dict(StackName=fqn,
-                    Parameters=parameters,
-                    Tags=tags,
-                    Capabilities=["CAPABILITY_NAMED_IAM"])
+        args = generate_cloudformation_args(
+            fqn, parameters, tags, template,
+            service_role=self.service_role,
+        )
+
         try:
             retry_on_throttling(
                 self.cloudformation.update_stack,
-                kwargs=dict(args, **template_args(template)),
+                kwargs=args
             )
         except botocore.exceptions.ClientError as e:
             if "No updates are to be performed." in e.message:
@@ -795,8 +834,9 @@ class Provider(BaseProvider):
                                                     'reference a valid '
                                                     'S3 object to which '
                                                     'you have access.'):
-                s3_fallback(fqn, template.url, parameters, tags,
-                            self.cloudformation.update_stack)
+                s3_fallback(fqn, template, parameters, tags,
+                            self.cloudformation.update_stack,
+                            self.service_role)
             else:
                 raise
 


### PR DESCRIPTION
Allows us to pass a service role when executing cloudformation API
calls.

Fixes #265