### PR TITLE
Add support for stack policies

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -367,6 +367,11 @@ A stack has the following keys:
   (optional): If provided, specifies the name of a AWS profile to use when
   performing AWS API calls for this stack. This can be used to provision stacks
   in multiple accounts or regions.
+**stack_policy_path**:
+  (optional): If provided, specifies the path to a JSON formatted stack policy
+  that will be applied when the CloudFormation stack is created and updated.
+  You can use stack policies to prevent CloudFormation from making updates to
+  protected resources (e.g. databases). See: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/protect-stack-resources.html
 
 Here's an example from stacker_blueprints_, used to create a VPC::
 

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -297,6 +297,8 @@ class Stack(Model):
 
     tags = DictType(StringType, serialize_when_none=False)
 
+    stack_policy_path = StringType(serialize_when_none=False)
+
     def validate_class_path(self, data, value):
         if value and data["template_path"]:
             raise ValidationError(

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -103,6 +103,16 @@ class Stack(object):
         return requires
 
     @property
+    def stack_policy(self):
+        if not hasattr(self, "_stack_policy"):
+            self._stack_policy = None
+            if self.definition.stack_policy_path:
+                with open(self.definition.stack_policy_path) as f:
+                    self._stack_policy = f.read()
+
+        return self._stack_policy
+
+    @property
     def blueprint(self):
         if not hasattr(self, "_blueprint"):
             kwargs = {}

--- a/stacker/tests/fixtures/mock_blueprints.py
+++ b/stacker/tests/fixtures/mock_blueprints.py
@@ -92,6 +92,7 @@ class FunctionalTests(Blueprint):
                             awacs.cloudformation.DeleteStack,
                             awacs.cloudformation.CreateStack,
                             awacs.cloudformation.UpdateStack,
+                            awacs.cloudformation.SetStackPolicy,
                             awacs.cloudformation.DescribeStacks,
                             awacs.cloudformation.DescribeStackEvents])]))
 

--- a/stacker/tests/providers/aws/test_default.py
+++ b/stacker/tests/providers/aws/test_default.py
@@ -348,6 +348,14 @@ class TestMethods(unittest.TestCase):
         change_set_result["ChangeSetName"] = "MyChanges"
         self.assertEqual(result, change_set_result)
 
+        # Check stack policy
+        stack_policy = Template(body="{}")
+        result = generate_cloudformation_args(stack_policy=stack_policy,
+                                              **std_args)
+        stack_policy_result = copy.deepcopy(std_return)
+        stack_policy_result["StackPolicyBody"] = "{}"
+        self.assertEqual(result, stack_policy_result)
+
         # If not TemplateURL is provided, use TemplateBody
         std_args["template"] = Template(body=template_body)
         template_body_result = copy.deepcopy(std_return)

--- a/tests/fixtures/stack_policies/default.json
+++ b/tests/fixtures/stack_policies/default.json
@@ -1,0 +1,10 @@
+{
+  "Statement" : [
+    {
+      "Effect" : "Allow",
+      "Action" : "Update:*",
+      "Principal": "*",
+      "Resource" : "*"
+    }  
+  ]
+}

--- a/tests/fixtures/stack_policies/none.json
+++ b/tests/fixtures/stack_policies/none.json
@@ -1,0 +1,10 @@
+{
+  "Statement" : [
+    {
+      "Effect" : "Deny",
+      "Action" : "Update:*",
+      "Principal": "*",
+      "Resource" : "*"
+    }  
+  ]
+}

--- a/tests/suite.bats
+++ b/tests/suite.bats
@@ -94,6 +94,7 @@ namespace: ${STACKER_NAMESPACE}
 stacks:
   - name: vpc
     class_path: stacker.tests.fixtures.mock_blueprints.VPC
+    stack_policy: tests/fixtures/stack_policies/default.json
     variables:
       PublicSubnets: 10.128.0.0/24,10.128.1.0/24,10.128.2.0/24,10.128.3.0/24
       PrivateSubnets: 10.128.8.0/22,10.128.12.0/22,10.128.16.0/22,10.128.20.0/22


### PR DESCRIPTION
Closes https://github.com/remind101/stacker/issues/112

This is something I've wanted for a long time. Stack policies are a great way to add an extra layer of protection around sensitive resources, like databases, VPC subnets, etc.

It's entirely possible to make use of stack policies outside of stacker (we have for some time now), but it ends up being pretty manual. It'd be great to be able to automate it with stacker.