### PR TITLE
Implement a threadsafe credential cacher

### DIFF
--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -1,8 +1,15 @@
-import json
-import os
 import boto3
 import logging
 from .ui import ui
+
+
+logger = logging.getLogger(__name__)
+
+
+# A global credential cache that can be shared among boto3 sessions. This is
+# inherently threadsafe thanks to the GIL:
+# https://docs.python.org/3/glossary.html#term-global-interpreter-lock
+credential_cache = {}
 
 
 def get_session(region, profile=None):
@@ -19,60 +26,6 @@ def get_session(region, profile=None):
     session = boto3.Session(region_name=region, profile_name=profile)
     c = session._session.get_component('credential_provider')
     provider = c.get_provider('assume-role')
-    provider.cache = CredentialCache()
+    provider.cache = credential_cache
     provider._prompter = ui.getpass
     return session
-
-
-logger = logging.getLogger(__name__)
-
-
-class CredentialCache(object):
-
-    """JSON file cache.
-    This provides a dict like interface that stores JSON serializable
-    objects.
-    The objects are serialized to JSON and stored in a file.  These
-    values can be retrieved at a later time.
-    """
-
-    CACHE_DIR = os.path.expanduser(
-        os.path.join('~', '.aws', 'cli', 'cache'))
-
-    def __init__(self, working_dir=CACHE_DIR):
-        self._working_dir = working_dir
-
-    def __contains__(self, cache_key):
-        actual_key = self._convert_cache_key(cache_key)
-        return os.path.isfile(actual_key)
-
-    def __getitem__(self, cache_key):
-        """Retrieve value from a cache key."""
-        logger.debug("Getting cached credentials from: %s", self.CACHE_DIR)
-        actual_key = self._convert_cache_key(cache_key)
-        try:
-            with open(actual_key) as f:
-                return json.load(f)
-        except (OSError, ValueError, IOError):
-            raise KeyError(cache_key)
-
-    def __setitem__(self, cache_key, value):
-        full_key = self._convert_cache_key(cache_key)
-        try:
-            file_content = json.dumps(value, default=str)
-        except (TypeError, ValueError):
-            raise ValueError("Value cannot be cached, must be "
-                             "JSON serializable: %s" % value)
-        if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir)
-        with os.fdopen(os.open(full_key,
-                               os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
-            f.truncate()
-            f.write(file_content)
-            logger.debug(
-                "Updating cache with new obtained credentials: %s",
-                self.CACHE_DIR)
-
-    def _convert_cache_key(self, cache_key):
-        full_path = os.path.join(self._working_dir, cache_key + '.json')
-        return full_path


### PR DESCRIPTION
Fixes https://github.com/remind101/stacker/issues/560

This replaces the `CredentialCache` with an in memory dict, which is inherently threadsafe. The [original reason](https://github.com/remind101/stacker/pull/307) we added a credential cache, was to ensure that only the _first_ AssumeRole would make a network request, and subsequent stacks would use the cached credentials within a `stacker build`. Disk persistence isn't necessary.