### PR TITLE
Fix parameter handling for diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- (bugfix) Fix parameter handling for diffs [GH-540]
+
 ## 1.2.0rc1 (2018-02-15)
 
 The biggest change in this release has to do with how we build the graph

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -215,11 +215,11 @@ class Action(build.Action):
 
         stack.resolve(self.context, self.provider)
         # generate our own template & params
-        new_template = stack.blueprint.to_json()
         parameters = self.build_parameters(stack)
         new_params = dict()
         for p in parameters:
             new_params[p['ParameterKey']] = p['ParameterValue']
+        new_template = stack.blueprint.rendered
         new_stack = self._normalize_json(new_template)
 
         print "============== Stack: %s ==============" % (stack.name,)

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -214,6 +214,23 @@ class VPC(Blueprint):
         self.template.add_resource(WaitConditionHandle("VPC"))
 
 
+class DiffTester(Blueprint):
+    VARIABLES = {
+        "InstanceType": {
+            "type": CFNString,
+            "description": "NAT EC2 instance type.",
+            "default": "m3.medium"},
+        "WaitConditionCount": {
+            "type": int,
+            "description": "Number of WaitConditionHandle resources "
+                           "to add to the template"}
+    }
+
+    def create_template(self):
+        for i in range(self.get_variables()["WaitConditionCount"]):
+            self.template.add_resource(WaitConditionHandle("VPC%d" % i))
+
+
 class Bastion(Blueprint):
     VARIABLES = {
         "VpcId": {"type": EC2VPCId, "description": "Vpc Id"},

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -317,29 +317,44 @@ EOF
 @test "stacker diff - simple diff with output lookups" {
   needs_aws
 
-  config() {
+  config1() {
     cat <<EOF
 namespace: ${STACKER_NAMESPACE}
 stacks:
   - name: vpc
-    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
-  - name: bastion
-    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    class_path: stacker.tests.fixtures.mock_blueprints.DiffTester
     variables:
-      StringVariable: \${output vpc::DummyId}
+      InstanceType: m3.large
+      WaitConditionCount: 1
+EOF
+  }
+
+  config2() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.DiffTester
+    variables:
+      InstanceType: m3.xlarge
+      WaitConditionCount: 2
 EOF
   }
 
   teardown() {
-    stacker destroy --force <(config)
+    stacker destroy --force <(config1)
   }
 
   # Create the new stacks.
-  stacker build <(config)
+  stacker build <(config1)
   assert "$status" -eq 0
 
-  stacker diff <(config)
+  stacker diff <(config2)
   assert "$status" -eq 0
+  assert_has_line "\-InstanceType = m3.large"
+  assert_has_line "+InstanceType = m3.xlarge"
+  assert_has_line "+         \"VPC1\": {"
+  assert_has_line "+             \"Type\": \"AWS::CloudFormation::WaitConditionHandle\""
 }
 
 @test "stacker build - replacements-only test with additional resource, no keyerror" {


### PR DESCRIPTION
After using the DAG RC for the past week or so, I realized diffs were broken today. All of the param portions of the diffs came out as something like this:

```
--- Old Parameters
+++ New Parameters
******************
-Owner = foo
+Owner = unused_value
-Environment = d
+Environment = unused_value
```

This also led to a lot of unresolved variable errors like:
```
[2018-02-20T22:34:42] Variable "ASGMapping" in blueprint "ECSHosts" is missing
Traceback (most recent call last):
  File "/Users/adam/code/stacker/stacker/plan.py", line 86, in _run_once
    status = self.fn(self.stack, status=self.status)
  File "/Users/adam/code/stacker/stacker/actions/diff.py", line 228, in _diff_stack
    new_template = stack.blueprint.to_json()
  File "/Users/adam/code/stacker/stacker/blueprints/base.py", line 495, in to_json
    self.resolve_variables(variables_to_resolve)
  File "/Users/adam/code/stacker/stacker/blueprints/base.py", line 445, in resolve_variables
    self.name
  File "/Users/adam/code/stacker/stacker/blueprints/base.py", line 209, in resolve_variable
    raise MissingVariable(blueprint_name, var_name)
MissingVariable: Variable "ASGMapping" in blueprint "ECSHosts" is missing
```