### PR TITLE
Color failed stacks as red

### DIFF
--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 COLOR_CODES = {
     SUBMITTED.code: 33,  # yellow
     COMPLETE.code: 32,   # green
+    FAILED.code: 31,     # red
 }
 
 


### PR DESCRIPTION
We color submitted/completed stacks, but not failed. This makes it a little easier to pinpoint a stack that failed in the output:

![](http://ejholmes.s3.amazonaws.com/k9ccGGPPgowWafVcJl2YdzLogVVsPjuhud.png)