### PR TITLE
Add targets

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -348,6 +348,9 @@ A stack has the following keys:
   (optional) a list of other stacks this stack requires. This is for explicit
   dependencies - you do not need to set this if you refer to another stack in
   a Parameter, so this is rarely necessary.
+**required_by:**
+  (optional) a list of other stacks or targets that require this stack. It's an
+  inverse to ``requires``.
 **tags:**
   (optional) a dictionary of CloudFormation tags to apply to this stack. This
   will be combined with the global tags, but these tags will take precendence.
@@ -391,6 +394,37 @@ Here's an example from stacker_blueprints_, used to create a VPC::
           - 10.128.16.0/22
           - 10.128.20.0/22
         CidrBlock: 10.128.0.0/16
+
+Targets
+-------
+
+In stacker, **targets** can be used as a lightweight method to group a number
+of stacks together, as a named "target" in the graph. Internally, this adds a
+node to the underlying DAG, which can then be used alongside the `--targets`
+flag. If you're familiar with the concept of "targets" in systemd, the concept
+is the same.
+
+**name:**
+  The logical name for this target.
+**requires:**
+  (optional) a list of stacks or other targets this target requires.
+**required_by:**
+  (optional) a list of stacks or other targets that require this target.
+
+Here's an example of a target that will execute all "database" stacks::
+
+  targets:
+    - name: databases
+
+  stacks:
+    - name: dbA
+      class_path: blueprints.DB
+      required_by:
+        - databases
+    - name: dbB
+      class_path: blueprints.DB
+      required_by:
+        - databases
 
 Variables
 ==========

--- a/stacker/actions/base.py
+++ b/stacker/actions/base.py
@@ -4,11 +4,15 @@ import logging
 import threading
 
 from ..dag import walk, ThreadedWalker
-from ..plan import Step, build_plan
+from ..plan import Step, build_plan, build_graph
 
 import botocore.exceptions
 from stacker.session_cache import get_session
 from stacker.exceptions import PlanFailed
+
+from ..status import (
+    SKIPPED
+)
 
 from stacker.util import (
     ensure_s3_bucket,
@@ -48,16 +52,15 @@ def build_walker(concurrency):
     return ThreadedWalker(concurrency).walk
 
 
-def plan(description, action, stacks,
-         targets=None, tail=None,
-         reverse=False):
+def plan(description, stack_action, context,
+         tail=None, reverse=False):
     """A simple helper that builds a graph based plan from a set of stacks.
 
     Args:
         description (str): a description of the plan.
         action (func): a function to call for each stack.
-        stacks (list): a list of :class:`stacker.stack.Stack` objects to build.
-        targets (list): an optional list of targets to filter the graph to.
+        context (:class:`stacker.context.Context`): a
+            :class:`stacker.context.Context` to build the plan from.
         tail (func): an optional function to call to tail the stack progress.
         reverse (bool): if True, execute the graph in reverse (useful for
             destroy actions).
@@ -66,14 +69,22 @@ def plan(description, action, stacks,
         :class:`plan.Plan`: The resulting plan object
     """
 
+    def target_fn(*args, **kwargs):
+        return SKIPPED
+
     steps = [
-        Step(stack, fn=action, watch_func=tail)
-        for stack in stacks]
+        Step(stack, fn=stack_action, watch_func=tail)
+        for stack in context.get_stacks()]
+
+    steps += [
+        Step(target, fn=target_fn) for target in context.get_targets()]
+
+    graph = build_graph(steps)
 
     return build_plan(
         description=description,
-        steps=steps,
-        targets=targets,
+        graph=graph,
+        targets=context.stack_names,
         reverse=reverse)
 
 

--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -335,10 +335,9 @@ class Action(BaseAction):
     def _generate_plan(self, tail=False):
         return plan(
             description="Create/Update stacks",
-            action=self._launch_stack,
+            stack_action=self._launch_stack,
             tail=self._tail_stack if tail else None,
-            stacks=self.context.get_stacks(),
-            targets=self.context.stack_names)
+            context=self.context)
 
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""

--- a/stacker/actions/destroy.py
+++ b/stacker/actions/destroy.py
@@ -35,10 +35,9 @@ class Action(BaseAction):
     def _generate_plan(self, tail=False):
         return plan(
             description="Destroy stacks",
-            action=self._destroy_stack,
+            stack_action=self._destroy_stack,
             tail=self._tail_stack if tail else None,
-            stacks=self.context.get_stacks(),
-            targets=self.context.stack_names,
+            context=self.context,
             reverse=True)
 
     def _destroy_stack(self, stack, **kwargs):

