### PR TITLE
change aws api, fix the case where no parameter was found.

### DIFF
--- a/stacker/lookups/handlers/ssmstore.py
+++ b/stacker/lookups/handlers/ssmstore.py
@@ -41,14 +41,7 @@ def handler(value, **kwargs):
         region, value = value.split("@", 1)
 
     client = get_session(region).client("ssm")
-    response = client.get_parameters(
-        Names=[
-            value,
-        ],
-        WithDecryption=True
+    response = client.get_parameter(
+        Name=value, WithDecryption=True
     )
-    if 'Parameters' in response:
-        return response['Parameters'][0]['Value']
-
-    raise ValueError('SSMKey "{}" does not exist in region {}'.format(value,
-                                                                      region))
+    return response['Parameter']['Value']


### PR DESCRIPTION
1. AWS has an API to retrieve a single parameter, we should just use that.
2. Previously, the code cannot correctly handle the case where a
parameter is not found, because AWS will always produce an empty
`Parameters` dict in the response. Instead of handling the exception in
this handler, we can just do nothing about it and stacker itself will
pick it up and raise something like:

stacker.exceptions.FailedVariableLookup: Couldn't resolve lookups in variable `Username`. An error occurred (ParameterNotFound) when calling the GetParameter operation: Parameter /path/to/parameter/username not found.

Signed-off-by: Kai Xia <xiaket@gmail.com>