### PR TITLE
improve testutil.assertRenderedBlueprint

### DIFF
--- a/stacker/blueprints/testutil.py
+++ b/stacker/blueprints/testutil.py
@@ -1,18 +1,5 @@
-import difflib
 import json
 import unittest
-
-
-def diff(a, b):
-    """A human readable differ."""
-    return '\n'.join(
-        list(
-            difflib.Differ().compare(
-                a.splitlines(),
-                b.splitlines()
-            )
-        )
-    )
 
 
 class BlueprintTestCase(unittest.TestCase):
@@ -26,10 +13,8 @@ class BlueprintTestCase(unittest.TestCase):
 
         with open(expected_output) as fd:
             expected_dict = json.loads(fd.read())
-            expected_text = json.dumps(expected_dict, indent=4, sort_keys=True)
 
         with open(expected_output + "-result", "w") as fd:
             fd.write(rendered_text)
 
-        self.assertEquals(rendered_dict, expected_dict,
-                          diff(rendered_text, expected_text))
+        self.assertEquals(rendered_dict, expected_dict)


### PR DESCRIPTION
When giving the test output of comparing the two dictionaries with ` self.assertEquals(rendered_dict, expected_dict)`, python already gives you a diff output.