### PR TITLE
Prevent lookup infinite loop

### DIFF
--- a/stacker/tests/test_variables.py
+++ b/stacker/tests/test_variables.py
@@ -49,6 +49,15 @@ class TestVariables(unittest.TestCase):
         var.resolve(self.context, self.provider)
         self.assertTrue(var.resolved)
         self.assertEqual(var.value, "resolved")
+        self.assertEqual(len(var.lookups), 0)
+
+    def test_variable_resolve_default_lookup_empty(self):
+        var = Variable("Param1", "${default fakeStack::}")
+        self.assertEqual(len(var.lookups), 1)
+        var.resolve(self.context, self.provider)
+        self.assertTrue(var.resolved)
+        self.assertEqual(var.value, "")
+        self.assertEqual(len(var.lookups), 0)
 
     def test_variable_replace_multiple_lookups_string(self):
         var = Variable(

--- a/stacker/variables.py
+++ b/stacker/variables.py
@@ -111,7 +111,10 @@ class Variable(object):
         `_resolved_value` takes precedence over `_value`.
 
         """
-        return self._resolved_value or self._value
+        if self._resolved_value is not None:
+            return self._resolved_value
+        else:
+            return self._value
 
     @property
     def resolved(self):


### PR DESCRIPTION
Prevent lookup infinite loop when self._resolved_value is type cast to False. Added test that checks by using the default lookup with an empty string.