### PR TITLE
Refactor output lookup

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -260,7 +260,8 @@ class Action(BaseAction):
 
                 return FailedStatus(reason)
             elif self.provider.is_stack_completed(provider_stack):
-                self.provider.set_outputs(stack.fqn, provider_stack)
+                stack.set_outputs(
+                    self.provider.get_output_dict(provider_stack))
                 return CompleteStatus(old_status.reason)
             else:
                 return old_status
@@ -305,7 +306,7 @@ class Action(BaseAction):
             else:
                 return SubmittedStatus("destroying stack for re-creation")
         except StackDidNotChange:
-            self.provider.set_outputs(stack.fqn, provider_stack)
+            stack.set_outputs(self.provider.get_output_dict(provider_stack))
             return DidNotChangeStatus()
 
     def _template(self, blueprint):

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -253,7 +253,8 @@ class Action(build.Action):
             print_stack_changes(stack.name, new_stack, old_stack, new_params,
                                 old_params)
 
-        self.provider.set_outputs(stack.fqn, provider_stack)
+        stack.set_outputs(
+            self.provider.get_output_dict(provider_stack))
 
         return COMPLETE
 

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -129,20 +129,27 @@ class Context(object):
             list: a list of :class:`stacker.stack.Stack` objects
 
         """
-        stacks = []
-        definitions = self._get_stack_definitions()
-        for stack_def in definitions:
-            stack = Stack(
-                definition=stack_def,
-                context=self,
-                mappings=self.mappings,
-                force=stack_def.name in self.force_stacks,
-                locked=stack_def.locked,
-                enabled=stack_def.enabled,
-                protected=stack_def.protected,
-            )
-            stacks.append(stack)
-        return stacks
+        if not hasattr(self, "_stacks"):
+            stacks = []
+            definitions = self._get_stack_definitions()
+            for stack_def in definitions:
+                stack = Stack(
+                    definition=stack_def,
+                    context=self,
+                    mappings=self.mappings,
+                    force=stack_def.name in self.force_stacks,
+                    locked=stack_def.locked,
+                    enabled=stack_def.enabled,
+                    protected=stack_def.protected,
+                )
+                stacks.append(stack)
+            self._stacks = stacks
+        return self._stacks
+
+    def get_stack(self, name):
+        for stack in self.get_stacks():
+            if stack.name == name:
+                return stack
 
     def get_stacks_dict(self):
         return dict((stack.fqn, stack) for stack in self.get_stacks())

--- a/stacker/exceptions.py
+++ b/stacker/exceptions.py
@@ -210,11 +210,11 @@ class StackUpdateBadStatus(Exception):
 
 class PlanFailed(Exception):
 
-    def __init__(self, failed_stacks, *args, **kwargs):
-        self.failed_stacks = failed_stacks
+    def __init__(self, failed_steps, *args, **kwargs):
+        self.failed_steps = failed_steps
 
-        stack_names = ', '.join(stack.name for stack in failed_stacks)
-        message = "The following stacks failed: %s" % (stack_names,)
+        step_names = ', '.join(step.name for step in failed_steps)
+        message = "The following steps failed: %s" % (step_names,)
 
         super(PlanFailed, self).__init__(message, *args, **kwargs)
 

--- a/stacker/lookups/handlers/output.py
+++ b/stacker/lookups/handlers/output.py
@@ -5,48 +5,25 @@ TYPE_NAME = "output"
 Output = namedtuple("Output", ("stack_name", "output_name"))
 
 
-def handler(value, provider=None, context=None, fqn=False, rfqn=False,
-            **kwargs):
+def handler(value, context=None, **kwargs):
     """Fetch an output from the designated stack.
 
     Args:
         value (str): string with the following format:
             <stack_name>::<output_name>, ie. some-stack::SomeOutput
-        provider (:class:`stacker.provider.base.BaseProvider`): subclass of the
-            base provider
         context (:class:`stacker.context.Context`): stacker context
