### PR TITLE
add serverless transform / CREATE change set type support

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -266,6 +266,7 @@ class Action(BaseAction):
         template = self._template(stack.blueprint)
         tags = build_stack_tags(stack)
         parameters = self.build_parameters(stack, provider_stack)
+        force_change_set = stack.blueprint.template.transform is not None
 
         if recreate:
             logger.debug("Re-creating stack: %s", stack.fqn)
@@ -274,8 +275,16 @@ class Action(BaseAction):
             return SubmittedStatus("re-creating stack")
         elif not provider_stack:
             logger.debug("Creating new stack: %s", stack.fqn)
-            self.provider.create_stack(stack.fqn, template, parameters,
-                                       tags)
+            if force_change_set:
+                logger.debug("Stack template contains a Transform; creating "
+                             "with change sets")
+                self.provider.update_stack(stack.fqn, template,
+                                           [], parameters, tags,
+                                           force_interactive=stack.protected,
+                                           change_set_type='CREATE')
+            else:
+                self.provider.create_stack(stack.fqn, template, parameters,
+                                           tags)
             return SubmittedStatus("creating new stack")
         elif not should_update(stack):
             return NotUpdatedStatus()
@@ -283,9 +292,15 @@ class Action(BaseAction):
         try:
             if self.provider.prepare_stack_for_update(stack.fqn, tags):
                 existing_params = provider_stack.get('Parameters', [])
-                self.provider.update_stack(stack.fqn, template,
-                                           existing_params, parameters, tags,
-                                           force_interactive=stack.protected)
+                self.provider.update_stack(
+                    stack.fqn,
+                    template,
+                    existing_params,
+                    parameters,
+                    tags,
+                    force_interactive=stack.protected,
+                    force_change_set=force_change_set
+                )
 
                 logger.debug("Updating existing stack: %s", stack.fqn)
                 return SubmittedStatus("updating existing stack")

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -275,16 +275,8 @@ class Action(BaseAction):
             return SubmittedStatus("re-creating stack")
         elif not provider_stack:
             logger.debug("Creating new stack: %s", stack.fqn)
-            if force_change_set:
-                logger.debug("Stack template contains a Transform; creating "
-                             "with change sets")
-                self.provider.update_stack(stack.fqn, template,
-                                           [], parameters, tags,
-                                           force_interactive=stack.protected,
-                                           change_set_type='CREATE')
-            else:
-                self.provider.create_stack(stack.fqn, template, parameters,
-                                           tags)
+            self.provider.create_stack(stack.fqn, template, parameters, tags,
+                                       force_change_set)
             return SubmittedStatus("creating new stack")
         elif not should_update(stack):
             return NotUpdatedStatus()

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -641,7 +641,8 @@ class Provider(BaseProvider):
             logger.debug("    no template url, uploading template "
                          "directly.")
         if force_change_set:
-            logger.debug("Creating stack with change sets.")
+            logger.debug("force_change_set set to True, creating stack with "
+                         "changeset.")
             _changes, change_set_id = create_change_set(
                 self.cloudformation, fqn, template, parameters, tags,
                 'CREATE', service_role=self.service_role, **kwargs

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -210,6 +210,7 @@ class TestLaunchStack(TestBuildAction):
         self.stack = mock.MagicMock()
         self.stack.name = 'vpc'
         self.stack.fqn = 'vpc'
+        self.stack.blueprint.rendered = '{}'
         self.stack.locked = False
         self.stack_status = None
 

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -393,21 +393,17 @@ class TestProviderDefaultMode(unittest.TestCase):
 
     def test_select_update_method(self):
         for i in [[{'force_interactive': True,
-                    'force_change_set': False,
-                    'change_set_type': 'UPDATE'},
+                    'force_change_set': False},
                    self.provider.interactive_update_stack],
                   [{'force_interactive': False,
-                    'force_change_set': False,
-                    'change_set_type': 'CREATE'},
-                   self.provider.noninteractive_changeset_update],
+                    'force_change_set': False},
+                   self.provider.default_update_stack],
                   [{'force_interactive': False,
-                    'force_change_set': True,
-                    'change_set_type': 'UPDATE'},
+                    'force_change_set': True},
                    self.provider.noninteractive_changeset_update],
