### PR TITLE
add stacker.cmd for windows installs

### DIFF
--- a/scripts/stacker.cmd
+++ b/scripts/stacker.cmd
@@ -1,0 +1,45 @@
+@echo OFF
+REM="""
+setlocal
+set PythonExe=""
+set PythonExeFlags=
+
+for %%i in (cmd bat exe) do (
+    for %%j in (python.%%i) do (
+        call :SetPythonExe "%%~$PATH:j"
+    )
+)
+for /f "tokens=2 delims==" %%i in ('assoc .py') do (
+    for /f "tokens=2 delims==" %%j in ('ftype %%i') do (
+        for /f "tokens=1" %%k in ("%%j") do (
+            call :SetPythonExe %%k
+        )
+    )
+)
+%PythonExe% -x %PythonExeFlags% "%~f0" %*
+exit /B %ERRORLEVEL%
+goto :EOF
+
+:SetPythonExe
+if not ["%~1"]==[""] (
+    if [%PythonExe%]==[""] (
+        set PythonExe="%~1"
+    )
+)
+goto :EOF
+"""
+
+# ===================================================
+# Python script starts here
+# Above helper adapted from https://github.com/aws/aws-cli/blob/1.11.121/bin/aws.cmd
+# ===================================================
+
+#!/usr/bin/env python
+
+from stacker.commands import Stacker
+
+if __name__ == "__main__":
+    stacker = Stacker()
+    args = stacker.parse_args()
+    stacker.configure(args)
+    args.run(args)

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup_requires = [
 scripts = [
     "scripts/compare_env",
     "scripts/docker-stacker",
+    "scripts/stacker.cmd",
     "scripts/stacker"
 ]
 


### PR DESCRIPTION
Adapted from awscli's implementation, this allows `stacker` to be executed natively  on Windows

Fixes #441 