-        fqn (bool): boolean for whether or not the
-            :class:`stacker.context.Context` should resolve the `fqn` of the
-            stack.
-        rfqn (bool): boolean for whether or not the
-            :class:`stacker.context.Context` should resolve the `fqn` of the
-            stack prefixed by the namespace variable
 
     Returns:
         str: output from the specified stack
 
     """
 
-    if rfqn:
-            value = "%s%s%s" % (
-                    context.namespace,
-                    context.namespace_delimiter,
-                    value
-            )
-
-    if provider is None:
-        raise ValueError('Provider is required')
     if context is None:
         raise ValueError('Context is required')
 
     d = deconstruct(value)
-
-    stack_fqn = d.stack_name
-    if not fqn:
-        stack_fqn = context.get_fqn(d.stack_name)
-
-    output = provider.get_output(stack_fqn, d.output_name)
-    return output
+    stack = context.get_stack(d.stack_name)
+    return stack.outputs[d.output_name]
 
 
 def deconstruct(value):

--- a/stacker/lookups/handlers/rxref.py
+++ b/stacker/lookups/handlers/rxref.py
@@ -11,13 +11,31 @@ Example:
         some-relative-fully-qualified-stack-name::SomeOutputName}
 
 """
-from functools import partial
-
-from .output import handler as output_handler
+from .output import deconstruct
 
 TYPE_NAME = "rxref"
 
-# rxref is the same as the `output` handler, except the value already contains
-# the relative fully qualified name for the stack we're fetching the output
-# from.
-handler = partial(output_handler, rfqn=True)
+
+def handler(value, provider=None, context=None, **kwargs):
+    """Fetch an output from the designated stack.
+
+    Args:
+        value (str): string with the following format:
+            <stack_name>::<output_name>, ie. some-stack::SomeOutput
+        provider (:class:`stacker.provider.base.BaseProvider`): subclass of the
+            base provider
+        context (:class:`stacker.context.Context`): stacker context
+
+    Returns:
+        str: output from the specified stack
+    """
+
+    if provider is None:
+        raise ValueError('Provider is required')
+    if context is None:
+        raise ValueError('Context is required')
+
+    d = deconstruct(value)
+    stack_fqn = context.get_fqn(d.stack_name)
+    output = provider.get_output(stack_fqn, d.output_name)
+    return output

--- a/stacker/lookups/handlers/xref.py
+++ b/stacker/lookups/handlers/xref.py
@@ -10,12 +10,28 @@ Example:
     conf_value: ${xref some-fully-qualified-stack-name::SomeOutputName}
 
 """
-from functools import partial
-
-from .output import handler as output_handler
+from .output import deconstruct
 
 TYPE_NAME = "xref"
 
-# xref is the same as the `output` handler, except the value already contains
-# the fully qualified name for the stack we're fetching the output from.
-handler = partial(output_handler, fqn=True)
+
+def handler(value, provider=None, **kwargs):
+    """Fetch an output from the designated stack.
+
+    Args:
+        value (str): string with the following format:
+            <stack_name>::<output_name>, ie. some-stack::SomeOutput
+        provider (:class:`stacker.provider.base.BaseProvider`): subclass of the
+            base provider
+
+    Returns:
+        str: output from the specified stack
+    """
+
+    if provider is None:
+        raise ValueError('Provider is required')
+
+    d = deconstruct(value)
+    stack_fqn = d.stack_name
+    output = provider.get_output(stack_fqn, d.output_name)
+    return output

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -32,7 +32,7 @@ COLOR_CODES = {
 
 
 def log_step(step):
-    msg = "%s: %s" % (step.name, step.status.name)
+    msg = "%s: %s" % (step, step.status.name)
     if step.status.reason:
         msg += " (%s)" % (step.status.reason)
     color_code = COLOR_CODES.get(step.status.code, 37)
@@ -59,6 +59,9 @@ class Step(object):
 
     def __repr__(self):
         return "<stacker.plan.Step:%s>" % (self.stack.fqn,)
+
+    def __str__(self):
+        return self.stack.fqn
 
     def run(self):
         """Runs this step until it has completed successfully, or been
@@ -96,10 +99,6 @@ class Step(object):
 
     @property
     def name(self):