-                  [{'force_interactive': False,
-                    'force_change_set': False,
-                    'change_set_type': 'UPDATE'},
-                   self.provider.default_update_stack]]:
+                  [{'force_interactive': True,
+                    'force_change_set': True},
+                   self.provider.interactive_update_stack]]:
             self.assertEquals(
                 self.provider.select_update_method(**i[0]),
                 i[1]
@@ -609,20 +605,16 @@ class TestProviderInteractiveMode(unittest.TestCase):
 
     def test_select_update_method(self):
         for i in [[{'force_interactive': False,
-                    'force_change_set': False,
-                    'change_set_type': 'UPDATE'},
+                    'force_change_set': False},
                    self.provider.interactive_update_stack],
                   [{'force_interactive': True,
-                    'force_change_set': False,
-                    'change_set_type': 'CREATE'},
+                    'force_change_set': False},
                    self.provider.interactive_update_stack],
                   [{'force_interactive': False,
-                    'force_change_set': False,
-                    'change_set_type': 'CREATE'},
+                    'force_change_set': True},
                    self.provider.interactive_update_stack],
-                  [{'force_interactive': False,
-                    'force_change_set': True,
-                    'change_set_type': 'UPDATE'},
+                  [{'force_interactive': True,
+                    'force_change_set': True},
                    self.provider.interactive_update_stack]]:
             self.assertEquals(
                 self.provider.select_update_method(**i[0]),

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -392,15 +392,26 @@ class TestProviderDefaultMode(unittest.TestCase):
         self.assertEqual(response["StackName"], stack_name)
 
     def test_select_update_method(self):
-        self.assertEquals(
-            self.provider.select_update_method(force_interactive=False),
-            self.provider.default_update_stack
-        )
-
-        self.assertEquals(
-            self.provider.select_update_method(force_interactive=True),
-            self.provider.interactive_update_stack
-        )
+        for i in [[{'force_interactive': True,
+                    'force_change_set': False,
+                    'change_set_type': 'UPDATE'},
+                   self.provider.interactive_update_stack],
+                  [{'force_interactive': False,
+                    'force_change_set': False,
+                    'change_set_type': 'CREATE'},
+                   self.provider.noninteractive_changeset_update],
+                  [{'force_interactive': False,
+                    'force_change_set': True,
+                    'change_set_type': 'UPDATE'},
+                   self.provider.noninteractive_changeset_update],
+                  [{'force_interactive': False,
+                    'force_change_set': False,
+                    'change_set_type': 'UPDATE'},
+                   self.provider.default_update_stack]]:
+            self.assertEquals(
+                self.provider.select_update_method(**i[0]),
+                i[1]
+            )
 
     def test_prepare_stack_for_update_missing(self):
         stack_name = "MockStack"
@@ -597,12 +608,23 @@ class TestProviderInteractiveMode(unittest.TestCase):
         self.assertEqual(patched_approval.call_count, 1)
 
     def test_select_update_method(self):
-        self.assertEquals(
-            self.provider.select_update_method(force_interactive=False),
-            self.provider.interactive_update_stack
-        )
-
-        self.assertEquals(
-            self.provider.select_update_method(force_interactive=True),
-            self.provider.interactive_update_stack
-        )
+        for i in [[{'force_interactive': False,
+                    'force_change_set': False,
+                    'change_set_type': 'UPDATE'},
+                   self.provider.interactive_update_stack],
+                  [{'force_interactive': True,
+                    'force_change_set': False,
+                    'change_set_type': 'CREATE'},
+                   self.provider.interactive_update_stack],
+                  [{'force_interactive': False,
+                    'force_change_set': False,
+                    'change_set_type': 'CREATE'},
+                   self.provider.interactive_update_stack],
+                  [{'force_interactive': False,
+                    'force_change_set': True,
+                    'change_set_type': 'UPDATE'},
+                   self.provider.interactive_update_stack]]:
+            self.assertEquals(
+                self.provider.select_update_method(**i[0]),
+                i[1]
+            )


### PR DESCRIPTION
Trying to perform a `create_stack` with a template including a
'Transform' generates the following error:
```
botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the CreateStack operation: CreateStack cannot be used with templates containing Transforms.
```

This detects these templates and ensures that they are only
deployed via change sets.