### PR TITLE
Implement --tail with threads

### DIFF
--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -779,3 +779,34 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-vpc2: submitted (creating new stack)"
   assert_has_line "${STACKER_NAMESPACE}-vpc2: complete (creating new stack)"
 }
+
+@test "stacker build - tailing" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    requires: [vpc]
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build --tail <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "Tailing stack: ${STACKER_NAMESPACE}-vpc"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: complete (creating new stack)"
+  assert_has_line "Tailing stack: ${STACKER_NAMESPACE}-bastion"
+  assert_has_line "${STACKER_NAMESPACE}-bastion: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-bastion: complete (creating new stack)"
+}


### PR DESCRIPTION
Fixes #545

There was a report from someone in #stacker about `stacker build` locking up when using `--tail`. I was able to repro pretty easily

```
$ stacker build --tail dev.yaml
[2018-02-28T15:43:18] Using default AWS provider mode
[2018-02-28T15:43:18] Tailing stack: ejholmes-vpc
[2018-02-28T15:43:21] ejholmes-vpc: submitted (creating new stack)
[2018-02-28T15:43:30] [ejholmes-vpc] CREATE_IN_PROGRESS AWS::CloudFormation::WaitConditionHandle
[2018-02-28T15:43:30] [ejholmes-vpc] CREATE_IN_PROGRESS AWS::CloudFormation::WaitConditionHandle Resource creation Initiated
[2018-02-28T15:43:30] [ejholmes-vpc] CREATE_COMPLETE AWS::CloudFormation::WaitConditionHandle
[2018-02-28T15:43:30] [ejholmes-vpc] CREATE_COMPLETE AWS::CloudFormation::Stack
[2018-02-28T15:43:52] ejholmes-vpc: complete (creating new stack)
[2018-02-28T15:43:52] Signal SIGTERM received, quitting (this can take some time)...
```

When using processes, calling `watcher.terminate()` would send the process a SIGTERM, which is now handled [here](https://github.com/remind101/stacker/blob/master/stacker/commands/stacker/base.py#L17-L31). That would have no effect in the forked process, and the step would block on the following `watcher.join()`.

Since we're now using threads for plan execution, I think it's simpler to just use threads for the implementation of tail, which fixes signal handling and the lockup.