### PR TITLE
Remove python-dateutil from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ install_requires = [
     "formic~=0.9b",
     "gitpython~=2.0",
     "schematics~=2.0.1",
-    "python-dateutil~=2.0"
 ]
 
 tests_require = [


### PR DESCRIPTION
Recent versions of botocore lock this to [python-dateutil>=2.1,<2.7.0](https://github.com/boto/botocore/commit/90d7692702be1a423af15e0f49b58365f2a400f2). It may be best for us to just remove the version requirement here and rely on botocore's.