-        return self.stack.fqn
-
-    @property
-    def short_name(self):
         return self.stack.name
 
     @property
@@ -189,7 +188,7 @@ def build_plan(description, steps,
         nodes = []
         for target in targets:
             for step in steps:
-                if step.short_name == target:
+                if step.name == target:
                     nodes.append(step.name)
         graph = graph.filtered(nodes)
 
@@ -311,7 +310,7 @@ class Plan(object):
                 level,
                 "  - step: %s: target: \"%s\", action: \"%s\"",
                 steps,
-                step.short_name,
+                step.name,
                 step.fn.__name__,
             )
             steps += 1

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -895,12 +895,11 @@ class Provider(BaseProvider):
     def get_outputs(self, stack_name, *args, **kwargs):
         if stack_name not in self._outputs:
             stack = self.get_stack(stack_name)
-            self.set_outputs(stack_name, stack)
+            self._outputs[stack_name] = get_output_dict(stack)
         return self._outputs[stack_name]
 
-    def set_outputs(self, stack_name, stack):
-        self._outputs[stack_name] = get_output_dict(stack)
-        return
+    def get_output_dict(self, stack):
+        return get_output_dict(stack)
 
     def get_stack_info(self, stack):
         """ Get the template and parameters of the stack currently in AWS

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -77,8 +77,7 @@ class Stack(object):
 
     @property
     def requires(self):
-        requires = set([self.context.get_fqn(r) for r in
-                        self.definition.requires or []])
+        requires = set(self.definition.requires or [])
 
         # Add any dependencies based on output lookups
         for variable in self.variables:
@@ -96,8 +95,7 @@ class Stack(object):
                             "within lookup: %s"
                         ) % (variable.name, self.name, lookup.raw)
                         raise ValueError(message)
-                    stack_fqn = self.context.get_fqn(d.stack_name)
-                    requires.add(stack_fqn)
+                    requires.add(d.stack_name)
 
         return requires
 

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -71,6 +71,7 @@ class Stack(object):
         self.enabled = enabled
         self.protected = protected
         self.context = copy.deepcopy(context)
+        self.outputs = None
 
     def __repr__(self):
         return self.fqn
@@ -172,3 +173,6 @@ class Stack(object):
         """
         resolve_variables(self.variables, context, provider)
         self.blueprint.resolve_variables(self.variables)
+
+    def set_outputs(self, outputs):
+        self.outputs = outputs

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -112,10 +112,10 @@ class TestBuildAction(unittest.TestCase):
         plan = build_action._generate_plan()
         self.assertEqual(
             {
-                'namespace-db': set(['namespace-bastion', 'namespace-vpc']),
-                'namespace-bastion': set(['namespace-vpc']),
-                'namespace-other': set([]),
-                'namespace-vpc': set([])},
+                'db': set(['bastion', 'vpc']),
+                'bastion': set(['vpc']),
+                'other': set([]),
+                'vpc': set([])},
             plan.graph.to_dict()
         )
 

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -45,22 +45,15 @@ class TestDestroyAction(unittest.TestCase):
         plan = self.action._generate_plan()
         self.assertEqual(
             {
-                'namespace-vpc': set(
-                    [
-                        'namespace-db',
-                        'namespace-instance',
-                        'namespace-bastion']),
-                'namespace-other': set([]),
-                'namespace-bastion': set(
-                    [
-                        'namespace-instance',
-                        'namespace-db']),
-                'namespace-instance': set(
-                    [
-                        'namespace-db']),
-                'namespace-db': set(
-                    [
-                        'namespace-other'])},
+                'vpc': set(
+                    ['db', 'instance', 'bastion']),
+                'other': set([]),
+                'bastion': set(
+                    ['instance', 'db']),
+                'instance': set(
+                    ['db']),
+                'db': set(
+                    ['other'])},
             plan.graph.to_dict()
         )
 

--- a/stacker/tests/lookups/handlers/test_output.py
+++ b/stacker/tests/lookups/handlers/test_output.py
@@ -1,22 +1,25 @@
 from mock import MagicMock
 import unittest
 
