### PR TITLE
Run dump and outline actions offline

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -72,6 +72,20 @@ def should_submit(stack):
     return False
 
 
+def should_ensure_cfn_bucket(outline, dump):
+    """Test whether access to the cloudformation template bucket is required
+
+    Args:
+        outline (bool): The outline action.
+        dump (bool): The dump action.
+
+    Returns:
+        bool: If access to CF bucket is needed, return True.
+
+    """
+    return outline is False and dump is False
+
+
 def _resolve_parameters(parameters, blueprint):
     """Resolves CloudFormation Parameters for a given blueprint.
 
@@ -351,7 +365,8 @@ class Action(BaseAction):
 
     def pre_run(self, outline=False, dump=False, *args, **kwargs):
         """Any steps that need to be taken prior to running the action."""
-        self.ensure_cfn_bucket()
+        if should_ensure_cfn_bucket(outline, dump):
+            self.ensure_cfn_bucket()
         hooks = self.context.config.pre_build
         handle_hooks(
             "pre_build",

--- a/stacker/tests/actions/test_build.py
+++ b/stacker/tests/actions/test_build.py
@@ -155,6 +155,26 @@ class TestBuildAction(unittest.TestCase):
             mock_stack.force = t.force
             self.assertEqual(build.should_update(mock_stack), t.result)
 
+    def test_should_ensure_cfn_bucket(self):
+        test_scenarios = [
+            {"outline": False, "dump": False, "result": True},
+            {"outline": True, "dump": False, "result": False},
+            {"outline": False, "dump": True, "result": False},
+            {"outline": True, "dump": True, "result": False},
+            {"outline": True, "dump": "DUMP", "result": False}
+        ]
+
+        for scenario in test_scenarios:
+            outline = scenario["outline"]
+            dump = scenario["dump"]
+            result = scenario["result"]
+            try:
+                self.assertEqual(
+                    build.should_ensure_cfn_bucket(outline, dump), result)
+            except AssertionError as e:
+                e.args += ("scenario", str(scenario))
+                raise
+
     def test_should_submit(self):
         test_scenario = namedtuple("test_scenario",
                                    ["enabled", "result"])


### PR DESCRIPTION
Build does not need access to AWS when run with `dump` or
`outline` options so make it run offline for those actions.