--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -263,9 +263,8 @@ class Action(build.Action):
     def _generate_plan(self):
         return plan(
             description="Diff stacks",
-            action=self._diff_stack,
-            stacks=self.context.get_stacks(),
-            targets=self.context.stack_names)
+            stack_action=self._diff_stack,
+            context=self.context)
 
     def run(self, concurrency=0, *args, **kwargs):
         plan = self._generate_plan()

--- a/stacker/commands/stacker/build.py
+++ b/stacker/commands/stacker/build.py
@@ -25,7 +25,7 @@ class Build(BaseCommand):
                             help="If a stackname is provided to --force, it "
                                  "will be updated, even if it is locked in "
                                  "the config.")
-        parser.add_argument("--stacks", action="append",
+        parser.add_argument("--targets", "--stacks", action="append",
                             metavar="STACKNAME", type=str,
                             help="Only work on the stacks given, and their "
                                  "dependencies. Can be specified more than "
@@ -55,4 +55,4 @@ class Build(BaseCommand):
                        dump=options.dump)
 
     def get_context_kwargs(self, options, **kwargs):
-        return {"stack_names": options.stacks, "force_stacks": options.force}
+        return {"stack_names": options.targets, "force_stacks": options.force}

--- a/stacker/commands/stacker/destroy.py
+++ b/stacker/commands/stacker/destroy.py
@@ -19,7 +19,7 @@ class Destroy(BaseCommand):
         parser.add_argument("-f", "--force", action="store_true",
                             help="Whether or not you want to go through "
                                  " with destroying the stacks")
-        parser.add_argument("--stacks", action="append",
+        parser.add_argument("--targets", "--stacks", action="append",
                             metavar="STACKNAME", type=str,
                             help="Only work on the stacks given. Can be "
                                  "specified more than once. If not specified "
@@ -45,4 +45,4 @@ class Destroy(BaseCommand):
                        tail=options.tail)
 
     def get_context_kwargs(self, options, **kwargs):
-        return {"stack_names": options.stacks}
+        return {"stack_names": options.targets}

--- a/stacker/config/__init__.py
+++ b/stacker/config/__init__.py
@@ -268,6 +268,14 @@ class Hook(Model):
     args = DictType(AnyType)
 
 
+class Target(Model):
+    name = StringType(required=True)
+
+    requires = ListType(StringType, serialize_when_none=False)
+
+    required_by = ListType(StringType, serialize_when_none=False)
+
+
 class Stack(Model):
     name = StringType(required=True)
 
@@ -284,6 +292,8 @@ class Stack(Model):
     description = StringType(serialize_when_none=False)
 
     requires = ListType(StringType, serialize_when_none=False)
+
+    required_by = ListType(StringType, serialize_when_none=False)
 
     locked = BooleanType(default=False)
 
@@ -389,6 +399,9 @@ class Config(Model):
         DictType(DictType(StringType)), serialize_when_none=False)
 
     lookups = DictType(StringType, serialize_when_none=False)
+
+    targets = ListType(
+        ModelType(Target), serialize_when_none=False)
 
     stacks = ListType(
         ModelType(Stack), default=[], validators=[not_empty_list])

--- a/stacker/context.py
+++ b/stacker/context.py
@@ -3,6 +3,7 @@ import logging
 
 from stacker.config import Config
 from .stack import Stack
+from .target import Target
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +119,21 @@ class Context(object):
 
     def _get_stack_definitions(self):
         return self.config.stacks
+
+    def get_targets(self):
+        """Returns the named targets that are specified in the config.
+
+        Returns:
+            list: a list of :class:`stacker.target.Target` objects
+
+        """
+        if not hasattr(self, "_targets"):
+            targets = []
+            for target_def in self.config.targets or []:
+                target = Target(target_def)
+                targets.append(target)
+            self._targets = targets
+        return self._targets
 
     def get_stacks(self):
         """Get the stacks for the current action.

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -56,7 +56,7 @@ class Step(object):
         self.watch_func = watch_func
 
     def __repr__(self):
-        return "<stacker.plan.Step:%s>" % (self.stack.fqn,)
+        return "<stacker.plan.Step:%s>" % (self.stack.name,)
 
     def __str__(self):
         return self.stack.name
@@ -102,6 +102,10 @@ class Step(object):
         return self.stack.requires
 
     @property
+    def required_by(self):
+        return self.stack.required_by
+
+    @property
     def completed(self):
         """Returns True if the step is in a COMPLETE state."""
         return self.status == COMPLETE
@@ -143,7 +147,8 @@ class Step(object):
                          status.name)
             self.status = status
             self.last_updated = time.time()
-            log_step(self)
+            if self.stack.logging:
+                log_step(self)
 
     def complete(self):
         """A shortcut for set_status(COMPLETE)"""
@@ -158,13 +163,13 @@ class Step(object):
         self.set_status(SUBMITTED)
 
 
-def build_plan(description, steps,
+def build_plan(description, graph,
                targets=None, reverse=False):
     """Builds a plan from a list of steps.
     Args:
         description (str): an arbitrary string to
             describe the plan.
-        steps (list): a list of :class:`Step` objects to execute.
+        graph (:class:`Graph`): a list of :class:`Graph` to execute.
         targets (list): an optional list of step names to filter the graph to.
             If provided, only these steps, and their transitive dependencies
             will be executed. If no targets are specified, every node in the
@@ -172,7 +177,6 @@ def build_plan(description, steps,
         reverse (bool): If provided, the graph will be walked in reverse order
             (dependencies last).
     """
-    graph = build_graph(steps)
 
     # If we want to execute the plan in reverse (e.g. Destroy), transpose the
     # graph.
@@ -183,7 +187,7 @@ def build_plan(description, steps,
     if targets:
         nodes = []
         for target in targets:
-            for step in steps:
+            for step in graph.steps.itervalues():
                 if step.name == target:
                     nodes.append(step.name)
         graph = graph.filtered(nodes)
@@ -204,7 +208,10 @@ def build_graph(steps):
 
     for step in steps:
         for dep in step.requires:
-            graph.connect(step, dep)
+            graph.connect(step.name, dep)
+
+        for parent in step.required_by:
+            graph.connect(parent, step.name)
 
     return graph
 
@@ -242,11 +249,11 @@ class Graph(object):
 
     def connect(self, step, dep):
         try:
-            self.dag.add_edge(step.name, dep)
+            self.dag.add_edge(step, dep)
         except KeyError as e:
-            raise GraphError(e, step.name, dep)
+            raise GraphError(e, step, dep)
         except DAGValidationError as e:
-            raise GraphError(e, step.name, dep)
+            raise GraphError(e, step, dep)
 
     def walk(self, walker, walk_func):
         def fn(step_name):

--- a/stacker/stack.py
+++ b/stacker/stack.py
@@ -61,6 +61,7 @@ class Stack(object):
 
     def __init__(self, definition, context, variables=None, mappings=None,
                  locked=False, force=False, enabled=True, protected=False):
+        self.logging = True
         self.name = definition.name
         self.fqn = context.get_fqn(definition.stack_name or self.name)
         self.region = definition.region
@@ -77,6 +78,10 @@ class Stack(object):
 
     def __repr__(self):
         return self.fqn
+
+    @property
+    def required_by(self):
+        return self.definition.required_by or []
 
     @property
     def requires(self):

--- a/stacker/target.py
+++ b/stacker/target.py
@@ -1,0 +1,11 @@
+class Target(object):
+    """A "target" is just a node in the stacker graph that does nothing, except
+    specify dependencies. These can be useful as a means of logically grouping
+    a set of stacks together that can be targeted with the `--targets` flag.
+    """
+
+    def __init__(self, definition):
+        self.name = definition.name
+        self.requires = definition.requires or []
+        self.required_by = definition.required_by or []
+        self.logging = False


### PR DESCRIPTION
This adds "targets" to stacker, which are just named nodes in the graph that specify dependencies.

Why would you want this? Primarily just as an easy way to specify a logical grouping of stacks that you can use with the `--targets` flag (e.g. maybe you want a target for "databases" or "apps", etc). Essentially, these are no different than stacks, except they don't incur any AWS API calls, and don't take up a precious CloudFormation stack spot.

If you familiar with [targets in systemd](https://www.freedesktop.org/software/systemd/man/systemd.target.html), the concept is exactly the same; a node in the graph that does nothing.