### PR TITLE
Use exponential backoff from botocore

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ src_dir = os.path.dirname(__file__)
 
 install_requires = [
     "troposphere>=1.9.0",
+    "botocore>=1.6.0",
     "boto3>=1.3.1,<1.5.0",
     "PyYAML~=3.12",
     "awacs>=0.6.0",

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -7,10 +7,10 @@ import urlparse
 import sys
 
 import botocore.exceptions
+from botocore.config import Config
 
 from ..base import BaseProvider
 from ... import exceptions
-from ...util import retry_with_backoff
 from ...ui import ui
 from stacker.session_cache import get_session
 
@@ -21,6 +21,23 @@ from ...actions.diff import (
 )
 
 logger = logging.getLogger(__name__)
+
+# This value controls the maximum number of times a CloudFormation API call
+# will be attempted, after being throttled. This value is used in an
+# exponential backoff algorithm to determine how long the client should wait
+# until attempting a retry:
+#
+#   base * growth_factor ^ (attempts - 1)
+#
+# A value of 10 here would cause the worst case wait time for the last retry to
+# be ~8 mins:
+#
+#   1 * 2 ^ (10 - 1) = 512 seconds
+#
+# References:
+# https://github.com/boto/botocore/blob/1.6.1/botocore/retryhandler.py#L39-L58
+# https://github.com/boto/botocore/blob/1.6.1/botocore/data/_retry.json#L97-L121
+MAX_ATTEMPTS = 10
 
 MAX_TAIL_RETRIES = 5
 DEFAULT_CAPABILITIES = ["CAPABILITY_NAMED_IAM", ]
@@ -48,43 +65,6 @@ def get_output_dict(stack):
     return outputs
 
 
-def retry_on_throttling(fn, attempts=3, args=None, kwargs=None):
-    """Wrap retry_with_backoff to handle AWS Cloudformation Throttling.
-
-    Args:
-        fn (function): The function to call.
-        attempts (int): Maximum # of attempts to retry the function.
-        args (list): List of positional arguments to pass to the function.
-        kwargs (dict): Dict of keyword arguments to pass to the function.
-
-    Returns:
-        passthrough: This returns the result of the function call itself.
-
-    Raises:
-        passthrough: This raises any exceptions the function call raises,
-            except for boto.exception.BotoServerError, provided it doesn't
-            retry more than attempts.
-    """
-    def _throttling_checker(exc):
-        """
-
-        Args:
-        exc (botocore.exceptions.ClientError): Expected exception type
-
-        Returns:
-             boolean: indicating whether this error is a throttling error
-        """
-        if exc.response['ResponseMetadata']['HTTPStatusCode'] == 400 and \
-                exc.response['Error']['Code'] == "Throttling":
-            logger.debug("AWS throttling calls.")
-            return True
-        return False
-
-    return retry_with_backoff(fn, args=args, kwargs=kwargs, attempts=attempts,
-                              exc_list=(botocore.exceptions.ClientError, ),
-                              retry_checker=_throttling_checker)
-
-
 def s3_fallback(fqn, template, parameters, tags, method,
                 change_set_name=None, service_role=None):
     logger.warn("DEPRECATION WARNING: Falling back to legacy "
@@ -108,7 +88,7 @@ def s3_fallback(fqn, template, parameters, tags, method,
         change_set_name=get_change_set_name()
     )
 
-    response = retry_on_throttling(method, kwargs=args)
+    response = method(**args)
     return response
 
 
@@ -274,11 +254,8 @@ def wait_till_change_set_complete(cfn_client, change_set_id, try_count=25,
     complete = False
     response = None
     for i in range(try_count):
-        response = retry_on_throttling(
-            cfn_client.describe_change_set,
-            kwargs={
-                'ChangeSetName': change_set_id,
-            },
+        response = cfn_client.describe_change_set(
+            ChangeSetName=change_set_id,
         )
         complete = response["Status"] in ("FAILED", "CREATE_COMPLETE")
         if complete:
@@ -310,10 +287,7 @@ def create_change_set(cfn_client, fqn, template, parameters, tags,
         change_set_name=get_change_set_name()
     )
     try:
-        response = retry_on_throttling(
-            cfn_client.create_change_set,
-            kwargs=args
-        )
+        response = cfn_client.create_change_set(**args)
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Message'] == ('TemplateURL must reference '
                                               'a valid S3 object to which '
@@ -499,16 +473,21 @@ class Provider(BaseProvider):
         # see https://github.com/remind101/stacker/issues/196
         pid = os.getpid()
         if pid != self._pid or not self._cloudformation:
+            config = Config(
+                retries=dict(
+                    max_attempts=MAX_ATTEMPTS
+                )
+            )
             session = get_session(self.region)
-            self._cloudformation = session.client('cloudformation')
+            self._cloudformation = session.client('cloudformation',
+                                                  config=config)
 
         return self._cloudformation
 
     def get_stack(self, stack_name, **kwargs):
         try:
-            return retry_on_throttling(
-                self.cloudformation.describe_stacks,
-                kwargs=dict(StackName=stack_name))['Stacks'][0]
+            return self.cloudformation.describe_stacks(
+                StackName=stack_name)['Stacks'][0]
         except botocore.exceptions.ClientError as e:
             if "does not exist" not in e.message:
                 raise
@@ -613,7 +592,7 @@ class Provider(BaseProvider):
         if self.service_role:
             args["RoleARN"] = self.service_role
 
-        retry_on_throttling(self.cloudformation.delete_stack, kwargs=args)
+        self.cloudformation.delete_stack(**args)
         return True
 
     def create_stack(self, fqn, template, parameters, tags,
@@ -647,11 +626,8 @@ class Provider(BaseProvider):
                 'CREATE', service_role=self.service_role, **kwargs
             )
 
-            retry_on_throttling(
-                self.cloudformation.execute_change_set,
-                kwargs={
-                    'ChangeSetName': change_set_id,
-                },
+            self.cloudformation.execute_change_set(
+                ChangeSetName=change_set_id,
             )
         else:
             args = generate_cloudformation_args(
@@ -660,10 +636,7 @@ class Provider(BaseProvider):
             )
 
             try:
-                retry_on_throttling(
-                    self.cloudformation.create_stack,
-                    kwargs=args
-                )
+                self.cloudformation.create_stack(**args)
             except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Message'] == ('TemplateURL must '
                                                       'reference a valid S3 '
@@ -837,11 +810,8 @@ class Provider(BaseProvider):
             finally:
                 ui.unlock()
 
-        retry_on_throttling(
-            self.cloudformation.execute_change_set,
-            kwargs={
-                'ChangeSetName': change_set_id,
-            },
+        self.cloudformation.execute_change_set(
+            ChangeSetName=change_set_id,
         )
 
     def noninteractive_changeset_update(self, fqn, template, old_parameters,
@@ -869,11 +839,8 @@ class Provider(BaseProvider):
             'UPDATE', service_role=self.service_role, **kwargs
         )
 
-        retry_on_throttling(
-            self.cloudformation.execute_change_set,
-            kwargs={
-                'ChangeSetName': change_set_id,
-            },
+        self.cloudformation.execute_change_set(
+            ChangeSetName=change_set_id,
         )
 
     def default_update_stack(self, fqn, template, old_parameters, parameters,
@@ -899,10 +866,7 @@ class Provider(BaseProvider):
         )
 
         try:
-            retry_on_throttling(
-                self.cloudformation.update_stack,
-                kwargs=args
-            )
+            self.cloudformation.update_stack(**args)
         except botocore.exceptions.ClientError as e:
             if "No updates are to be performed." in e.message:
                 logger.debug(
@@ -944,9 +908,8 @@ class Provider(BaseProvider):
         stack = self.get_stack(stack_name)
 
         try:
-            template = retry_on_throttling(
-                self.cloudformation.get_template,
-                kwargs=dict(StackName=stack_name))['TemplateBody']
+            template = self.cloudformation.get_template(
+                StackName=stack_name)['TemplateBody']
         except botocore.exceptions.ClientError as e:
             if "does not exist" not in e.message:
                 raise

--- a/stacker/util.py
+++ b/stacker/util.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import time
 import zipfile
 
 import collections
@@ -26,68 +25,6 @@ from yaml.nodes import MappingNode
 from stacker.session_cache import get_session
 
 logger = logging.getLogger(__name__)
-
-
-def retry_with_backoff(function, args=None, kwargs=None, attempts=5,
-                       min_delay=1, max_delay=3, exc_list=None,
-                       retry_checker=None):
-    """Retries function, catching expected Exceptions.
-
-    Each retry has a delay between `min_delay` and `max_delay` seconds,
-    increasing with each attempt.
-
-    Args:
-        function (function): The function to call.
-        args (list, optional): A list of positional arguments to pass to the
-            given function.
-        kwargs (dict, optional): Keyword arguments to pass to the given
-            function.
-        attempts (int, optional): The # of times to retry the function.
-            Default: 5
-        min_delay (int, optional): The minimum time to delay retries, in
-            seconds. Default: 1
-        max_delay (int, optional): The maximum time to delay retries, in
-            seconds. Default: 5
-        exc_list (list, optional): A list of :class:`Exception` classes that
-            should be retried. Default: [:class:`Exception`,]
-        retry_checker (func, optional): An optional function that is used to
-            do a deeper analysis on the received :class:`Exception` to
-            determine if it qualifies for retry. Receives a single argument,
-            the :class:`Exception` object that was caught. Should return
-            True if it should be retried.
-
-    Returns:
-        variable: Returns whatever the given function returns.
-
-    Raises:
-        :class:`Exception`: Raises whatever exception the given function
-            raises, if unable to succeed within the given number of attempts.
-    """
-    args = args or []
-    kwargs = kwargs or {}
-    attempt = 0
-    if not exc_list:
-        exc_list = (Exception, )
-    while True:
-        attempt += 1
-        logger.debug("Calling %s, attempt %d.", function, attempt)
-        sleep_time = min(max_delay, min_delay * attempt)
-        try:
-            return function(*args, **kwargs)
-        except exc_list as e:
-            # If there is no retry checker function, or if there is and it
-            # returns True, then go ahead and retry
-            if not retry_checker or retry_checker(e):
-                if attempt == attempts:
-                    logger.error("Function %s failed after %s retries. Giving "
-                                 "up.", function.func_name, attempts)
-                    raise
-                logger.debug("Caught expected exception: %r", e)
-            # If there is a retry checker function, and it returned False,
-            # do not retry
-            else:
-                raise
-        time.sleep(sleep_time)
 
 
 def camel_to_snake(name):


### PR DESCRIPTION
[Since botocore 1.6.0](https://github.com/boto/botocore/blob/develop/CHANGELOG.rst#160), it's possible to pass `max_attempts` to a generated client, like so:

```python
from botocore.config import Config

config = Config(
    retries = dict(
        max_attempts = 10
    )
)

ec2 = boto3.client('ec2', config=config)
```

This removes the internal `retry_with_backoff` function, in favor of using botocore's internal exponential backoff with a higher value of `max_attempts`.

The old behavior was a combination of the internal botocore backoff, combined with a linear backoff in stacker, where stacker's algorithm was:

```python
sleep_time = min(max_delay, min_delay * attempt)
```

So, in the event of throttling, the request would have been retried 4 times in boto (as determined by https://github.com/boto/botocore/blob/1.6.1/botocore/data/_retry.json#L77) with exponential backoff, then retried immediately after by stacker, which would reset the backoff in botocore.

With this change, the backoff continues to grow instead of getting reset.

Note, I've set `max_attempts` on the CloudFormation client to 10, which is pretty high (about 8 minutes worst case), but I think a large value makes sense for stacker's use case, especially with [parallelization](https://github.com/remind101/stacker/pull/531). It's rare that you would actually want stacker to abort on throttling.