### PR TITLE
Fix datetime is not JSON serializable error

### DIFF
--- a/stacker/actions/diff.py
+++ b/stacker/actions/diff.py
@@ -152,7 +152,7 @@ def normalize_json(template):
         list: json representation of the parameters
     """
     obj = parse_cloudformation_template(template)
-    json_str = json.dumps(obj, sort_keys=True, indent=4)
+    json_str = json.dumps(obj, sort_keys=True, indent=4, default=str)
     result = []
     lines = json_str.split("\n")
     for line in lines:
@@ -250,7 +250,8 @@ class Action(build.Action):
             old_stack = normalize_json(
                 json.dumps(old_template,
                            sort_keys=True,
-                           indent=4)
+                           indent=4,
+                           default=str)
             )
             print_stack_changes(stack.name, new_stack, old_stack, new_params,
                                 old_params)

--- a/stacker/tests/actions/test_diff.py
+++ b/stacker/tests/actions/test_diff.py
@@ -138,3 +138,22 @@ class TestDiffFunctions(unittest.TestCase):
             '}\n'
         ]
         self.assertEquals(normalized_template, normalize_json(template))
+
+    def test_normalize_json_date(self):
+        """Ensure normalize_json handles objects loaded as datetime objects"""
+
+        template = """
+AWSTemplateFormatVersion: '2010-09-09'
+Description: ECS Cluster Application
+Resources:
+  ECSTaskRoleDefault:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17  # datetime.date(2012, 10, 17)
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole"""
+        self.assertTrue(normalize_json(template))


### PR DESCRIPTION
`TypeError: datetime.date(2012, 10, 17) is not JSON serializable`

This fixes the above exception raised by json.dumps when the yaml
library loads an unquoted date value e.g. `2012-10-17` as a
`datetime.time` object.