### PR TITLE
Remove changesets if no changes were made

### DIFF
--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -330,10 +330,18 @@ def create_change_set(cfn_client, fqn, template, parameters, tags,
         status_reason = response["StatusReason"]
         if "didn't contain changes" in response["StatusReason"]:
             logger.debug(
-                "Stack %s did not change, not updating.",
+                "Stack %s did not change, not updating and removing "
+                "changeset.",
                 fqn,
             )
-            raise exceptions.StackDidNotChange
+            cfn_client.delete_change_set(ChangeSetName=change_set_id)
+            raise exceptions.StackDidNotChange()
+        logger.warn(
+            "Got strange status, '%s' for changeset '%s'. Not deleting for "
+            "further investigation - you will need to delete the changeset "
+            "manually.",
+            status, change_set_id
+        )
         raise exceptions.UnhandledChangeSetStatus(
             fqn, change_set_id, status, status_reason
         )

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -266,6 +266,12 @@ class TestMethods(unittest.TestCase):
             )
         )
 
+        self.stubber.add_response(
+            "delete_change_set",
+            {},
+            expected_params={"ChangeSetName": "CHANGESETID"}
+        )
+
         with self.stubber:
             with self.assertRaises(exceptions.StackDidNotChange):
                 create_change_set(


### PR DESCRIPTION
Fixes #508

Not sure when this was introduced, but there's no reason to leave behind
ChangeSets that were created but not used because no changes actually
happened.

We still leave behind changesets that have an abnormal status for
investigations, though maybe in the future this should be an argument or
something.