### PR TITLE
Remove DescribeStacks call from prepare_stack_for_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - assertRenderedBlueprint always dumps current results [GH-528]
 - stacker now builds a DAG internally [GH-523]
+- an unecessary DescribeStacks network call was removed [GH-529]
 
 ## 1.1.4 (2018-01-26)
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -282,7 +282,7 @@ class Action(BaseAction):
             return NotUpdatedStatus()
 
         try:
-            if self.provider.prepare_stack_for_update(stack.fqn, tags):
+            if self.provider.prepare_stack_for_update(provider_stack, tags):
                 existing_params = provider_stack.get('Parameters', [])
                 self.provider.update_stack(
                     stack.fqn,

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -694,7 +694,7 @@ class Provider(BaseProvider):
         else:
             return self.default_update_stack
 
-    def prepare_stack_for_update(self, fqn, tags):
+    def prepare_stack_for_update(self, stack, tags):
         """Prepare a stack for updating
 
         It may involve deleting the stack if is has failed it's initial
@@ -705,7 +705,7 @@ class Provider(BaseProvider):
             enabled by the user, or because interactive mode is on.
 
         Args:
-            fqn (str): fully-qualified name of the stack to work on
+            stack (dict): a stack object returned from get_stack
             tags (list): list of expected tags that must be present in the
                 stack if it must be re-created
 
@@ -713,8 +713,6 @@ class Provider(BaseProvider):
             bool: True if the stack can be updated, False if it must be
                 re-created
         """
-
-        stack = self.get_stack(fqn)
 
         if self.is_stack_destroyed(stack):
             return False


### PR DESCRIPTION
This is a small performance optimization to remove an unnecessary DescribeStacks call from the `prepare_stack_for_update` method.

Before this change, the outbound network calls for a single noop stack update would look like this:

1. [DescribeStacks](https://github.com/remind101/stacker/blob/044ca52e2453dbddcc54d4a72714962bb04842f6/stacker/actions/build.py#L217): Check if stack is created or not, and to build a list of parameters
2. [DescribeStacks](https://github.com/remind101/stacker/blob/044ca52e2453dbddcc54d4a72714962bb04842f6/stacker/actions/build.py#L263) * N: Resolve any output lookups from other stacks
3. [HeadObject](https://github.com/remind101/stacker/blob/044ca52e2453dbddcc54d4a72714962bb04842f6/stacker/actions/base.py#L141): Check if the template has already been uploaded.
4. [DescribeStacks](https://github.com/remind101/stacker/blob/044ca52e2453dbddcc54d4a72714962bb04842f6/stacker/actions/build.py#L285): Check if the stack is in a rollback_complete state, and needs to be deleted)
5. [UpdateStack](https://github.com/remind101/stacker/blob/044ca52e2453dbddcc54d4a72714962bb04842f6/stacker/actions/build.py#L287): Perform the update.

The 3rd DescribeStacks (step 4) is unnecessary, and can be easily removed, since we already have a DescribeStacks response from the first call.