### PR TITLE
raise error on dupe sibling YAML keys

### DIFF
--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -355,10 +355,11 @@ class Config(Model):
 
     def validate_stacks(self, data, value):
         if value:
-            names = set()
-            for i, stack in enumerate(value):
-                if stack.name in names:
-                    raise ValidationError(
-                        "Duplicate stack %s found at index %d."
-                        % (stack.name, i))
-                names.add(stack.name)
+            stack_names = [stack.name for stack in value]
+            if len(set(stack_names)) != len(stack_names):
+                # only loop / enumerate if there is an issue.
+                for i, stack_name in enumerate(stack_names):
+                    if stack_names.count(stack_name) != 1:
+                        raise ValidationError(
+                            "Duplicate stack %s found at index %d."
+                            % (stack_name, i))


### PR DESCRIPTION
Fixes #491 

Most of this code is derived from upstream pyYAML library.

https://bitbucket.org/xi/pyyaml/src/10c55a624429f28191ef2bc1d9db44684946eb5d/lib/yaml/constructor.py?at=default&fileviewer=file-view-default#constructor.py-120:135

	modified:   stacker/config/__init__.py
	modified:   stacker/tests/test_config.py
	modified:   stacker/util.py