### PR TITLE
Diff improvements

### DIFF
--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -8,7 +8,12 @@ from .base import plan, build_walker
 from . import build
 from .. import exceptions
 from ..util import parse_cloudformation_template
-from ..status import NotSubmittedStatus, NotUpdatedStatus, COMPLETE
+from ..status import (
+    NotSubmittedStatus,
+    NotUpdatedStatus,
+    COMPLETE,
+    INTERRUPTED,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +203,9 @@ class Action(build.Action):
 
     def _diff_stack(self, stack, **kwargs):
         """Handles the diffing a stack in CloudFormation vs our config"""
+        if self.cancel.wait(0):
+            return INTERRUPTED
+
         if not build.should_submit(stack):
             return NotSubmittedStatus()
 

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -212,10 +212,12 @@ class Action(build.Action):
         if not build.should_update(stack):
             return NotUpdatedStatus()
 
+        provider_stack = self.provider.get_stack(stack.fqn)
+
         # get the current stack template & params from AWS
         try:
             [old_template, old_params] = self.provider.get_stack_info(
-                stack.fqn)
+                provider_stack)
         except exceptions.StackDoesNotExist:
             old_template = None
             old_params = {}
@@ -249,6 +251,9 @@ class Action(build.Action):
             )
             print_stack_changes(stack.name, new_stack, old_stack, new_params,
                                 old_params)
+
+        self.provider.set_outputs(stack.fqn, provider_stack)
+
         return COMPLETE
 
     def _generate_plan(self):

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -900,12 +900,12 @@ class Provider(BaseProvider):
         self._outputs[stack_name] = get_output_dict(stack)
         return
 
-    def get_stack_info(self, stack_name):
+    def get_stack_info(self, stack):
         """ Get the template and parameters of the stack currently in AWS
 
         Returns [ template, parameters ]
         """
-        stack = self.get_stack(stack_name)
+        stack_name = stack['StackId']
 
         try:
             template = self.cloudformation.get_template(


### PR DESCRIPTION
These are a couple of minor improvements to the `diff` command:

1. Handles SIGINT/SIGTERM like we do in `build`/`destroy`.
2. Caches outputs using `set_outputs`, like we do in `build`.

These should have been a part of https://github.com/remind101/stacker/pull/531, but I didn't focus much on the diff command in that PR.