### PR TITLE
Improved signal handling

### DIFF
--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import logging
 import threading
 
@@ -7,6 +8,7 @@ from ..plan import Step, build_plan
 
 import botocore.exceptions
 from stacker.session_cache import get_session
+from stacker.exceptions import PlanFailed
 
 from stacker.util import (
     ensure_s3_bucket,
@@ -188,9 +190,13 @@ class BaseAction(object):
         return template_url
 
     def execute(self, *args, **kwargs):
-        self.pre_run(*args, **kwargs)
-        self.run(*args, **kwargs)
-        self.post_run(*args, **kwargs)
+        try:
+            self.pre_run(*args, **kwargs)
+            self.run(*args, **kwargs)
+            self.post_run(*args, **kwargs)
+        except PlanFailed as e:
+            logger.error(e.message)
+            sys.exit(1)
 
     def pre_run(self, *args, **kwargs):
         pass

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from .base import BaseAction, plan, build_walker
 from .base import STACK_POLL_TIME
@@ -354,8 +353,7 @@ class Action(BaseAction):
             plan.outline(logging.DEBUG)
             logger.debug("Launching stacks: %s", ", ".join(plan.keys()))
             walker = build_walker(concurrency)
-            if not plan.execute(walker):
-                sys.exit(1)
+            plan.execute(walker)
         else:
             if outline:
                 plan.outline()

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from .base import BaseAction, plan, build_walker
 from .base import STACK_POLL_TIME
@@ -91,8 +90,7 @@ class Action(BaseAction):
             # steps to COMPLETE in order to log them
             plan.outline(logging.DEBUG)
             walker = build_walker(concurrency)
-            if not plan.execute(walker):
-                sys.exit(1)
+            plan.execute(walker)
         else:
             plan.outline(message="To execute this plan, run with \"--force\" "
                                  "flag.")

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -1,7 +1,6 @@
 import difflib
 import json
 import logging
-import sys
 from operator import attrgetter
 
 from .base import plan, build_walker
@@ -270,8 +269,7 @@ class Action(build.Action):
         plan.outline(logging.DEBUG)
         logger.info("Diffing stacks: %s", ", ".join(plan.keys()))
         walker = build_walker(concurrency)
-        if not plan.execute(walker):
-            sys.exit(1)
+        plan.execute(walker)
 
     """Don't ever do anything for pre_run or post_run"""
     def pre_run(self, *args, **kwargs):

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -6,6 +6,13 @@ import logging
 
 from ...environment import parse_environment
 
+logger = logging.getLogger(__name__)
+
+SIGNAL_NAMES = {
+    signal.SIGINT: "SIGINT",
+    signal.SIGTERM: "SIGTERM",
+}
+
 
 def cancel():
     """Returns a threading.Event() that will get set when SIGTERM, or
@@ -14,6 +21,9 @@ def cancel():
     cancel = threading.Event()
 
     def cancel_execution(signum, frame):
+        signame = SIGNAL_NAMES.get(signum, signum)
+        logger.info("Signal %s received, quitting "
+                    "(this can take some time)...", signame)
         cancel.set()
 
     signal.signal(signal.SIGINT, cancel_execution)

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -214,7 +214,7 @@ class PlanFailed(Exception):
         self.failed_stacks = failed_stacks
 
         stack_names = ', '.join(stack.name for stack in failed_stacks)
-        message = "The following stacks failed: %s\n" % (stack_names,)
+        message = "The following stacks failed: %s" % (stack_names,)
 
         super(PlanFailed, self).__init__(message, *args, **kwargs)
 

--- a/stacker/tests/test_dag.py
+++ b/stacker/tests/test_dag.py
@@ -83,32 +83,7 @@ def test_walk():
         nodes.append(n)
         return True
 
-    ok = dag.walk(walk_func)
-    assert ok == True  # noqa: E712
-    assert nodes == ['d', 'c', 'b', 'a'] or nodes == ['d', 'b', 'c', 'a']
-
-
-@with_setup(blank_setup)
-def test_walk_failed():
-    dag = DAG()
-
-    # b and c should be executed at the same time.
-    dag.from_dict({'a': ['b', 'c'],
-                   'b': ['d'],
-                   'c': ['d'],
-                   'd': []})
-
-    nodes = []
-
-    def walk_func(n):
-        nodes.append(n)
-        return False
-
-    ok = dag.walk(walk_func)
-
-    # Only 2 should have been hit. The rest are canceled because they depend on
-    # the success of d.
-    assert ok == False  # noqa: E712
+    dag.walk(walk_func)
     assert nodes == ['d', 'c', 'b', 'a'] or nodes == ['d', 'b', 'c', 'a']
 
 
@@ -209,6 +184,5 @@ def test_threaded_walker():
         lock.release()
         return True
 
-    ok = walker.walk(dag, walk_func)
-    assert ok == True  # noqa: E712
+    walker.walk(dag, walk_func)
     assert nodes == ['d', 'c', 'b', 'a'] or nodes == ['d', 'b', 'c', 'a']

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -19,6 +19,7 @@ from stacker.plan import (
 from stacker.exceptions import (
     CancelExecution,
     GraphError,
+    PlanFailed,
 )
 from stacker.status import (
     COMPLETE,
@@ -116,7 +117,7 @@ class TestPlan(unittest.TestCase):
             description="Test",
             steps=[Step(vpc, fn), Step(db, fn), Step(app, fn)],
             targets=['db.1'])
-        self.assertTrue(plan.execute(walk))
+        plan.execute(walk)
 
         self.assertEquals(calls, [
             'namespace-vpc.1', 'namespace-db.1'])
@@ -141,7 +142,8 @@ class TestPlan(unittest.TestCase):
         bastion_step = Step(bastion, fn)
         plan = build_plan(description="Test", steps=[vpc_step, bastion_step])
 
-        plan.execute(walk)
+        with self.assertRaises(PlanFailed):
+            plan.execute(walk)
 
         self.assertEquals(calls, ['namespace-vpc.1'])
         self.assertEquals(vpc_step.status, FAILED)
@@ -166,7 +168,7 @@ class TestPlan(unittest.TestCase):
         bastion_step = Step(bastion, fn)
 
         plan = build_plan(description="Test", steps=[vpc_step, bastion_step])
-        self.assertTrue(plan.execute(walk))
+        plan.execute(walk)
 
         self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
 
@@ -195,7 +197,8 @@ class TestPlan(unittest.TestCase):
 
         plan = build_plan(description="Test", steps=[
             vpc_step, bastion_step, db_step])
-        self.assertFalse(plan.execute(walk))
+        with self.assertRaises(PlanFailed):
+            plan.execute(walk)
 
         calls.sort()
 
@@ -222,7 +225,7 @@ class TestPlan(unittest.TestCase):
 
         plan = build_plan(description="Test", steps=[
             vpc_step, bastion_step])
-        self.assertTrue(plan.execute(walk))
+        plan.execute(walk)
 
         self.assertEquals(calls, ['namespace-vpc.1', 'namespace-bastion.1'])
 

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -673,6 +673,7 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: submitted (rolling back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: failed (rolled back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-child: failed (dependency has failed)"
+  assert_has_line "The following stacks failed: dependent-rollback-parent, dependent-rollback-child"
 }
 
 @test "stacker build - raw template" {


### PR DESCRIPTION
This has a few small improvements to handle SIGTERM/SIGINT signals better:

* Fixes a bug where the SIGTERM/SIGINT signal handler wasn't being immediately handled. See https://stackoverflow.com/questions/25676835/signal-handling-in-multi-threaded-python
* Logs a line when SIGTERM/SIGINT are handled.
* Logs a line at the end of the plan execution to show a summary of stacks that failed (same behavior as what we have in 1.1).

/cc @GarisonLotus @troyready 