### PR TITLE
DAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Upcoming/Master
 
 - assertRenderedBlueprint always dumps current results [GH-528]
+- stacker now builds a DAG internally [GH-523]
 
 ## 1.1.4 (2018-01-26)
 

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,10 +1,9 @@
-import copy
 import logging
-import sys
+
+from ..plan2 import Step, build_plan
 
 import botocore.exceptions
 from stacker.session_cache import get_session
-from stacker.exceptions import PlanFailed
 
 from stacker.util import (
     ensure_s3_bucket,
@@ -12,6 +11,40 @@ from stacker.util import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def plan(description, action, stacks,
+         targets=None, tail=None,
+         reverse=False):
+    """A simple helper that builds a graph based plan from a set of stacks.
+
+    Args:
+        description (str): a description of the plan.
+        action (func): a function to call for each stack.
+        stacks (list): a list of :class:`stacker.stack.Stack` objects to build.
+        targets (list): an optional list of targets to filter the graph to.
+        tail (func): an optional function to call to tail the stack progress.
+        reverse (bool): if True, execute the graph in reverse (useful for
+            destroy actions).
+
+    Returns:
+        :class:`plan.Plan`: The resulting plan object
+    """
+
+    steps = [
+        Step(stack, fn=action, watch_func=tail)
+        for stack in stacks]
+
+    plan = build_plan(
+        description=description,
+        steps=steps,
+        targets=targets,
+        reverse=reverse)
+
+    for step in steps:
+        step.status_changed_func = plan._check_point
+
+    return plan
 
 
 def stack_template_key_name(blueprint):
@@ -126,13 +159,9 @@ class BaseAction(object):
         return template_url
 
     def execute(self, *args, **kwargs):
-        try:
-            self.pre_run(*args, **kwargs)
-            self.run(*args, **kwargs)
-            self.post_run(*args, **kwargs)
-        except PlanFailed as e:
-            logger.error(e.message)
-            sys.exit(1)
+        self.pre_run(*args, **kwargs)
+        self.run(*args, **kwargs)
+        self.post_run(*args, **kwargs)
 
     def pre_run(self, *args, **kwargs):
         pass
@@ -142,60 +171,3 @@ class BaseAction(object):
 
     def post_run(self, *args, **kwargs):
         pass
-
-    def _get_all_stack_names(self, dependencies):
-        """Get all stack names specified in dependencies.
-
-        Args:
-            - dependencies (dict): a dictionary where each key should be the
-                fully qualified name of a stack whose value is an array of
-                fully qualified stack names that the stack depends on.
-
-        Returns:
-            set: set of all stack names
-
-        """
-        return set(
-            dependencies.keys() +
-            [item for items in dependencies.values() for item in items]
-        )
-
-    def get_stack_execution_order(self, dependencies):
-        """Return the order in which the stacks should be executed.
-
-        Args:
-            - dependencies (dict): a dictionary where each key should be the
-                fully qualified name of a stack whose value is an array of
-                fully qualified stack names that the stack depends on. This is
-                used to generate the order in which the stacks should be
-                executed.
-
-        Returns:
-            array: An array of stack names in the order which they should be
-                executed.
-
-        """
-        # copy the dependencies since we pop items out of it to get the
-        # execution order, we don't want to mutate the one passed in
-        dependencies = copy.deepcopy(dependencies)
-        pending_steps = []
-        executed_steps = []
-        stack_names = self._get_all_stack_names(dependencies)
-        for stack_name in stack_names:
-            requirements = dependencies.get(stack_name, None)
-            if not requirements:
-                dependencies.pop(stack_name, None)
-                pending_steps.append(stack_name)
-
-        while dependencies:
-            for step in pending_steps:
-                for stack_name, requirements in dependencies.items():
-                    if step in requirements:
-                        requirements.remove(step)
-
-                    if not requirements:
-                        dependencies.pop(stack_name)
-                        pending_steps.append(stack_name)
-                pending_steps.remove(step)
-                executed_steps.append(step)
-        return executed_steps + pending_steps

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -1,6 +1,7 @@
 import logging
+import sys
 
-from .base import BaseAction
+from .base import BaseAction, plan
 
 from ..providers.base import Template
 from .. import util
@@ -10,7 +11,6 @@ from ..exceptions import (
     StackDoesNotExist,
 )
 
-from ..plan import Plan
 from ..status import (
     NotSubmittedStatus,
     NotUpdatedStatus,
@@ -315,31 +315,12 @@ class Action(BaseAction):
             return Template(body=blueprint.rendered)
 
     def _generate_plan(self, tail=False):
-        plan_kwargs = {}
-        if tail:
-            plan_kwargs["watch_func"] = self.provider.tail_stack
-
-        plan = Plan(description="Create/Update stacks",
-                    logger_type=self.context.logger_type, **plan_kwargs)
-        stacks = self.context.get_stacks_dict()
-        dependencies = self._get_dependencies()
-        for stack_name in self.get_stack_execution_order(dependencies):
-            try:
-                stack = stacks[stack_name]
-            except KeyError:
-                raise StackDoesNotExist(stack_name)
-            plan.add(
-                stack,
-                run_func=self._launch_stack,
-                requires=dependencies.get(stack_name),
-            )
-        return plan
-
-    def _get_dependencies(self):
-        dependencies = {}
-        for stack in self.context.get_stacks():
-            dependencies[stack.fqn] = stack.requires
-        return dependencies
+        return plan(
+            description="Create/Update stacks",
+            action=self._launch_stack,
+            tail=self.provider.tail_stack if tail else None,
+            stacks=self.context.get_stacks(),
+            targets=self.context.stack_names)
 
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
@@ -363,7 +344,8 @@ class Action(BaseAction):
         if not outline and not dump:
             plan.outline(logging.DEBUG)
             logger.debug("Launching stacks: %s", ", ".join(plan.keys()))
-            plan.execute()
+            if not plan.execute():
+                sys.exit(1)
         else:
             if outline:
                 plan.outline()

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -27,10 +27,10 @@ class Build(BaseCommand):
                                  "the config.")
         parser.add_argument("--stacks", action="append",
                             metavar="STACKNAME", type=str,
-                            help="Only work on the stacks given. Can be "
-                                 "specified more than once. If not specified "
-                                 "then stacker will work on all stacks in the "
-                                 "config file.")
+                            help="Only work on the stacks given, and their "
+                                 "dependencies. Can be specified more than "
+                                 "once. If not specified then stacker will "
+                                 "work on all stacks in the config file.")
         parser.add_argument("-t", "--tail", action="store_true",
                             help="Tail the CloudFormation logs while working "
                                  "with stacks")

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -119,10 +119,7 @@ class Context(object):
         return self.config.mappings or {}
 
     def _get_stack_definitions(self):
