### PR TITLE
Don't require class_path or template_path for locked stacks

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -334,7 +334,8 @@ A stack has the following keys:
   updated unless the stack is passed to stacker via the *--force* flag.
   This is useful for *risky* stacks that you don't want to take the
   risk of allowing CloudFormation to update, but still want to make
-  sure get launched when the environment is first created.
+  sure get launched when the environment is first created. When ``locked``,
+  it's not necessary to specify a ``class_path`` or ``template_path``.
 **enabled:**
   (optional) If set to false, the stack is disabled, and will not be
   built or updated. This can allow you to disable stacks in different

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -228,6 +228,11 @@ class Action(BaseAction):
         except StackDoesNotExist:
             provider_stack = None
 
+        if provider_stack and not should_update(stack):
+            stack.set_outputs(
+                self.provider.get_output_dict(provider_stack))
+            return NotUpdatedStatus()
+
         recreate = False
         if provider_stack and old_status == SUBMITTED:
             logger.debug(
@@ -289,8 +294,6 @@ class Action(BaseAction):
             provider.create_stack(stack.fqn, template, parameters, tags,
                                   force_change_set)
             return SubmittedStatus("creating new stack")
-        elif not should_update(stack):
-            return NotUpdatedStatus()
 
         try:
             if provider.prepare_stack_for_update(provider_stack, tags):

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -312,6 +312,11 @@ class Stack(Model):
         self.validate_stack_source(data)
 
     def validate_stack_source(self, data):
+        # Locked stacks don't actually need a template, since they're
+        # read-only.
+        if data["locked"]:
+            return
+
         if not (data["class_path"] or data["template_path"]):
             raise ValidationError(
                 "class_path or template_path is required.")

--- a/stacker/tests/test_config.py
+++ b/stacker/tests/test_config.py
@@ -55,13 +55,21 @@ class TestConfig(unittest.TestCase):
             config.validate()
 
         stack_errors = ex.exception.errors['stacks'][0]
-        print stack_errors
         self.assertEquals(
             stack_errors['template_path'][0].__str__(),
             "class_path or template_path is required.")
         self.assertEquals(
             stack_errors['class_path'][0].__str__(),
             "class_path or template_path is required.")
+
+    def test_config_validate_missing_stack_source_when_locked(self):
+        config = Config({
+            "namespace": "prod",
+            "stacks": [
+                {
+                    "name": "bastion",
+                    "locked": True}]})
+        config.validate()
 
     def test_config_validate_stack_class_and_template_paths(self):
         config = Config({

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -433,6 +433,51 @@ EOF
   assert_has_line "add-resource-test-with-replacements-only: complete (stack destroyed)"
 }
 
+@test "stacker build - locked stacks" {
+  needs_aws
+
+  config1() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+EOF
+  }
+
+  config2() {
+    cat <<EOF
+namespace: ${STACKER_NAMESPACE}
+stacks:
+  - name: vpc
+    locked: true
+  - name: bastion
+    class_path: stacker.tests.fixtures.mock_blueprints.Dummy
+    variables:
+      StringVariable: \${output vpc::DummyId}
+EOF
+  }
+
+  teardown() {
+    stacker destroy --force <(config2)
+  }
+
+  stacker build <(config2)
+  assert "$status" -eq 1
+  assert_has_line "AttributeError: Stack does not have a defined class or template path."
+
+  # Create the new stacks.
+  stacker build <(config1)
+  assert "$status" -eq 0
+
+  stacker build <(config2)
+  assert "$status" -eq 0
+  assert_has_line "Using default AWS provider mode"
+  assert_has_line "vpc: skipped (locked)"
+  assert_has_line "bastion: submitted (creating new stack)"
+  assert_has_line "bastion: complete (creating new stack)"
+}
+
 @test "stacker build - default mode, without & with protected stack" {
   needs_aws
 


### PR DESCRIPTION
Technically, "locked" stacks don't actually need a `class_path` or a `template_path`, since they're readonly. This change also fixes a bug introduced in https://github.com/remind101/stacker/pull/550, where the `output` plugin would fail with the following when looking up outputs on locked stacks:

```
FailedVariableLookup: Couldn't resolve lookups in variable `StringVariable`. 'NoneType' object has no attribute '__getitem__'
```

Tests are gonna fail right now until https://github.com/remind101/stacker/pull/556 is merged.