### PR TITLE
Multi region support

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -312,8 +312,10 @@ stack to be built.
 A stack has the following keys:
 
 **name:**
-  The base name for the stack (note: the namespace from the environment
-  will be prepended to this)
+  The logical name for this stack, which can be used in conjuction with the
+  ``output`` lookup. The value here must be unique within the config. If no
+  ``stack_name`` is provided, the value here will be used for the name of the
+  CloudFormation stack.
 **class_path:**
   The python class path to the Blueprint to be used. Specify this or
   ``template_path`` for the stack.
@@ -348,6 +350,17 @@ A stack has the following keys:
 **tags:**
   (optional) a dictionary of CloudFormation tags to apply to this stack. This
   will be combined with the global tags, but these tags will take precendence.
+**stack_name:**
+  (optional) If provided, this will be used as the name of the CloudFormation
+  stack. Unlike ``name``, the value doesn't need to be unique within the config,
+  since you could have multiple stacks with the same name, but in different
+  regions or accounts. (note: the namespace from the environment will be
+  prepended to this)
+**region**:
+  (optional): If provided, specifies the name of the region that the
+  CloudFormation stack should reside in. If not provided, the default region
+  will be used (``AWS_DEFAULT_REGION``, ``~/.aws/config`` or the ``--region``
+  flag).
 
 Here's an example from stacker_blueprints_, used to create a VPC::
 

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -36,7 +36,7 @@ class Action(BaseAction):
         return plan(
             description="Destroy stacks",
             action=self._destroy_stack,
-            tail=self.provider.tail_stack if tail else None,
+            tail=self._tail_stack if tail else None,
             stacks=self.context.get_stacks(),
             targets=self.context.stack_names,
             reverse=True)
@@ -47,8 +47,10 @@ class Action(BaseAction):
         if self.cancel.wait(wait_time):
             return INTERRUPTED
 
+        provider = self.build_provider(stack)
+
         try:
-            provider_stack = self.provider.get_stack(stack.fqn)
+            provider_stack = provider.get_stack(stack.fqn)
         except StackDoesNotExist:
             logger.debug("Stack %s does not exist.", stack.fqn)
             # Once the stack has been destroyed, it doesn't exist. If the
@@ -61,16 +63,16 @@ class Action(BaseAction):
 
         logger.debug(
             "Stack %s provider status: %s",
-            self.provider.get_stack_name(provider_stack),
-            self.provider.get_stack_status(provider_stack),
+            provider.get_stack_name(provider_stack),
+            provider.get_stack_status(provider_stack),
         )
-        if self.provider.is_stack_destroyed(provider_stack):
+        if provider.is_stack_destroyed(provider_stack):
             return DestroyedStatus
-        elif self.provider.is_stack_in_progress(provider_stack):
+        elif provider.is_stack_in_progress(provider_stack):
             return DestroyingStatus
         else:
             logger.debug("Destroying stack: %s", stack.fqn)
-            self.provider.destroy_stack(provider_stack)
+            provider.destroy_stack(provider_stack)
         return DestroyingStatus
 
     def pre_run(self, outline=False, *args, **kwargs):

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -213,17 +213,19 @@ class Action(build.Action):
         if not build.should_update(stack):
             return NotUpdatedStatus()
 
-        provider_stack = self.provider.get_stack(stack.fqn)
+        provider = self.build_provider(stack)
+
+        provider_stack = provider.get_stack(stack.fqn)
 
         # get the current stack template & params from AWS
         try:
-            [old_template, old_params] = self.provider.get_stack_info(
+            [old_template, old_params] = provider.get_stack_info(
                 provider_stack)
         except exceptions.StackDoesNotExist:
             old_template = None
             old_params = {}
 
-        stack.resolve(self.context, self.provider)
+        stack.resolve(self.context, provider)
         # generate our own template & params
         parameters = self.build_parameters(stack)
         new_params = dict()
@@ -254,7 +256,7 @@ class Action(build.Action):
                                 old_params)
 
         stack.set_outputs(
-            self.provider.get_output_dict(provider_stack))
+            provider.get_output_dict(provider_stack))
 
         return COMPLETE
 

--- a/stacker/actions/info.py
+++ b/stacker/actions/info.py
@@ -16,8 +16,10 @@ class Action(BaseAction):
     def run(self, *args, **kwargs):
         logger.info('Outputs for stacks: %s', self.context.get_fqn())
         for stack in self.context.get_stacks():
