### PR TITLE
Fix potential race in s3_stack_push

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -342,6 +342,7 @@ class Action(BaseAction):
 
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
+        self.ensure_cfn_bucket()
         hooks = self.context.config.pre_build
         handle_hooks(
             "pre_build",

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -41,7 +41,6 @@ class TestDestroyAction(unittest.TestCase):
         })
         self.context = Context(config=config)
         self.action = destroy.Action(self.context,
-                                     provider_builder=mock.MagicMock(),
                                      cancel=MockThreadingEvent())
 
     def test_generate_plan(self):


### PR DESCRIPTION
Fixes https://github.com/remind101/stacker/issues/567

This contains two changes:

1. It makes `s3_stack_push` thread safe, so that we only initialize one s3 client (boto3 clients are threadsafe, but initialization is not)
2. It improves performance, since we only call `ensure_bucket` (`s3:HeadBucket`) once instead of one time for every stack.