### PR TITLE
Always dump the current output/result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Upcoming/Master
 
+- assertRenderedBlueprint always dumps current results [GH-528]
 
 ## 1.1.4 (2018-01-26)
 

--- a/stacker/blueprints/testutil.py
+++ b/stacker/blueprints/testutil.py
@@ -24,12 +24,12 @@ class BlueprintTestCase(unittest.TestCase):
         rendered_dict = blueprint.template.to_dict()
         rendered_text = json.dumps(rendered_dict, indent=4, sort_keys=True)
 
+        with open(expected_output + "-result", "w") as fd:
+            fd.write(rendered_text)
+
         with open(expected_output) as fd:
             expected_dict = json.loads(fd.read())
             expected_text = json.dumps(expected_dict, indent=4, sort_keys=True)
-
-        with open(expected_output + "-result", "w") as fd:
-            fd.write(rendered_text)
 
         self.assertEquals(rendered_dict, expected_dict,
                           diff(rendered_text, expected_text))


### PR DESCRIPTION
This fixes an issue that was introduced in #467. The original
functionality was to always dump the current output to `.json-result`,
that way it was easy to build & compare the output.

With the current implementation (from #467) we raise an exception if the
old results aren't available, but don't create the new results.  This is
an issue whenever creating a new test.

@danielkza can you verify that this doesn't break anything that you were trying to fix in #467?  I can't see how it would.