+            provider = self.build_provider(stack)
+
             try:
-                provider_stack = self.provider.get_stack(stack.fqn)
+                provider_stack = provider.get_stack(stack.fqn)
             except exceptions.StackDoesNotExist:
                 logger.info('Stack "%s" does not exist.' % (stack.fqn,))
                 continue

--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -30,7 +30,7 @@ class Stacker(BaseCommand):
             environment=options.environment,
             validate=True)
 
-        options.provider = default.Provider(
+        options.provider_builder = default.ProviderBuilder(
             region=options.region,
             interactive=options.interactive,
             replacements_only=options.replacements_only,

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -47,7 +47,7 @@ class Build(BaseCommand):
     def run(self, options, **kwargs):
         super(Build, self).run(options, **kwargs)
         action = build.Action(options.context,
-                              provider=options.provider,
+                              provider_builder=options.provider_builder,
                               cancel=cancel())
         action.execute(concurrency=options.max_parallel,
                        outline=options.outline,

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -38,7 +38,7 @@ class Destroy(BaseCommand):
     def run(self, options, **kwargs):
         super(Destroy, self).run(options, **kwargs)
         action = destroy.Action(options.context,
-                                provider=options.provider,
+                                provider_builder=options.provider_builder,
                                 cancel=cancel())
         action.execute(concurrency=options.max_parallel,
                        force=options.force,

--- a/stacker/commands/stacker/diff.py
+++ b/stacker/commands/stacker/diff.py
@@ -28,7 +28,8 @@ class Diff(BaseCommand):
 
     def run(self, options, **kwargs):
         super(Diff, self).run(options, **kwargs)
-        action = diff.Action(options.context, provider=options.provider)
+        action = diff.Action(options.context,
+                             provider_builder=options.provider_builder)
         action.execute()
 
     def get_context_kwargs(self, options, **kwargs):

--- a/stacker/commands/stacker/info.py
+++ b/stacker/commands/stacker/info.py
@@ -20,7 +20,9 @@ class Info(BaseCommand):
 
     def run(self, options, **kwargs):
         super(Info, self).run(options, **kwargs)
-        action = info.Action(options.context, provider=options.provider)
+        action = info.Action(options.context,
+                             provider_builder=options.provider_builder)
+
         action.execute()
 
     def get_context_kwargs(self, options, **kwargs):

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -273,6 +273,8 @@ class Stack(Model):
 
     stack_name = StringType(serialize_when_none=False)
 
+    region = StringType(serialize_when_none=False)
+
     class_path = StringType(serialize_when_none=False)
 
     template_path = StringType(serialize_when_none=False)

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -271,6 +271,8 @@ class Hook(Model):
 class Stack(Model):
     name = StringType(required=True)
 
+    stack_name = StringType(serialize_when_none=False)
+
     class_path = StringType(serialize_when_none=False)
 
     template_path = StringType(serialize_when_none=False)

--- a/stacker/providers/base.py
+++ b/stacker/providers/base.py
@@ -3,6 +3,11 @@ def not_implemented(method):
                               "method." % method)
 
 
+class BaseProviderBuilder(object):
+    def build(self, region=None):
+        not_implemented("build")
+
+
 class BaseProvider(object):
     def get_stack(self, stack_name, *args, **kwargs):
         # pylint: disable=unused-argument

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -62,7 +62,7 @@ class Stack(object):
     def __init__(self, definition, context, variables=None, mappings=None,
                  locked=False, force=False, enabled=True, protected=False):
         self.name = definition.name
-        self.fqn = context.get_fqn(self.name)
+        self.fqn = context.get_fqn(definition.stack_name or self.name)
         self.definition = definition
         self.variables = _gather_variables(definition)
         self.mappings = mappings

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -63,6 +63,7 @@ class Stack(object):
                  locked=False, force=False, enabled=True, protected=False):
         self.name = definition.name
         self.fqn = context.get_fqn(definition.stack_name or self.name)
+        self.region = definition.region
         self.definition = definition
         self.variables = _gather_variables(definition)
         self.mappings = mappings

--- a/stacker/tests/actions/test_base.py
+++ b/stacker/tests/actions/test_base.py
@@ -9,8 +9,10 @@ from stacker.actions.base import (
 
 from stacker.providers.aws.default import Provider
 from stacker.blueprints.base import Blueprint
+from stacker.session_cache import get_session
 
 from stacker.tests.factories import (
+    MockProviderBuilder,
     mock_context,
 )
 
@@ -29,10 +31,11 @@ class TestBlueprint(Blueprint):
 
 class TestBaseAction(unittest.TestCase):
     def test_ensure_cfn_bucket_exists(self):
-        provider = Provider("us-east-1")
+        session = get_session("us-east-1")
+        provider = Provider(session)
         action = BaseAction(
             context=mock_context("mynamespace"),
-            provider=provider
+            provider_builder=MockProviderBuilder(provider)
         )
         stubber = Stubber(action.s3_conn)
         stubber.add_response(
@@ -46,10 +49,11 @@ class TestBaseAction(unittest.TestCase):
             action.ensure_cfn_bucket()
 
     def test_ensure_cfn_bucket_doesnt_exist_us_east(self):
-        provider = Provider("us-east-1")
+        session = get_session("us-east-1")
+        provider = Provider(session)
         action = BaseAction(
             context=mock_context("mynamespace"),
-            provider=provider
+            provider_builder=MockProviderBuilder(provider)
         )
         stubber = Stubber(action.s3_conn)
         stubber.add_client_error(
@@ -69,10 +73,11 @@ class TestBaseAction(unittest.TestCase):
             action.ensure_cfn_bucket()
 
     def test_ensure_cfn_bucket_doesnt_exist_us_west(self):
-        provider = Provider("us-west-1")
+        session = get_session("us-west-1")
+        provider = Provider(session)
         action = BaseAction(
             context=mock_context("mynamespace"),
-            provider=provider
+            provider_builder=MockProviderBuilder(provider, region="us-west-1")
         )
         stubber = Stubber(action.s3_conn)
         stubber.add_client_error(
@@ -95,10 +100,11 @@ class TestBaseAction(unittest.TestCase):
             action.ensure_cfn_bucket()
 
     def test_ensure_cfn_forbidden(self):
-        provider = Provider("us-west-1")
+        session = get_session("us-west-1")
+        provider = Provider(session)
         action = BaseAction(
             context=mock_context("mynamespace"),
-            provider=provider
+            provider_builder=MockProviderBuilder(provider)
         )
         stubber = Stubber(action.s3_conn)
         stubber.add_client_error(
@@ -122,10 +128,11 @@ class TestBaseAction(unittest.TestCase):
         blueprint = TestBlueprint(name="myblueprint", context=context)
 
         for region, endpoint in test_cases:
-            provider = Provider(region)
+            session = get_session(region)
+            provider = Provider(session)
             action = BaseAction(
                 context=context,
-                provider=provider
+                provider_builder=MockProviderBuilder(provider, region=region)
             )
             self.assertEqual(
                 action.stack_template_url(blueprint),

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -10,6 +10,15 @@ class MockThreadingEvent(object):
         return False
 
 
+class MockProviderBuilder(object):
+    def __init__(self, provider, region=None):
+        self.provider = provider
+        self.region = region
+
+    def build(self, region):
+        return self.provider
+
+
 def mock_provider(**kwargs):
     return MagicMock(**kwargs)
 

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -43,7 +43,7 @@ class FunctionalTests(Blueprint):
 
         bucket_arn = Sub("arn:aws:s3:::${StackerBucket}*")
         cloudformation_scope = Sub(
-            "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:"
+            "arn:aws:cloudformation:*:${AWS::AccountId}:"
             "stack/${StackerNamespace}-*")
         changeset_scope = "*"
 
@@ -91,7 +91,8 @@ class FunctionalTests(Blueprint):
                             awacs.cloudformation.DeleteStack,
                             awacs.cloudformation.CreateStack,
                             awacs.cloudformation.UpdateStack,
-                            awacs.cloudformation.DescribeStacks])]))
+                            awacs.cloudformation.DescribeStacks,
+                            awacs.cloudformation.DescribeStackEvents])]))
 
         user = t.add_resource(
             iam.User(

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -11,6 +11,7 @@ import boto3
 from ....actions.diff import DictValue
 
 from ....providers.base import Template
+from ....session_cache import get_session
 
 from ....providers.aws.default import (
     DEFAULT_CAPABILITIES,
@@ -359,7 +360,9 @@ class TestMethods(unittest.TestCase):
 class TestProviderDefaultMode(unittest.TestCase):
     def setUp(self):
         region = "us-east-1"
-        self.provider = Provider(region=region, recreate_failed=False)
+        self.session = get_session(region=region)
+        self.provider = Provider(
+            self.session, region=region, recreate_failed=False)
         self.stubber = Stubber(self.provider.cloudformation)
 
     def test_get_stack_stack_does_not_exist(self):
@@ -489,16 +492,15 @@ class TestProviderDefaultMode(unittest.TestCase):
 class TestProviderInteractiveMode(unittest.TestCase):
     def setUp(self):
         region = "us-east-1"
-        self.provider = Provider(region=region, interactive=True,
-                                 recreate_failed=True)
+        self.session = get_session(region=region)
+        self.provider = Provider(
+            self.session, interactive=True, recreate_failed=True)
         self.stubber = Stubber(self.provider.cloudformation)
 
     def test_successful_init(self):
-        region = "us-east-1"
         replacements = True
-        p = Provider(region=region, interactive=True,
+        p = Provider(self.session, interactive=True,
                      replacements_only=replacements)
-        self.assertEqual(p.region, region)
         self.assertEqual(p.replacements_only, replacements)
 
     @patch("stacker.providers.aws.default.ask_for_approval")

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -811,3 +811,34 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-bastion: submitted (creating new stack)"
   assert_has_line "${STACKER_NAMESPACE}-bastion: complete (creating new stack)"
 }
+
+@test "stacker build - override stack name" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    stack_name: vpcx
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    variables:
+      StringVariable: \${output vpc::DummyId}
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "${STACKER_NAMESPACE}-vpcx: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-vpcx: complete (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-bastion: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-bastion: complete (creating new stack)"
+}

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -124,6 +124,33 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-vpc: complete (stack destroyed)"
 }
 
+@test "stacker info - simple info" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+
+  stacker info <(config)
+  assert "$status" -eq 0
+  assert_has_line "Outputs for stacks: ${STACKER_NAMESPACE}"
+  assert_has_line "${STACKER_NAMESPACE}-vpc:"
+  assert_has_line "DummyId: dummy-1234"
+}
+
 @test "stacker build - simple build with output lookups" {
   needs_aws
 
@@ -810,6 +837,9 @@ EOF
   assert_has_line "Tailing stack: ${STACKER_NAMESPACE}-bastion"
   assert_has_line "${STACKER_NAMESPACE}-bastion: submitted (creating new stack)"
   assert_has_line "${STACKER_NAMESPACE}-bastion: complete (creating new stack)"
+
+  stacker destroy --force --tail <(config)
+  assert "$status" -eq 0
 }
 
 @test "stacker build - override stack name" {
@@ -841,4 +871,41 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-vpcx: complete (creating new stack)"
   assert_has_line "${STACKER_NAMESPACE}-bastion: submitted (creating new stack)"
   assert_has_line "${STACKER_NAMESPACE}-bastion: complete (creating new stack)"
+}
+
+@test "stacker build - multi region" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: west/vpc
+    region: us-west-1
+    stack_name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: east/vpc
+    region: us-east-1
+    stack_name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+  - name: app
+    region: us-east-1
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    variables:
+      StringVariable: \${output west/vpc::DummyId}
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: complete (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-app: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-app: complete (creating new stack)"
 }


