### PR TITLE
Add a --profile flag to specify default profile

### DIFF
--- a/stacker/commands/stacker/__init__.py
+++ b/stacker/commands/stacker/__init__.py
@@ -9,6 +9,7 @@ from ...config import render_parse_load as load_config
 from ...context import Context
 from ...providers.aws import default
 from ... import __version__
+from ... import session_cache
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ class Stacker(BaseCommand):
             options.config.read(),
             environment=options.environment,
             validate=True)
+
+        session_cache.default_profile = options.profile
 
         options.provider_builder = default.ProviderBuilder(
             region=options.region,

--- a/stacker/commands/stacker/base.py
+++ b/stacker/commands/stacker/base.py
@@ -150,7 +150,12 @@ class BaseCommand(object):
                  "more than once.")
         parser.add_argument(
             "-r", "--region",
-            help="The AWS region to launch in.")
+            help="The default AWS region to use for all AWS API calls.")
+        parser.add_argument(
+            "-p", "--profile",
+            help="The default AWS profile to use for all AWS API calls. If "
+                 "not specified, the default will be according to http://bo"
+                 "to3.readthedocs.io/en/latest/guide/configuration.html.")
         parser.add_argument(
             "-v", "--verbose", action="count", default=0,
             help="Increase output verbosity. May be specified up to twice.")

--- a/stacker/providers/aws/default.py
+++ b/stacker/providers/aws/default.py
@@ -425,9 +425,6 @@ class ProviderBuilder(object):
         self.kwargs = kwargs
 
     def build(self, region=None, profile=None):
-        # TODO(ejholmes): This class _could_ cache built providers, however,
-        # the building of boto3 clients is _not_ threadsafe. See
-        # https://github.com/boto/boto3/issues/801#issuecomment-245455979
         if not region:
             region = self.region
         session = get_session(region=region, profile=profile)

--- a/stacker/session_cache.py
+++ b/stacker/session_cache.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 # https://docs.python.org/3/glossary.html#term-global-interpreter-lock
 credential_cache = {}
 
+default_profile = None
+
 
 def get_session(region, profile=None):
     """Creates a boto3 session with a cache
@@ -23,6 +25,14 @@ def get_session(region, profile=None):
         :class:`boto3.session.Session`: A boto3 session with
             credential caching
     """
+    if profile is None:
+        logger.debug("No AWS profile explicitly provided. "
+                     "Falling back to default.")
+        profile = default_profile
+
+    logger.debug("Building session using profile \"%s\" in region \"%s\""
+                 % (profile, region))
+
     session = boto3.Session(region_name=region, profile_name=profile)
     c = session._session.get_component('credential_provider')
     provider = c.get_provider('assume-role')


### PR DESCRIPTION
This adds a `--profile` flag, similar to the `--region` flag that specifies a global default profile for stacker to use for all AWS API calls, when no explicit `profile` is specified.

Another way to do this is is to specify the `AWS_PROFILE` or `AWS_DEFAULT_PROFILE` environment variable, but [in certain configurations that won't actually work](https://github.com/boto/botocore/issues/1401).