### PR TITLE
Fix an issue introduced in #594

### DIFF
--- a/stacker/actions/build.py
+++ b/stacker/actions/build.py
@@ -83,7 +83,8 @@ def should_ensure_cfn_bucket(outline, dump):
         bool: If access to CF bucket is needed, return True.
 
     """
-    return outline is False and dump is False
+    print "OUTLINE: %s, DUMP: %s" % (outline, dump)
+    return not outline and not dump
 
 
 def _resolve_parameters(parameters, blueprint):


### PR DESCRIPTION
594 assumed that `dump` would use `False` as it's default, but since
`--dump` is a `str` type, it instead uses `None` when it is not
specified on the CLI.

The truth is that this is more pythonic anyway, and has the same effect.
I can't imagine when this could cause un-expected behaivior.