-        if not self.stack_names:
-            return self.config.stacks
-        return [s for s in self.config.stacks if s.name in
-                self.stack_names]
+        return self.config.stacks
 
     def get_stacks(self):
         """Get the stacks for the current action.

--- a/stacker/dag/__init__.py
+++ b/stacker/dag/__init__.py
@@ -1,0 +1,366 @@
+import collections
+import logging
+from copy import copy, deepcopy
+from collections import deque
+
+logger = logging.getLogger(__name__)
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
+
+class DAGValidationError(Exception):
+    pass
+
+
+class DAG(object):
+    """ Directed acyclic graph implementation. """
+
+    def __init__(self):
+        """ Construct a new DAG with no nodes or edges. """
+        self.reset_graph()
+
+    def add_node(self, node_name):
+        """ Add a node if it does not exist yet, or error out.
+
+        Args:
+            node_name (str): The unique name of the node to add.
+
+        Raises:
+            KeyError: Raised if a node with the same name already exist in the
+                      graph
+        """
+        graph = self.graph
+        if node_name in graph:
+            raise KeyError('node %s already exists' % node_name)
+        graph[node_name] = set()
+
+    def add_node_if_not_exists(self, node_name):
+        """ Add a node if it does not exist yet, ignoring duplicates.
+
+        Args:
+            node_name (str): The name of the node to add.
+        """
+        try:
+            self.add_node(node_name)
+        except KeyError:
+            pass
+
+    def delete_node(self, node_name):
+        """ Deletes this node and all edges referencing it.
+
+        Args:
+            node_name (str): The name of the node to delete.
+
+        Raises:
+            KeyError: Raised if the node does not exist in the graph.
+        """
+        graph = self.graph
+        if node_name not in graph:
+            raise KeyError('node %s does not exist' % node_name)
+        graph.pop(node_name)
+
+        for node, edges in graph.iteritems():
+            if node_name in edges:
+                edges.remove(node_name)
+
+    def delete_node_if_exists(self, node_name):
+        """ Deletes this node and all edges referencing it.
+
+        Ignores any node that is not in the graph, rather than throwing an
+        exception.
+
+        Args:
+            node_name (str): The name of the node to delete.
+        """
+
+        try:
+            self.delete_node(node_name)
+        except KeyError:
+            pass
+
+    def add_edge(self, ind_node, dep_node):
+        """ Add an edge (dependency) between the specified nodes.
+
+        Args:
+            ind_node (str): The independent node to add an edge to.
+            dep_node (str): The dependent node that has a dependency on the
+                            ind_node.
+
+        Raises:
+            KeyError: Either the ind_node, or dep_node do not exist.
+            DAGValidationError: Raised if the resulting graph is invalid.
+        """
+        graph = self.graph
+        if ind_node not in graph:
+            raise KeyError('independent node %s does not exist' % ind_node)
+        if dep_node not in graph:
+            raise KeyError('dependent node %s does not exist' % dep_node)
+        test_graph = deepcopy(graph)
+        test_graph[ind_node].add(dep_node)
+        test_dag = DAG()
+        test_dag.graph = test_graph
+        is_valid, message = test_dag.validate()
+        if is_valid:
+            graph[ind_node].add(dep_node)
+        else:
+            raise DAGValidationError(message)
+
+    def delete_edge(self, ind_node, dep_node):
+        """ Delete an edge from the graph.
+
+        Args:
+            ind_node (str): The independent node to delete an edge from.
+            dep_node (str): The dependent node that has a dependency on the
+                            ind_node.
+
+        Raises:
+            KeyError: Raised when the edge doesn't already exist.
+        """
+        graph = self.graph
+        if dep_node not in graph.get(ind_node, []):
+            raise KeyError("No edge exists between %s and %s." % (
+                ind_node, dep_node
+                )
+            )
+        graph[ind_node].remove(dep_node)
+
+    def transpose(self):
+        """ Builds a new graph with the edges reversed.
+
+        Returns:
+            :class:`stacker.dag.DAG`: The transposed graph.
+        """
+        graph = self.graph
+        transposed = DAG()
+        for node, edges in graph.items():
+            transposed.add_node(node)
+        for node, edges in graph.items():
+            # for each edge A -> B, transpose it so that B -> A
+            for edge in edges:
+                transposed.add_edge(edge, node)
+        return transposed
+
+    def walk(self, walk_func):
+        """ Walks each node of the graph in reverse topological order.
+        This can be used to perform a set of operations, where the next
+        operation depends on the previous operation. It's important to note
+        that walking happens serially, and is not paralellized.
+
+        Args:
+            walk_func (:class:`types.FunctionType`): The function to be called
+                on each node of the graph.
+
+        Returns:
+            bool: True if the function succeeded on every node, otherwise
+                  False.
+        """
+        nodes = self.topological_sort()
+        # Reverse so we start with nodes that have no dependencies.
+        nodes.reverse()
+
+        failed = False
+        for n in nodes:
+            if not walk_func(n):
+                failed = True
+
+        return not failed
+
+    def rename_edges(self, old_node_name, new_node_name):
+        """ Change references to a node in existing edges.
+
+        Args:
+            old_node_name (str): The old name for the node.
+            new_node_name (str): The new name for the node.
+        """
+        graph = self.graph
+        for node, edges in graph.items():
+            if node == old_node_name:
+                graph[new_node_name] = copy(edges)
+                del graph[old_node_name]
+
+            else:
+                if old_node_name in edges:
+                    edges.remove(old_node_name)
+                    edges.add(new_node_name)
+
+    def predecessors(self, node):
+        """ Returns a list of all immediate predecessors of the given node
+
+        Args:
+            node (str): The node whose predecessors you want to find.
+
+        Returns:
+            list: A list of nodes that are immediate predecessors to node.
+        """
+        graph = self.graph
+        return [key for key in graph if node in graph[key]]
+
+    def downstream(self, node):
+        """ Returns a list of all nodes this node has edges towards.
+
+        Args:
+            node (str): The node whose downstream nodes you want to find.
+
+        Returns:
+            list: A list of nodes that are immediately downstream from the
+                  node.
+        """
+        graph = self.graph
+        if node not in graph:
+            raise KeyError('node %s is not in graph' % node)
+        return list(graph[node])
+
+    def all_downstreams(self, node):
+        """Returns a list of all nodes ultimately downstream
+        of the given node in the dependency graph, in
+        topological order.
+
+        Args:
+             node (str): The node whose downstream nodes you want to find.
+
+        Returns:
+            list: A list of nodes that are downstream from the node.
+        """
+        nodes = [node]
+        nodes_seen = set()
+        i = 0
+        while i < len(nodes):
+            downstreams = self.downstream(nodes[i])
+            for downstream_node in downstreams:
+                if downstream_node not in nodes_seen:
+                    nodes_seen.add(downstream_node)
+                    nodes.append(downstream_node)
+            i += 1
+        return filter(
+                lambda node: node
+                in nodes_seen, self.topological_sort())
+
+    def filter(self, nodes):
+        """ Returns a new DAG with only the given nodes and their
+        dependencies.
+
+        Args:
+            nodes (list): The nodes you are interested in.
+
+        Returns:
+            :class:`stacker.dag.DAG`: The filtered graph.
+        """
+
+        filtered_dag = DAG()
+
+        # Add only the nodes we need.
+        for node in nodes:
+            filtered_dag.add_node_if_not_exists(node)
+            for edge in self.all_downstreams(node):
+                filtered_dag.add_node_if_not_exists(edge)
+
+        # Now, rebuild the graph for each node that's present.
+        for node, edges in self.graph.items():
+            if node in filtered_dag.graph:
+                filtered_dag.graph[node] = edges
+
+        return filtered_dag
+
+    def all_leaves(self):
+        """ Return a list of all leaves (nodes with no downstreams)
+
+        Returns:
+            list: A list of all the nodes with no downstreams.
+        """
+        graph = self.graph
+        return [key for key in graph if not graph[key]]
+
+    def from_dict(self, graph_dict):
+        """ Reset the graph and build it from the passed dictionary.
+
+        The dictionary takes the form of {node_name: [directed edges]}
+
+        Args:
+            graph_dict (dict): The dictionary used to create the graph.
+
+        Raises:
+            TypeError: Raised if the value of items in the dict are not lists.
+        """
+
+        self.reset_graph()
+        for new_node in graph_dict.iterkeys():
+            self.add_node(new_node)
+        for ind_node, dep_nodes in graph_dict.iteritems():
+            if not isinstance(dep_nodes, collections.Iterable):
+                raise TypeError('%s: dict values must be lists' % ind_node)
+            for dep_node in dep_nodes:
+                self.add_edge(ind_node, dep_node)
+
+    def reset_graph(self):
+        """ Restore the graph to an empty state. """
+        self.graph = OrderedDict()
+
+    def ind_nodes(self):
+        """ Returns a list of all nodes in the graph with no dependencies.
+
+        Returns:
+            list: A list of all independent nodes.
+        """
+        graph = self.graph
+
+        dependent_nodes = set(
+            node for dependents
+            in graph.itervalues() for node in dependents)
+        return [node for node in graph.keys() if node not in dependent_nodes]
+
+    def validate(self):
+        """ Returns (Boolean, message) of whether DAG is valid. """
+        if len(self.ind_nodes()) == 0:
+            return (False, 'no independent nodes detected')
+        try:
+            self.topological_sort()
+        except ValueError as e:
+            return (False, e.message)
+        return (True, 'valid')
+
+    def topological_sort(self):
+        """ Returns a topological ordering of the DAG.
+
+        Returns:
+            list: A list of topologically sorted nodes in the graph.
+
+        Raises:
+            ValueError: Raised if the graph is not acyclic.
+        """
+        graph = self.graph
+
+        in_degree = {}
+        for u in graph:
+            in_degree[u] = 0
+
+        for u in graph:
+            for v in graph[u]:
+                in_degree[v] += 1
+
+        queue = deque()
+        for u in in_degree:
+            if in_degree[u] == 0:
+                queue.appendleft(u)
+
+        sorted_graph = []
+        while queue:
+            u = queue.pop()
+            sorted_graph.append(u)
+            for v in graph[u]:
+                in_degree[v] -= 1
+                if in_degree[v] == 0:
+                    queue.appendleft(v)
+
+        if len(sorted_graph) == len(graph):
+            return sorted_graph
+        else:
+            raise ValueError('graph is not acyclic')
+
+    def size(self):
+        return len(self)
+
+    def __len__(self):
+        return len(self.graph)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -217,3 +217,17 @@ class PlanFailed(Exception):
         message = "The following stacks failed: %s\n" % (stack_names,)
 
         super(PlanFailed, self).__init__(message, *args, **kwargs)
+
+
+class GraphError(Exception):
+    """Raised when the graph is invalid (e.g. acyclic dependencies)
+    """
+
+    def __init__(self, exception, stack, dependency):
+        self.stack = stack
+        self.dependency = dependency
+        self.exception = exception
+        message = ("Error detected when adding '%s' "
+                   "as a dependency of '%s': %s") % (
+                           dependency, stack, exception.message)
+        super(GraphError, self).__init__(message)

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -9,7 +9,7 @@ import uuid
 from colorama.ansi import Fore
 
 
-from .actions.base import stack_template_key_name
+from .util import stack_template_key_name
 from .exceptions import (
     CancelExecution,
     ImproperlyConfigured,

--- a/stacker/plan2.py
+++ b/stacker/plan2.py
@@ -1,0 +1,400 @@
+import os
+import logging
+import time
+import uuid
+import multiprocessing
+
+from colorama.ansi import Fore
+
+from .util import stack_template_key_name
+from .exceptions import (
+    CancelExecution,
+    GraphError,
+)
+from .dag import DAG, DAGValidationError
+from .status import (
+    FailedStatus,
+    SkippedStatus,
+    PENDING,
+    SUBMITTED,
+    COMPLETE,
+    SKIPPED,
+    FAILED,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Step(object):
+    """State machine for executing generic actions related to stacks.
+    Args:
+        stack (:class:`stacker.stack.Stack`): the stack associated
+            with this step
+        fn (func): the function to run to execute the step. This function will
+            be ran multiple times until the step is "done".
+        watch_func (func): an optional function that will be called to "tail"
+            the step action.
+        status_changed_func (func): an optional function that will be called
+            when the step changes status.
+    """
+
+    def __init__(self, stack, fn, watch_func=None,
+                 status_changed_func=None):
+        self.stack = stack
+        self.status = PENDING
+        self.last_updated = time.time()
+        self.fn = fn
+        self.watch_func = watch_func
+        self.status_changed_func = status_changed_func
+
+    def __repr__(self):
+        return "<stacker.plan.Step:%s>" % (self.stack.fqn,)
+
+    def run(self):
+        """Runs this step until it has completed successfully, or been
+        skipped.
+        """
+
+        watcher = None
+        if self.watch_func:
+            watcher = multiprocessing.Process(
+                target=self.watch_func,
+                args=(self.stack,)
+            )
+            watcher.start()
+
+        try:
+            if self.status_changed_func:
+                self.status_changed_func()
+
+            while not self.done:
+                self._run_once()
+        finally:
+            if watcher and watcher.is_alive():
+                watcher.terminate()
+                watcher.join()
+        return self.ok
+
+    def _run_once(self):
+        try:
+            status = self.fn(self.stack, status=self.status)
+        except CancelExecution:
+            status = SkippedStatus(reason="canceled execution")
+        self.set_status(status)
+        return status
+
+    @property
+    def name(self):
+        return self.stack.fqn
+
+    @property
+    def short_name(self):
+        return self.stack.name
+
+    @property
+    def requires(self):
+        return self.stack.requires
+
+    @property
+    def completed(self):
+        """Returns True if the step is in a COMPLETE state."""
+        return self.status == COMPLETE
+
+    @property
+    def skipped(self):
+        """Returns True if the step is in a SKIPPED state."""
+        return self.status == SKIPPED
+
+    @property
+    def failed(self):
+        """Returns True if the step is in a FAILED state."""
+        return self.status == FAILED
+
+    @property
+    def done(self):
+        """Returns True if the step is finished (either COMPLETE, SKIPPED or FAILED)
+        """
+        return self.completed or self.skipped or self.failed
+
+    @property
+    def ok(self):
+        """Returns True if the step is finished (either COMPLETE or SKIPPED)"""
+        return self.completed or self.skipped
+
+    @property
+    def submitted(self):
+        """Returns True if the step is SUBMITTED, COMPLETE, or SKIPPED."""
+        return self.status >= SUBMITTED
+
+    def set_status(self, status):
+        """Sets the current step's status.
+        Args:
+            status (:class:`Status <Status>` object): The status to set the
+                step to.
+        """
+        if status is not self.status:
+            logger.debug("Setting %s state to %s.", self.stack.name,
+                         status.name)
+            self.status = status
+            self.last_updated = time.time()
+            if self.status_changed_func:
+                self.status_changed_func()
+
+    def complete(self):
+        """A shortcut for set_status(COMPLETE)"""
+        self.set_status(COMPLETE)
+
+    def skip(self):
+        """A shortcut for set_status(SKIPPED)"""
+        self.set_status(SKIPPED)
+
+    def submit(self):
+        """A shortcut for set_status(SUBMITTED)"""
+        self.set_status(SUBMITTED)
+
+
+def build_plan(description, steps,
+               targets=None, reverse=False):
+    """Builds a plan from a list of steps.
+    Args:
+        description (str): an arbitrary string to
+            describe the plan.
+        steps (list): a list of :class:`Step` objects to execute.
+        targets (list): an optional list of step names to filter the graph to.
+            If provided, only these steps, and their transitive dependencies
+            will be executed. If no targets are specified, every node in the
+            graph will be executed.
+        reverse (bool): If provided, the graph will be walked in reverse order
+            (dependencies last).
+    """
+    graph = build_graph(steps)
+
+    # If we want to execute the plan in reverse (e.g. Destroy), transpose the
+    # graph.
+    if reverse:
+        graph = graph.transposed()
+
+    # If we only want to build a specific target, filter the graph.
+    if targets:
+        nodes = []
+        for target in targets:
+            for step in steps:
+                if step.short_name == target:
+                    nodes.append(step.name)
+        graph = graph.filtered(nodes)
+
+    return Plan(description=description, graph=graph)
+
+
+def build_graph(steps):
+    """Builds a graph of steps.
+    Args:
+        steps (list): a list of :class:`Step` objects to execute.
+    """
+
+    graph = Graph()
+
+    for step in steps:
+        graph.add_step(step)
+
+    for step in steps:
+        for dep in step.requires:
+            graph.connect(step, dep)
+
+    return graph
+
+
+class Graph(object):
+    """Graph represents a graph of steps.
+
+    The :class:`Graph` helps organize the steps needed to execute a particular
+    action for a set of :class:`stacker.stack.Stack` objects. When initialized
+    with a set of steps, it will first build a Directed Acyclic Graph from the
+    steps and their dependencies.
+
+    Example:
+
+    >>> dag = DAG()
+    >>> a = Step("a", fn=build)
+    >>> b = Step("b", fn=build)
+    >>> dag.add_step(a)
+    >>> dag.add_step(b)
+    >>> dag.connect(a, b)
+
+    Args:
+        steps (list): an optional list of :class:`Step` objects to execute.
+        dag (:class:`stacker.dag.DAG`): an optional :class:`stacker.dag.DAG`
+            object. If one is not provided, a new one will be initialized.
+    """
+
+    def __init__(self, steps=None, dag=None):
+        self.steps = steps or {}
+        self.dag = dag or DAG()
+
+    def add_step(self, step):
+        self.steps[step.name] = step
+        self.dag.add_node(step.name)
+
+    def connect(self, step, dep):
+        try:
+            self.dag.add_edge(step.name, dep)
+        except KeyError as e:
+            raise GraphError(e, step.name, dep)
+        except DAGValidationError as e:
+            raise GraphError(e, step.name, dep)
+
+    def walk(self, walk_func):
+        def fn(step_name):
+            step = self.steps[step_name]
+            return walk_func(step)
+
+        return self.dag.walk(fn)
+
+    def downstream(self, step_name):
+        """Returns the direct dependencies of the given step"""
+        return list(self.steps[dep] for dep in self.dag.downstream(step_name))
+
+    def transposed(self):
+        """Returns a "transposed" version of this graph. Useful for walking in
+        reverse.
+        """
+        return Graph(steps=self.steps, dag=self.dag.transpose())
+
+    def filtered(self, step_names):
+        """Returns a "filtered" version of this graph."""
+        return Graph(steps=self.steps, dag=self.dag.filter(step_names))
+
+    def topological_sort(self):
+        nodes = self.dag.topological_sort()
+        return [self.steps[step_name] for step_name in nodes]
+
+    def to_dict(self):
+        return self.dag.graph
+
+
+class Plan(object):
+    """A convenience class for working on a Graph.
+    Args:
+        description (str): description of the plan.
+        graph (:class:`Graph`): a graph of steps.
+    """
+
+    def __init__(self, description, graph):
+        self.id = uuid.uuid4()
+        self.description = description
+        self.graph = graph
+
+    def outline(self, level=logging.INFO, message=""):
+        """Print an outline of the actions the plan is going to take.
+        The outline will represent the rough ordering of the steps that will be
+        taken.
+        Args:
+            level (int, optional): a valid log level that should be used to log
+                the outline
+            message (str, optional): a message that will be logged to
+                the user after the outline has been logged.
+        """
+        steps = 1
+        logger.log(level, "Plan \"%s\":", self.description)
+        for step in self.steps:
+            logger.log(
+                level,
+                "  - step: %s: target: \"%s\", action: \"%s\"",
+                steps,
+                step.short_name,
+                step.fn.__name__,
+            )
+            steps += 1
+
+        if message:
+            logger.log(level, message)
+
+    def dump(self, directory, context, provider=None):
+        logger.info("Dumping \"%s\"...", self.description)
+        directory = os.path.expanduser(directory)
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
+        def walk_func(step):
+            step.stack.resolve(
+                context=context,
+                provider=provider,
+            )
+            blueprint = step.stack.blueprint
+            filename = stack_template_key_name(blueprint)
+            path = os.path.join(directory, filename)
+
+            blueprint_dir = os.path.dirname(path)
+            if not os.path.exists(blueprint_dir):
+                os.makedirs(blueprint_dir)
+
+            logger.info("Writing stack \"%s\" -> %s", step.name, path)
+            with open(path, "w") as f:
+                f.write(blueprint.rendered)
+
+            return True
+
+        return self.graph.walk(walk_func)
+
+    def execute(self, **kwargs):
+        return self.walk(**kwargs)
+
+    def walk(self):
+        """Walks each step in the underlying graph, in topological order."""
+
+        def walk_func(step):
+            # Before we execute the step, we need to ensure that it's
+            # transitive dependencies are all in an "ok" state. If not, we
+            # won't execute this step.
+            for dep in self.graph.downstream(step.name):
+                if not dep.ok:
+                    step.set_status(FailedStatus("dependency has failed"))
+                    return step.ok
+
+            return step.run()
+
+        return self.graph.walk(walk_func)
+
+    def _check_point(self):
+        """Outputs the current status of all steps in the plan."""
+        status_to_color = {
+            SUBMITTED.code: Fore.YELLOW,
+            COMPLETE.code: Fore.GREEN,
+        }
+        logger.info("Plan Status:", extra={"reset": True, "loop": self.id})
+
+        longest = 0
+        messages = []
+        for step in self.steps:
+            length = len(step.name)
+            if length > longest:
+                longest = length
+
+            msg = "%s: %s" % (step.name, step.status.name)
+            if step.status.reason:
+                msg += " (%s)" % (step.status.reason)
+
+            messages.append((msg, step))
+
+        for msg, step in messages:
+            parts = msg.split(' ', 1)
+            fmt = "\t{0: <%d}{1}" % (longest + 2,)
+            color = status_to_color.get(step.status.code, Fore.WHITE)
+            logger.info(fmt.format(*parts), extra={
+                'loop': self.id,
+                'color': color,
+                'last_updated': step.last_updated,
+            })
+
+    @property
+    def steps(self):
+        steps = self.graph.topological_sort()
+        steps.reverse()
+        return steps
+
+    @property
+    def step_names(self):
+        return [step.name for step in self.steps]
+
+    def keys(self):
+        return self.step_names

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -3,8 +3,7 @@ import unittest
 import mock
 
 from stacker.actions import destroy
-from stacker.context import Context
-from stacker.config import Config
+from stacker.context import Context, Config
 from stacker.exceptions import StackDoesNotExist
 from stacker.status import (
     COMPLETE,
@@ -41,10 +40,25 @@ class TestDestroyAction(unittest.TestCase):
 
     def test_generate_plan(self):
         plan = self.action._generate_plan()
-        stacks = ["other", "db", "instance", "bastion", "vpc"]
         self.assertEqual(
-            [self.context.get_fqn(s) for s in stacks],
-            plan.keys(),
+            {
+                'namespace-vpc': set(
+                    [
+                        'namespace-db',
+                        'namespace-instance',
+                        'namespace-bastion']),
+                'namespace-other': set([]),
+                'namespace-bastion': set(
+                    [
+                        'namespace-instance',
+                        'namespace-db']),
+                'namespace-instance': set(
+                    [
+                        'namespace-db']),
+                'namespace-db': set(
+                    [
+                        'namespace-other'])},
+            plan.graph.to_dict()
         )
 
     def test_only_execute_plan_when_forced(self):
@@ -73,64 +87,6 @@ class TestDestroyAction(unittest.TestCase):
         # we successfully deleted it
         self.assertEqual(status, COMPLETE)
 
-    def test_destroy_stack_in_parallel(self):
-        count = {"_count": 0}
-        mock_provider = mock.MagicMock()
-        self.context.config = Config({
-            "namespace": "namespace",
-            "stacks": [
-                {"name": "vpc"},
-                {"name": "bastion", "requires": ["vpc"]},
-                {"name": "instance", "requires": ["vpc"]},
-                {"name": "db", "requires": ["vpc"]},
-            ],
-        })
-        stacks_dict = self.context.get_stacks_dict()
-
-        def get_stack(stack_name):
-            return stacks_dict.get(stack_name)
-
-        def get_stack_staggered(stack_name):
-            count["_count"] += 1
-            if not count["_count"] % 2:
-                raise StackDoesNotExist(stack_name)
-            return stacks_dict.get(stack_name)
-
-        def wait_func(*args):
-            # we want "get_stack" above to return staggered results for the
-            # stack being "deleted" to simulate waiting on stacks to complete
-            mock_provider.get_stack.side_effect = get_stack_staggered
-
-        plan = self.action._generate_plan()
-        plan._wait_func = wait_func
-
-        # swap for mock provider
-        plan.provider = mock_provider
-        self.action.provider = mock_provider
-
-        # we want "get_stack" to return the mock stacks above on the first
-        # pass. "wait_func" will simulate the stack being deleted every second
-        # pass
-        mock_provider.get_stack.side_effect = get_stack
-        mock_provider.is_stack_destroyed.return_value = False
-        mock_provider.is_stack_in_progress.return_value = True
-
-        independent_stacks = filter(lambda x: x.name != "vpc",
-                                    self.context.get_stacks())
-        while not plan._single_run():
-            # vpc should be the last stack that is deleted
-            if plan["namespace-vpc"].completed:
-                self.assertFalse(plan.list_pending())
-
-            # all of the independent stacks should be submitted at the same
-            # time
-            submitted_stacks = [
-                plan[stack.fqn].submitted for stack in independent_stacks
-            ]
-            if any(submitted_stacks):
-                self.assertTrue(all(submitted_stacks))
-            wait_func()
-
     def test_destroy_stack_step_statuses(self):
         mock_provider = mock.MagicMock()
         stacks_dict = self.context.get_stacks_dict()
@@ -139,7 +95,7 @@ class TestDestroyAction(unittest.TestCase):
             return stacks_dict.get(stack_name)
 
         plan = self.action._generate_plan()
-        _, step = plan.list_pending()[0]
+        step = plan.steps[0]
         # we need the AWS provider to generate the plan, but swap it for
         # the mock one to make the test easier
         self.action.provider = mock_provider
@@ -154,13 +110,13 @@ class TestDestroyAction(unittest.TestCase):
         mock_provider.get_stack.side_effect = get_stack
         mock_provider.is_stack_destroyed.return_value = False
         mock_provider.is_stack_in_progress.return_value = False
-        status = step.run()
+        status = step._run_once()
         self.assertEqual(status, SUBMITTED)
         mock_provider.is_stack_destroyed.return_value = False
         mock_provider.is_stack_in_progress.return_value = True
-        status = step.run()
+        status = step._run_once()
         self.assertEqual(status, SUBMITTED)
         mock_provider.is_stack_destroyed.return_value = True
         mock_provider.is_stack_in_progress.return_value = False
-        status = step.run()
+        status = step._run_once()
         self.assertEqual(status, COMPLETE)

--- a/stacker/tests/test_context.py
+++ b/stacker/tests/test_context.py
@@ -21,13 +21,6 @@ class TestContext(unittest.TestCase):
         self.assertEqual(context.mappings, {})
         self.assertEqual(context.stack_names, ["stack"])
 
-    def test_context_get_stacks_specific_stacks(self):
-        context = Context(
-            config=self.config,
-            stack_names=["stack2"],
-        )
-        self.assertEqual(len(context.get_stacks()), 1)
-
     def test_context_get_stacks(self):
         context = Context(config=self.config)
         self.assertEqual(len(context.get_stacks()), 2)

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -1,0 +1,188 @@
+""" Tests on the DAG implementation """
+
+from nose import with_setup
+from nose.tools import nottest, raises
+from stacker.dag import DAG, DAGValidationError
+
+dag = None
+
+
+@nottest
+def blank_setup():
+    global dag
+    dag = DAG()
+
+
+@nottest
+def start_with_graph():
+    global dag
+    dag = DAG()
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+
+@with_setup(blank_setup)
+def test_add_node():
+    dag.add_node('a')
+    assert dag.graph == {'a': set()}
+
+
+@with_setup(start_with_graph)
+def test_transpose():
+    transposed = dag.transpose()
+    assert transposed.graph == {'d': set(['c', 'b']),
+                                'c': set(['a']),
+                                'b': set(['a']),
+                                'a': set([])}
+
+
+@with_setup(blank_setup)
+def test_add_edge():
+    dag.add_node('a')
+    dag.add_node('b')
+    dag.add_edge('a', 'b')
+    assert dag.graph == {'a': set('b'), 'b': set()}
+
+
+@with_setup(blank_setup)
+def test_from_dict():
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+    assert dag.graph == {'a': set(['b', 'c']),
+                         'b': set('d'),
+                         'c': set('d'),
+                         'd': set()}
+
+
+@with_setup(blank_setup)
+def test_reset_graph():
+    dag.add_node('a')
+    assert dag.graph == {'a': set()}
+    dag.reset_graph()
+    assert dag.graph == {}
+
+
+@with_setup(blank_setup)
+def test_walk():
+    dag = DAG()
+
+    # b and c should be executed at the same time.
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+    nodes = []
+
+    def walk_func(n):
+        nodes.append(n)
+        return True
+
+    ok = dag.walk(walk_func)
+    assert ok == True  # noqa: E712
+    assert nodes == ['d', 'c', 'b', 'a'] or nodes == ['d', 'b', 'c', 'a']
+
+
+@with_setup(blank_setup)
+def test_walk_failed():
+    dag = DAG()
+
+    # b and c should be executed at the same time.
+    dag.from_dict({'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []})
+
+    nodes = []
+
+    def walk_func(n):
+        nodes.append(n)
+        return False
+
+    ok = dag.walk(walk_func)
+
+    # Only 2 should have been hit. The rest are canceled because they depend on
+    # the success of d.
+    assert ok == False  # noqa: E712
+    assert nodes == ['d', 'c', 'b', 'a'] or nodes == ['d', 'b', 'c', 'a']
+
+
+@with_setup(start_with_graph)
+def test_ind_nodes():
+    assert dag.ind_nodes() == ['a']
+
+
+@with_setup(blank_setup)
+def test_topological_sort():
+    dag.from_dict({'a': [],
+                   'b': ['a'],
+                   'c': ['b']})
+    assert dag.topological_sort() == ['c', 'b', 'a']
+
+
+@with_setup(start_with_graph)
+def test_successful_validation():
+    assert dag.validate()[0] == True  # noqa: E712
+
+
+@raises(DAGValidationError)
+@with_setup(blank_setup)
+def test_failed_validation():
+    dag.from_dict({'a': ['b'],
+                   'b': ['a']})
+
+
+@with_setup(start_with_graph)
+def test_downstream():
+    assert set(dag.downstream('a')) == set(['b', 'c'])
+
+
+@with_setup(start_with_graph)
+def test_all_downstreams():
+    assert dag.all_downstreams('a') == ['c', 'b', 'd']
+    assert dag.all_downstreams('b') == ['d']
+    assert dag.all_downstreams('d') == []
+
+
+@with_setup(start_with_graph)
+def test_all_downstreams_pass_graph():
+    dag2 = DAG()
+    dag2.from_dict({'a': ['c'],
+                    'b': ['d'],
+                    'c': ['d'],
+                    'd': []})
+    assert dag2.all_downstreams('a') == ['c', 'd']
+    assert dag2.all_downstreams('b') == ['d']
+    assert dag2.all_downstreams('d') == []
+
+
+@with_setup(start_with_graph)
+def test_predecessors():
+    assert set(dag.predecessors('a')) == set([])
+    assert set(dag.predecessors('b')) == set(['a'])
+    assert set(dag.predecessors('c')) == set(['a'])
+    assert set(dag.predecessors('d')) == set(['b', 'c'])
+
+
+@with_setup(start_with_graph)
+def test_filter():
+    dag2 = dag.filter(['b', 'c'])
+    assert dag2.graph == {'b': set('d'),
+                          'c': set('d'),
+                          'd': set()}
+
+
+@with_setup(start_with_graph)
+def test_all_leaves():
+    assert dag.all_leaves() == ['d']
+
+
+@with_setup(start_with_graph)
+def test_size():
+    assert dag.size() == 4
+    dag.delete_node('a')
+    assert dag.size() == 3

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 import mock
 
-from stacker.actions.base import stack_template_key_name
+from stacker.util import stack_template_key_name
 from stacker.context import Context
 from stacker.context import Config
 from stacker.exceptions import ImproperlyConfigured, FailedVariableLookup

--- a/stacker/tests/test_plan2.py
+++ b/stacker/tests/test_plan2.py
@@ -1,0 +1,298 @@
+import os
+import shutil
+import tempfile
+
+import unittest
+import mock
+
+from stacker.context import Context, Config
+from stacker.util import stack_template_key_name
+from stacker.lookups.registry import (
+    register_lookup_handler,
+    unregister_lookup_handler,
+)
+from stacker.plan2 import (
+    Step,
+    build_plan,
+)
+from stacker.exceptions import (
+    CancelExecution,
+    GraphError,
+)
+from stacker.status import (
+    COMPLETE,
+    SKIPPED,
+    FAILED,
+)
+from stacker.stack import Stack
+
+from .factories import generate_definition
+
+count = 0
+
+
+class TestStep(unittest.TestCase):
+
+    def setUp(self):
+        stack = mock.MagicMock()
+        self.step = Step(stack=stack, fn=None)
+
+    def test_status(self):
+        self.assertFalse(self.step.submitted)
+        self.assertFalse(self.step.completed)
+        self.step.submit()
+        self.assertTrue(self.step.submitted)
+        self.assertFalse(self.step.completed)
+        self.step.complete()
+        self.assertTrue(self.step.submitted)
+        self.assertTrue(self.step.completed)
+
+
+class TestPlan(unittest.TestCase):
+
+    def setUp(self):
+        self.count = 0
+        self.config = Config({"namespace": "namespace"})
+        self.context = Context(config=self.config)
+        register_lookup_handler("noop", lambda **kwargs: "test")
+
+    def tearDown(self):
+        unregister_lookup_handler("noop")
+
+    def test_plan(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        plan = build_plan(description="Test", steps=[
+            Step(vpc, fn=None), Step(bastion, fn=None)])
+
+        self.assertEqual(plan.graph.to_dict(), {
+            'namespace-bastion.1': set(['namespace-vpc.1']),
+            'namespace-vpc.1': set([])})
+
+    def test_execute_plan(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        calls = []
+
+        def fn(stack, status=None):
+            calls.append(stack.fqn)
+            return COMPLETE
+
+        plan = build_plan(
+            description="Test", steps=[Step(vpc, fn), Step(bastion, fn)])
+        plan.execute()
+
+        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+
+    def test_execute_plan_filtered(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        db = Stack(
+            definition=generate_definition('db', 1, requires=[vpc.fqn]),
+            context=self.context)
+        app = Stack(
+            definition=generate_definition('app', 1, requires=[db.fqn]),
+            context=self.context)
+
+        calls = []
+
+        def fn(stack, status=None):
+            calls.append(stack.fqn)
+            return COMPLETE
+
+        plan = build_plan(
+            description="Test",
+            steps=[Step(vpc, fn), Step(db, fn), Step(app, fn)],
+            targets=['db.1'])
+        self.assertTrue(plan.execute())
+
+        self.assertEquals(calls, [
+            'namespace-vpc.1', 'namespace-db.1'])
+
+    def test_execute_plan_exception(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        calls = []
+
+        def fn(stack, status=None):
+            calls.append(stack.fqn)
+            if stack.fqn == vpc_step.name:
+                raise ValueError('Boom')
+            return COMPLETE
+
+        vpc_step = Step(vpc, fn)
+        bastion_step = Step(bastion, fn)
+        plan = build_plan(description="Test", steps=[vpc_step, bastion_step])
+
+        with self.assertRaises(ValueError):
+            plan.execute()
+
+        self.assertEquals(calls, ['namespace-vpc.1'])
+
+    def test_execute_plan_skipped(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        calls = []
+
+        def fn(stack, status=None):
+            calls.append(stack.fqn)
+            if stack.fqn == vpc_step.name:
+                return SKIPPED
+            return COMPLETE
+
+        vpc_step = Step(vpc, fn)
+        bastion_step = Step(bastion, fn)
+
+        plan = build_plan(description="Test", steps=[vpc_step, bastion_step])
+        self.assertTrue(plan.execute())
+
+        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+
+    def test_execute_plan_failed(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+        db = Stack(
+            definition=generate_definition('db', 1),
+            context=self.context)
+
+        calls = []
+
+        def fn(stack, status=None):
+            calls.append(stack.fqn)
+            if stack.fqn == vpc_step.name:
+                return FAILED
+            return COMPLETE
+
+        vpc_step = Step(vpc, fn)
+        bastion_step = Step(bastion, fn)
+        db_step = Step(db, fn)
+
+        plan = build_plan(description="Test", steps=[
+            vpc_step, bastion_step, db_step])
+        self.assertFalse(plan.execute())
+
+        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-db.1'])
+
+    def test_execute_plan_cancelled(self):
+        vpc = Stack(
+            definition=generate_definition('vpc', 1),
+            context=self.context)
+        bastion = Stack(
+            definition=generate_definition('bastion', 1, requires=[vpc.fqn]),
+            context=self.context)
+
+        calls = []
+
+        def fn(stack, status=None):
+            calls.append(stack.fqn)
+            if stack.fqn == vpc_step.name:
+                raise CancelExecution
+            return COMPLETE
+
+        vpc_step = Step(vpc, fn)
+        bastion_step = Step(bastion, fn)
+
+        plan = build_plan(description="Test", steps=[
+            vpc_step, bastion_step])
+        self.assertTrue(plan.execute())
+
+        self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
+
+    def test_build_plan_missing_dependency(self):
+        bastion = Stack(
+            definition=generate_definition(
+                'bastion', 1, requires=['namespace-vpc.1']),
+            context=self.context)
+
+        with self.assertRaises(GraphError) as expected:
+            build_plan(description="Test", steps=[Step(bastion, None)])
+        message = ("Error detected when adding 'namespace-vpc.1' "
+                   "as a dependency of 'namespace-bastion.1': dependent node "
+                   "namespace-vpc.1 does not exist")
+        self.assertEqual(expected.exception.message, message)
+
+    def test_build_plan_cyclic_dependencies(self):
+        vpc = Stack(
+            definition=generate_definition(
+                'vpc', 1),
+            context=self.context)
+        db = Stack(
+            definition=generate_definition(
+                'db', 1, requires=['namespace-app.1']),
+            context=self.context)
+        app = Stack(
+            definition=generate_definition(
+                'app', 1, requires=['namespace-db.1']),
+            context=self.context)
+
+        with self.assertRaises(GraphError) as expected:
+            build_plan(
+                description="Test",
+                steps=[Step(vpc, None), Step(db, None), Step(app, None)])
+        message = ("Error detected when adding 'namespace-db.1' "
+                   "as a dependency of 'namespace-app.1': graph is "
+                   "not acyclic")
+        self.assertEqual(expected.exception.message, message)
+
+    @mock.patch("stacker.plan.os")
+    @mock.patch("stacker.plan.open", mock.mock_open(), create=True)
+    def test_dump(self, *args):
+        requires = None
+        steps = []
+
+        for i in range(5):
+            overrides = {
+                "variables": {
+                    "PublicSubnets": "1",
+                    "SshKeyName": "1",
+                    "PrivateSubnets": "1",
+                    "Random": "${noop something}",
+                },
+                "requires": requires,
+            }
+
+            stack = Stack(
+                definition=generate_definition('vpc', i, **overrides),
+                context=self.context)
+            requires = [stack.fqn]
+
+            steps += [Step(stack, None)]
+
+        plan = build_plan(description="Test", steps=steps)
+
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            plan.dump(tmp_dir, context=self.context)
+
+            for step in plan.steps:
+                template_path = os.path.join(
+                    tmp_dir,
+                    stack_template_key_name(step.stack.blueprint))
+                self.assertTrue(os.path.isfile(template_path))
+        finally:
+            shutil.rmtree(tmp_dir)

--- a/stacker/tests/test_stacker.py
+++ b/stacker/tests/test_stacker.py
@@ -78,23 +78,6 @@ class TestStacker(unittest.TestCase):
         stacks = args.context.get_stacks()
         self.assertEqual(len(stacks), 2)
 
-    def test_stacker_build_context_single_stack_specified(self):
-        # Added the below test that is similar to the
-        # test_stacker_build_context_stack_names_specified test because
-        # someone could break stacks lookup flags but still get back 2 stacks
-        # with the assertEquil to 2. Now we also check for assertEquil to 1
-        stacker = Stacker()
-        args = stacker.parse_args(
-            ["build",
-             "-r", "us-west-2",
-             "stacker/tests/fixtures/basic.env",
-             "stacker/tests/fixtures/vpc-bastion-db-web.yaml",
-             "--stacks", "vpc"]
-        )
-        stacker.configure(args)
-        stacks = args.context.get_stacks()
-        self.assertEqual(len(stacks), 1)
-
     def test_stacker_build_fail_when_parameters_in_stack_def(self):
         stacker = Stacker()
         args = stacker.parse_args(

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -942,3 +942,19 @@ class SourceProcessor(object):
         if ref is not None:
             dir_name += "-%s" % ref
         return dir_name
+
+
+def stack_template_key_name(blueprint):
+    """Given a blueprint, produce an appropriate key name.
+
+    Args:
+        blueprint (:class:`stacker.blueprints.base.Blueprint`): The blueprint
+            object to create the key from.
+
+    Returns:
+        string: Key name resulting from blueprint.
+    """
+    name = blueprint.name
+    return "stack_templates/%s/%s-%s.json" % (blueprint.context.get_fqn(name),
+                                              name,
+                                              blueprint.version)

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -190,6 +190,55 @@ EOF
   assert "$status" -eq 0
 }
 
+@test "stacker build - interactive with skipped update" {
+  needs_aws
+
+  config1() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    requires: [vpc]
+EOF
+  }
+
+  config2() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy2
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy2
+    requires: [vpc]
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config1)
+  }
+
+  # Create the new stacks.
+  stacker build <(config1)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line -E "${STACKER_NAMESPACE}-vpc:\s.*pending"
+  assert_has_line -E "${STACKER_NAMESPACE}-vpc:\s.*submitted \(creating new stack\)"
+  assert_has_line -E "${STACKER_NAMESPACE}-vpc:\s.*complete \(creating new stack\)"
+  assert_has_line -E "${STACKER_NAMESPACE}-bastion:\s.*pending"
+  assert_has_line -E "${STACKER_NAMESPACE}-bastion:\s.*submitted \(creating new stack\)"
+  assert_has_line -E "${STACKER_NAMESPACE}-bastion:\s.*complete \(creating new stack\)"
+
+  # Attempt an update to all stacks, but skip the vpc update.
+  stacker build -i <(config2) <<< $'n\ny\n'
+  assert "$status" -eq 0
+  assert_has_line -E "${STACKER_NAMESPACE}-vpc:\s.*skipped \(canceled execution\)"
+  assert_has_line -E "${STACKER_NAMESPACE}-bastion:\s.*submitted \(updating existing stack\)"
+}
+
 @test "stacker build - no namespace" {
   needs_aws
 
@@ -634,5 +683,4 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: submitted (rolling back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: failed (rolled back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-child:  failed (dependency has failed)"
-  assert_has_line "The following stacks failed: dependent-rollback-parent, dependent-rollback-child"
 }


### PR DESCRIPTION
Third times the charm :)

Fixes https://github.com/remind101/stacker/issues/300
Fixes https://github.com/remind101/stacker/issues/186
Fixes https://github.com/remind101/stacker/issues/384

This is an internal refactor to change the Plan implementation to be backed by a Directed Acyclic Graph. Most of this work was already done a long time ago in https://github.com/remind101/stacker/pull/406, but this just brings it up to speed with the master branch, with a few important caveats:


### Not parallelized

This implementation is _not_ parallelized. This PR paves the way to make it easy to implement a 100% parallelized graph walk, but I didn't implement it here, primarily to make review easier, but also because it doesn't matter much based on the current implementation (more on that below). I think we should get the graph in `master`, and then add a parallelized walk after the fact since that will need special attention to deal with concurrency issues (logging, user input, etc).

In theory, this sounds like it should reduce performance, but ironically it has little impact. I benchmarked before and after on our internal stacker graph, which is pretty big:

**before (stacker 1.1.3)**

```console
$ time stacker build

real    8m31.716s
user    0m0.139s
sys     0m0.100s
```

**after (dag)**


```console
$ time stacker build

real    8m33.819s
user    0m0.142s
sys     0m0.094s
```

However, because the `--stacks` flag now works like you'd expect it to, this branch can actually make most workflows a lot faster, even without concurrency.

### Notes for reviewer

For the time being, I'd like to focus on functionality, and making sure everything is feature complete, and all of the integration tests pass. There's probably some missing doc's, and I'll get to those things later.

Also, to make review easier, instead of making changes to `stacker.plan` I made a new `stacker.plan2`, and swapped out call sites to use the new graph based plan implementation. This will likely replace `stacker.plan` before merging, unless we want to keep the old `stacker.plan` around for API compatibility.

The `stacker.dag` module probably doesn't need much attention, since it's already been reviewed previously, and is stilled based on `py-dag`. Feel free to review it if you want.


### TODO

* [x] Bring back the check pointed loop logger (I just changed this to a simplified logger to make refactoring easier)
* [x] Bring back some removed tests.
* [x] Re-implement the `--tail` flag.
* [x] Re-implement dump