+from stacker.stack import Stack
+from ...factories import generate_definition
 from stacker.lookups.handlers.output import handler
 
 
 class TestOutputHandler(unittest.TestCase):
 
     def setUp(self):
-        self.provider = MagicMock()
         self.context = MagicMock()
 
     def test_output_handler(self):
-        self.provider.get_output.return_value = "Test Output"
-        self.context.get_fqn.return_value = "fully-qualified-stack-name"
-        value = handler("stack-name::SomeOutput",
-                        provider=self.provider, context=self.context)
+        stack = Stack(
+            definition=generate_definition("vpc", 1),
+            context=self.context)
+        stack.set_outputs({
+            "SomeOutput": "Test Output"})
+        self.context.get_stack.return_value = stack
+        value = handler("stack-name::SomeOutput", context=self.context)
         self.assertEqual(value, "Test Output")
-        self.assertEqual(self.context.get_fqn.call_count, 1)
-        args = self.provider.get_output.call_args
-        self.assertEqual(args[0][0], "fully-qualified-stack-name")
-        self.assertEqual(args[0][1], "SomeOutput")
+        self.assertEqual(self.context.get_stack.call_count, 1)
+        args = self.context.get_stack.call_args
+        self.assertEqual(args[0][0], "stack-name")

--- a/stacker/tests/test_stack.py
+++ b/stacker/tests/test_stack.py
@@ -31,16 +31,16 @@ class TestStack(unittest.TestCase):
                 "Var3": "${output fakeStack::FakeOutput},"
                         "${output fakeStack2::FakeOutput}",
             },
-            requires=[self.context.get_fqn("fakeStack")],
+            requires=["fakeStack"],
         )
         stack = Stack(definition=definition, context=self.context)
         self.assertEqual(len(stack.requires), 2)
         self.assertIn(
-            self.context.get_fqn("fakeStack"),
+            "fakeStack",
             stack.requires,
         )
         self.assertIn(
-            self.context.get_fqn("fakeStack2"),
+            "fakeStack2",
             stack.requires,
         )
 

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -673,7 +673,7 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: submitted (rolling back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-parent: failed (rolled back new stack)"
   assert_has_line "${STACKER_NAMESPACE}-dependent-rollback-child: failed (dependency has failed)"
-  assert_has_line "The following stacks failed: ${STACKER_NAMESPACE}-dependent-rollback-parent, ${STACKER_NAMESPACE}-dependent-rollback-child"
+  assert_has_line "The following steps failed: dependent-rollback-parent, dependent-rollback-child"
 }
 
 @test "stacker build - raw template" {


### PR DESCRIPTION
This refactors the mechanics of the `${output}` lookup so that it uses the internal `stacker.Stack` as the lookup point.

With the addition of the DAG, in order to ensure that output lookups didn't involve unnecessary network calls, we changed `stacker.actions.build` to call `provider.set_outputs` to store the stacks outputs when the step was completed.

https://github.com/remind101/stacker/blob/c1aad4f8713c64c90abc02e6c10ad2eda1a18c8e/stacker/actions/build.py#L262-L264

 The output lookup would then use this cached value, through `provider.get_output`.

https://github.com/remind101/stacker/blob/c1aad4f8713c64c90abc02e6c10ad2eda1a18c8e/stacker/lookups/handlers/output.py#L44-L49

This was the smallest change that we could make in the DAG branch, while keeping everything fast and functional, but won't work well moving forward as we think about cross account/region support, as well as the possibility of adding new node types to the graph (e.g. hooks).

---

In this PR, when a stack is "done", we store the outputs on the internal `stacker.Stack` object. The `output` plugin looks up the stack object, then returns the output from there. This has a couple of advantages:

1. It ensures that we're not keeping global state for cached lookups, so we don't have a potential for a race.
2. It'll work better when we think about cross account/region stacks using profiles. You can think of a scenario where, stacker is managing two stacks, both named "RoleModel" in separate accounts. The `output` lookup needs to be aware that these nodes in the graph are separate things.