### PR DESCRIPTION
This implements support for provisioning stacks in multiple regions. You can target a stack to a specific region using the new per stack `region` option.

**Example**

Here's a simple pseudo stack config that shows how one might use this to create some resources in us-west-1, and reference them in us-east-1 with the `output` lookup.

```yaml
stacks:
  - name: west/encryption-key
    stack_name: encryption-key
    region: us-west-1
    class_path: stacker_blueprints.kms.Key
    variables:
      KeyAlias: alias/backups

  # You can use the `output` lookup to use an output from a stack in one
  # region, as the input to a stack in another region:
  - name: east/db-backups
    stack_name: db-backups
    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
    variables:
      # Reference the KMS key created in us-west-1!
      EncryptionKeyARN: ${output west/encryption-key}
```

In the long term, I'm also planning on adding multi account support, [aws profiles](https://github.com/remind101/stacker/wiki/RFC:-Profiles), but I still think having a `region` flag on a stack is still valuable for simplicity, and everything in this PR is a pre-req to supporting aws profiles.

Depends on https://github.com/remind101/stacker/pull/550

**TODO**

* [x] Fix `--tail` (breaks because it doesn't happen within `_launch_stack`, so it doesn't get the stack specific region applied).
* [x] Fix info command
* [x] Fix `FunctionalTests` blueprint to give stacker user access to all regions.