### PR TITLE
Move S3 templates into sub-dirs in S3

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -24,7 +24,9 @@ def stack_template_key_name(blueprint):
     Returns:
         string: Key name resulting from blueprint.
     """
-    return "%s-%s.json" % (blueprint.name, blueprint.version)
+    name = blueprint.name
+    return "%s/%s-%s.json" % (blueprint.context.get_fqn(name), name,
+                              blueprint.version)
 
 
 def stack_template_url(bucket_name, blueprint, endpoint):

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -25,8 +25,9 @@ def stack_template_key_name(blueprint):
         string: Key name resulting from blueprint.
     """
     name = blueprint.name
-    return "%s/%s-%s.json" % (blueprint.context.get_fqn(name), name,
-                              blueprint.version)
+    return "stack_templates/%s/%s-%s.json" % (blueprint.context.get_fqn(name),
+                                              name,
+                                              blueprint.version)
 
 
 def stack_template_url(bucket_name, blueprint, endpoint):

--- a/stacker/tests/actions/test_base.py
+++ b/stacker/tests/actions/test_base.py
@@ -129,9 +129,10 @@ class TestBaseAction(unittest.TestCase):
             )
             self.assertEqual(
                 action.stack_template_url(blueprint),
-                "https://%s/%s/%s-%s.json" % (
+                "https://%s/%s/%s/%s-%s.json" % (
                     endpoint,
                     "stacker-mynamespace",
+                    "mynamespace-myblueprint",
                     "myblueprint",
                     MOCK_VERSION
 

--- a/stacker/tests/actions/test_base.py
+++ b/stacker/tests/actions/test_base.py
@@ -129,7 +129,7 @@ class TestBaseAction(unittest.TestCase):
             )
             self.assertEqual(
                 action.stack_template_url(blueprint),
-                "https://%s/%s/%s/%s-%s.json" % (
+                "https://%s/%s/stack_templates/%s/%s-%s.json" % (
                     endpoint,
                     "stacker-mynamespace",
                     "mynamespace-myblueprint",


### PR DESCRIPTION
Fixes #347

This adds another layer to the s3 bucket space to try and keep things a
bit cleaner.  If you had a namespace of `mynamespace`, a bucket of
`mybucket`, and a stack called `vpc`, the old method would have resulted
in an s3 key of:

`s3://mybucket/vpc-$version.json`

It would now result in:

`s3://mybucket/mynamespace-vpc/vpc-$version.json`

Not 100% sure that's the best namespace use, but it seems specific
enough and should be helpful.

I'm pretty sure this will result in slower runs the first time after
updating to this version of stacker, only because it'll have to upload
all it's templates again, but it shouldn't result in any CloudFormation
updates.  I'll verify this.