### PR TITLE
Cross account support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,4 +48,5 @@ jobs:
             export TERM=xterm
             export AWS_DEFAULT_REGION=us-east-1
             export STACKER_NAMESPACE=stacker-functional-tests-$CIRCLE_BUILD_NUM
+            export STACKER_ROLE=arn:aws:iam::487039194316:role/stacker-functional-tests-stacke-FunctionalTestRole-JKTNS8IDNZZ4
             sudo -E  make test-functional

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -210,7 +210,8 @@ class BaseAction(object):
     def build_provider(self, stack):
         """Builds a :class:`stacker.providers.base.Provider` suitable for
         operating on the given :class:`stacker.Stack`."""
-        return self.provider_builder.build(region=stack.region)
+        return self.provider_builder.build(region=stack.region,
+                                           profile=stack.profile)
 
     @property
     def provider(self):

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -275,6 +275,8 @@ class Stack(Model):
 
     region = StringType(serialize_when_none=False)
 
+    profile = StringType(serialize_when_none=False)
+
     class_path = StringType(serialize_when_none=False)
 
     template_path = StringType(serialize_when_none=False)

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -424,13 +424,13 @@ class ProviderBuilder(object):
         self.region = region
         self.kwargs = kwargs
 
-    def build(self, region=None):
+    def build(self, region=None, profile=None):
         # TODO(ejholmes): This class _could_ cache built providers, however,
         # the building of boto3 clients is _not_ threadsafe. See
         # https://github.com/boto/boto3/issues/801#issuecomment-245455979
         if not region:
             region = self.region
-        session = get_session(region=region)
+        session = get_session(region=region, profile=profile)
         return Provider(session, region=region, **self.kwargs)
 
 

--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -1,27 +1,27 @@
 import json
 import os
-import botocore
 import boto3
 import logging
+from .ui import ui
 
 
-def get_session(region):
+def get_session(region, profile=None):
     """Creates a boto3 session with a cache
 
     Args:
         region (str): The region for the session
+        profile (str): The profile for the session
 
     Returns:
         :class:`boto3.session.Session`: A boto3 session with
             credential caching
     """
-    session = botocore.session.get_session()
-    if region is not None:
-        session.set_config_variable('region',  region)
-    c = session.get_component('credential_provider')
+    session = boto3.Session(region_name=region, profile_name=profile)
+    c = session._session.get_component('credential_provider')
     provider = c.get_provider('assume-role')
     provider.cache = CredentialCache()
-    return boto3.session.Session(botocore_session=session)
+    provider._prompter = ui.getpass
+    return session
 
 
 logger = logging.getLogger(__name__)

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -64,6 +64,7 @@ class Stack(object):
         self.name = definition.name
         self.fqn = context.get_fqn(definition.stack_name or self.name)
         self.region = definition.region
+        self.profile = definition.profile
         self.definition = definition
         self.variables = _gather_variables(definition)
         self.mappings = mappings

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -22,6 +22,7 @@ class MockStack(object):
         self.name = name
         self.fqn = name
         self.region = None
+        self.profile = None
         self.requires = []
 
 

--- a/stacker/tests/factories.py
+++ b/stacker/tests/factories.py
@@ -15,7 +15,7 @@ class MockProviderBuilder(object):
         self.provider = provider
         self.region = region
 
-    def build(self, region):
+    def build(self, region, profile):
         return self.provider
 
 

--- a/stacker/ui.py
+++ b/stacker/ui.py
@@ -1,5 +1,6 @@
 import threading
 import logging
+from getpass import getpass
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,14 @@ class UI(object):
         self.lock()
         try:
             return get_raw_input(message)
+        finally:
+            self.unlock()
+
+    def getpass(self, *args):
+        """Wraps getpass to lock the UI."""
+        try:
+            self.lock()
+            return getpass(*args)
         finally:
             self.unlock()
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,6 @@ This directory contains the functional testing suite for stacker. It exercises a
 
   ```console
   $ export STACKER_NAMESPACE=my-stacker-test-namespace
-  $ export AWS_DEFAULT_REGION=us-east-1
   ```
 3. Generate an IAM user for the test suite to use:
 
@@ -24,6 +23,7 @@ This directory contains the functional testing suite for stacker. It exercises a
   $ ./stacker.yaml.sh | stacker info -
   $ export AWS_ACCESS_KEY_ID=access-key
   $ export AWS_SECRET_ACCESS_KEY=secret-access-key
+  $ export STACKER_ROLE=<FunctionalTestRole>
   ```
 5. Run the test suite:
 

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -909,3 +909,28 @@ EOF
   assert_has_line "${STACKER_NAMESPACE}-app: submitted (creating new stack)"
   assert_has_line "${STACKER_NAMESPACE}-app: complete (creating new stack)"
 }
+
+@test "stacker build - profiles" {
+  needs_aws
+
+  config() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    profile: stacker
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config)
+  }
+
+  # Create the new stacks.
+  stacker build <(config)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: submitted (creating new stack)"
+  assert_has_line "${STACKER_NAMESPACE}-vpc: complete (creating new stack)"
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -9,6 +9,26 @@ if [ -z "$STACKER_NAMESPACE" ]; then
   exit 1
 fi
 
+if [ -z "$STACKER_ROLE" ]; then
+  >&2 echo "To run these tests, you must set a STACKER_ROLE environment variable"
+  exit 1
+fi
+
+# Setup a base .aws/config that can be use to test stack configurations that
+# require stacker to assume a role.
+export AWS_CONFIG_DIR=$(mktemp -d)
+export AWS_CONFIG_FILE="$AWS_CONFIG_DIR/config"
+
+cat <<EOF > "$AWS_CONFIG_FILE"
+[default]
+region = us-east-1
+
+[profile stacker]
+region = us-east-1
+role_arn = ${STACKER_ROLE}
+credential_source = Environment
+EOF
+
 # Simple wrapper around the builtin bash `test` command.
 assert() {
   builtin test "$@"


### PR DESCRIPTION
Depends on https://github.com/remind101/stacker/pull/551

This is based on the RFC in https://github.com/remind101/stacker/wiki/RFC:-Profiles

Closes https://github.com/remind101/stacker/issues/263
Fixes https://github.com/remind101/stacker/issues/277

With this change, you can specify a boto3 profile to use for a given stack. This can be used for cross account provisioning and linking of stacks. For example, say you wanted to provision a hot and cold version of an application in multiple regions and multiple accounts, you could do something like this:

```yaml
stacks:
- name: hot/vpc
  stack_name: vpc
  profile: hot
- name: cold/vpc
  stack_name: vpc
  profile: cold
- name: app
  profile: hot
  variables:
    VpcId: ${output hot/vpc::VpcId}
- name: cold/app
  stack_name: app
  profile: cold
  variables:
    VpcId: ${output cold/vpc::VpcId}
```

```console
$ echo <<EOF > .aws/config
[profile hot]
region = us-east-1
role_arn = arn:aws:iam::1234567:role/Stacker

[profile prod/cold]
region = us-west-1
role_arn = arn:aws:iam::7654321:role/Stacker
EOF
```

```console
$ AWS_CONFIG_FILE=.aws/config.prod stacker build stacker.yaml
```

## TODO

* [x] Docs around using AWS profiles with stacker.
* [x] Functional tests