### PR TITLE
Release 1.2.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
-## Unreleased
+## 1.2.0rc2 (2018-02-27)
 
-- (bugfix) Fix parameter handling for diffs [GH-540]
+- Fix parameter handling for diffs [GH-540]
+- Fix an issue where SIGTERM/SIGINT weren't handled immediately [GH-543]
+- Log a line when SIGINT/SIGTERM are handled [GH-543]
+- Log failed steps at the end of plan execution [GH-543]
+- Remove upper bound on boto3 dependency [GH-542]
 
 ## 1.2.0rc1 (2018-02-15)
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-VERSION = "1.2.0rc1"
+VERSION = "1.2.0rc2"
 
 src_dir = os.path.dirname(__file__)
 

--- a/stacker/__init__.py
+++ b/stacker/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.0rc1"
+__version__ = "1.2.0rc2"


### PR DESCRIPTION
There's been a few minor changes since 1.2.0rc1, so I wanna give an rc2 a little time to bake. Assuming no bugs, 1.2.0rc2 will make our 1.2.0 release.