### PR TITLE
Fixed typos with strings running together in the help output

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -71,7 +71,7 @@ If that behavior is also desired in non-interactive mode, enable the
     --stacks STACKNAME    Only work on the stacks given. Can be specified more
                           than once. If not specified then stacker will work on
                           all stacks in the config file.
-    -t, --tail            Tail the CloudFormation logs while workingwith stacks
+    -t, --tail            Tail the CloudFormation logs while working with stacks
     -d DUMP, --dump DUMP  Dump the rendered Cloudformation templates to a
                           directory
 
@@ -128,7 +128,7 @@ already been destroyed).
     --stacks STACKNAME    Only work on the stacks given. Can be specified more
                           than once. If not specified then stacker will work on
                           all stacks in the config file.
-    -t, --tail            Tail the CloudFormation logs while workingwith stacks
+    -t, --tail            Tail the CloudFormation logs while working with stacks
 
 Info
 ----

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -32,7 +32,7 @@ class Build(BaseCommand):
                                  "then stacker will work on all stacks in the "
                                  "config file.")
         parser.add_argument("-t", "--tail", action="store_true",
-                            help="Tail the CloudFormation logs while working"
+                            help="Tail the CloudFormation logs while working "
                                  "with stacks")
         parser.add_argument("-d", "--dump", action="store", type=str,
                             help="Dump the rendered Cloudformation templates "

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -26,7 +26,7 @@ class Destroy(BaseCommand):
                                  "then stacker will work on all stacks in the "
                                  "config file.")
         parser.add_argument("-t", "--tail", action="store_true",
-                            help="Tail the CloudFormation logs while working"
+                            help="Tail the CloudFormation logs while working "
                                  "with stacks")
 
     def run(self, options, **kwargs):


### PR DESCRIPTION
I noticed that these strings were running together in the output while looking at something else.