### PR TITLE
Fixes 566

### DIFF
--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -82,6 +82,7 @@ class Step(object):
             if watcher:
                 stop_watcher.set()
                 watcher.join()
+        return self.ok
 
     def _run_once(self):
         try:

--- a/stacker/plan.py
+++ b/stacker/plan.py
@@ -82,7 +82,6 @@ class Step(object):
             if watcher:
                 stop_watcher.set()
                 watcher.join()
-        return self.ok
 
     def _run_once(self):
         try:

--- a/stacker/status.py
+++ b/stacker/status.py
@@ -4,10 +4,17 @@ class Status(object):
         self.code = code
         self.reason = reason or getattr(self, "reason", None)
 
+    def cmp(self, a, b):
+        try:
+            return cmp(a, b)
+        except NameError:
+            # Python3 doesn't have cmp function.
+            return ((a > b) - (a < b))
+
     def __cmp__(self, other):
         if hasattr(other, "code"):
-            return cmp(self.code, other.code)
-        return False
+            return self.cmp(self.code, other.code)
+        raise Exception("Both Status objects must have a `code` attribute.")
 
 
 class PendingStatus(Status):

--- a/stacker/status.py
+++ b/stacker/status.py
@@ -1,20 +1,34 @@
+import operator
+
+
 class Status(object):
     def __init__(self, name, code, reason=None):
         self.name = name
         self.code = code
         self.reason = reason or getattr(self, "reason", None)
 
-    def cmp(self, a, b):
-        try:
-            return cmp(a, b)
-        except NameError:
-            # Python3 doesn't have cmp function.
-            return ((a > b) - (a < b))
-
-    def __cmp__(self, other):
+    def _comparison(self, operator, other):
         if hasattr(other, "code"):
-            return self.cmp(self.code, other.code)
-        raise Exception("Both Status objects must have a `code` attribute.")
+            return operator(self.code, other.code)
+        return NotImplemented
+
+    def __eq__(self, other):
+        return self._comparison(operator.eq, other)
+
+    def __ne__(self, other):
+        return self._comparison(operator.ne, other)
+
+    def __lt__(self, other):
+        return self._comparison(operator.lt, other)
+
+    def __gt__(self, other):
+        return self._comparison(operator.gt, other)
+
+    def __le__(self, other):
+        return self._comparison(operator.le, other)
+
+    def __ge__(self, other):
+        return self._comparison(operator.ge, other)
 
 
 class PendingStatus(Status):

--- a/stacker/tests/actions/test_destroy.py
+++ b/stacker/tests/actions/test_destroy.py
@@ -102,20 +102,24 @@ class TestDestroyAction(unittest.TestCase):
         # simulate stack doesn't exist and we haven't submitted anything for
         # deletion
         mock_provider.get_stack.side_effect = StackDoesNotExist("mock")
-        status = step.run()
-        self.assertEqual(status, SKIPPED)
+
+        step.run()
+        self.assertEqual(step.status, SKIPPED)
 
         # simulate stack getting successfully deleted
         mock_provider.get_stack.side_effect = get_stack
         mock_provider.is_stack_destroyed.return_value = False
         mock_provider.is_stack_in_progress.return_value = False
-        status = step._run_once()
-        self.assertEqual(status, SUBMITTED)
+
+        step._run_once()
+        self.assertEqual(step.status, SUBMITTED)
         mock_provider.is_stack_destroyed.return_value = False
         mock_provider.is_stack_in_progress.return_value = True
-        status = step._run_once()
-        self.assertEqual(status, SUBMITTED)
+
+        step._run_once()
+        self.assertEqual(step.status, SUBMITTED)
         mock_provider.is_stack_destroyed.return_value = True
         mock_provider.is_stack_in_progress.return_value = False
-        status = step._run_once()
-        self.assertEqual(status, COMPLETE)
+
+        step._run_once()
+        self.assertEqual(step.status, COMPLETE)

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -22,6 +22,7 @@ from stacker.exceptions import (
     PlanFailed,
 )
 from stacker.status import (
+    SUBMITTED,
     COMPLETE,
     SKIPPED,
     FAILED,
@@ -44,12 +45,27 @@ class TestStep(unittest.TestCase):
     def test_status(self):
         self.assertFalse(self.step.submitted)
         self.assertFalse(self.step.completed)
+
         self.step.submit()
+        self.assertEqual(self.step.status, SUBMITTED)
         self.assertTrue(self.step.submitted)
         self.assertFalse(self.step.completed)
+
         self.step.complete()
+        self.assertEqual(self.step.status, COMPLETE)
+        self.assertNotEqual(self.step.status, SUBMITTED)
         self.assertTrue(self.step.submitted)
         self.assertTrue(self.step.completed)
+
+        # trying to compare a Status object to an object without
+        # a code attribute is invalid and should raise an exception.
+        with self.assertRaises(Exception):
+            if self.step.status == True: # noqa
+                pass
+
+        with self.assertRaises(Exception):
+            if self.step.status == False: # noqa
+                pass
 
 
 class TestPlan(unittest.TestCase):

--- a/stacker/tests/test_plan.py
+++ b/stacker/tests/test_plan.py
@@ -57,15 +57,9 @@ class TestStep(unittest.TestCase):
         self.assertTrue(self.step.submitted)
         self.assertTrue(self.step.completed)
 
-        # trying to compare a Status object to an object without
-        # a code attribute is invalid and should raise an exception.
-        with self.assertRaises(Exception):
-            if self.step.status == True: # noqa
-                pass
-
-        with self.assertRaises(Exception):
-            if self.step.status == False: # noqa
-                pass
+        self.assertNotEqual(self.step.status, True)
+        self.assertNotEqual(self.step.status, False)
+        self.assertNotEqual(self.step.status, 'banana')
 
 
 class TestPlan(unittest.TestCase):


### PR DESCRIPTION
Fixes #566 

One of our tests had a logic error where we were using the returned
result of Step.run (which was always self.ok [which is always True])
and comparing this to a Status object.

The actual test should be comparing Step.status with SKIPPED.

	modified:   stacker/plan.py
	modified:   stacker/status.py
	modified:   stacker/tests/actions/test_destroy.py